### PR TITLE
MCS-21

### DIFF
--- a/ai2thor_wrapper/controller_ai2thor.py
+++ b/ai2thor_wrapper/controller_ai2thor.py
@@ -17,6 +17,14 @@ class Controller_AI2THOR(Controller_MCS):
 
     __step_number = 0
 
+    MAX_ROTATION = 360
+    MIN_ROTATION = -360
+    MAX_HORIZON = 90
+    MIN_HORIZON = -90
+
+    ROTATION_KEY = 'rotation'
+    HORIZON_KEY = 'horizon'
+
     def __init__(self, unity_app_path):
         super().__init__()
         self.__controller = ai2thor.controller.Controller(
@@ -46,15 +54,15 @@ class Controller_AI2THOR(Controller_MCS):
     def validate_params(self, **kwargs):
         isValid = True
 
-        rotation = kwargs.get("rotation", 0)
-        horizon = kwargs.get("horizon", 0)
+        rotation = kwargs.get(self.ROTATION_KEY, 0)
+        horizon = kwargs.get(self.HORIZON_KEY, 0)
 
-        if rotation > 360 or rotation < -360:
-            print("Value of rotation needs to be between -360 and 360. Current value: " + str(rotation))
+        if rotation > self.MAX_ROTATION or rotation < self.MIN_ROTATION:
+            print('Value of rotation needs to be between ' + str(self.MIN_ROTATION) + ' and ' + str(self.MAX_ROTATION) + '. Current value: ' + str(rotation))
             isValid = False
 
-        if horizon > 90 or horizon < -90:
-            print("Value of horizon needs to be between -90 and 90. Current value: " + str(horizon))
+        if horizon > self.MAX_HORIZON or horizon < self.MIN_HORIZON:
+            print('Value of horizon needs to be between ' + str(self.MIN_HORIZON) + ' and ' + str(self.MAX_HORIZON) + '. Current value: ' + str(horizon))
             isValid = False
 
         return isValid
@@ -64,11 +72,11 @@ class Controller_AI2THOR(Controller_MCS):
     # rotation degrees into an object)
     def convert_params(self, **kwargs):
         rotation_vector = {}
-        rotation_vector['y'] = kwargs.get('rotation', 0)
+        rotation_vector['y'] = kwargs.get(self.ROTATION_KEY, 0)
 
         return dict(
             rotation=rotation_vector,
-            horizon=kwargs.get('horizon', 0)
+            horizon=kwargs.get(self.HORIZON_KEY, 0)
         )
 
     # Override
@@ -77,12 +85,12 @@ class Controller_AI2THOR(Controller_MCS):
 
         # TODO: we might want a different strategy than "Pass" for invalid input in the future
         if self.validate_params(**kwargs) == False:
-            print("Passing due to validation errors")
-            action="Pass"
+            print('Passing due to validation errors')
+            action='Pass'
 
         params = self.convert_params(**kwargs)
 
-        return self.wrap_output(self.__controller.step(self.wrap_step(action=action, rotation=params.get('rotation'), horizon=params.get('horizon'))))
+        return self.wrap_output(self.__controller.step(self.wrap_step(action=action, rotation=params.get(self.ROTATION_KEY), horizon=params.get(self.HORIZON_KEY))))
 
     def retrieve_action_list(self, scene_event):
         # TODO Return the list of AI2-THOR actions based on the player's simulated age, position (lying, crawling, or standing), and nearby or held objects

--- a/ai2thor_wrapper/controller_ai2thor.py
+++ b/ai2thor_wrapper/controller_ai2thor.py
@@ -51,6 +51,16 @@ class Controller_AI2THOR(Controller_MCS):
         self.__step_number = 0
         return self.wrap_output(self.__controller.step(self.wrap_step(action='Initialize', sceneConfig=config_data)))
 
+    """
+    Check if value is a number.
+    """
+    def is_number(self, value):
+        try:
+            float(value)
+        except ValueError:
+            return False
+        return True
+
     # TODO: may need to reevaluate validation strategy/error handling in the future
     """
     Need a validation/conversion step for what ai2thor will accept as input
@@ -60,6 +70,14 @@ class Controller_AI2THOR(Controller_MCS):
     def validate_and_convert_params(self, **kwargs):
         rotation = kwargs.get(self.ROTATION_KEY, 0)
         horizon = kwargs.get(self.HORIZON_KEY, 0)
+
+        if self.is_number(rotation) == False:
+           print('Value of rotation needs to be a number. Will be set to 0.')
+           rotation = 0
+
+        if self.is_number(horizon) == False:
+           print('Value of horizon needs to be a number. Will be set to 0.')
+           horizon = 0
 
         if rotation > self.MAX_ROTATION or rotation < self.MIN_ROTATION:
             print('Value of rotation needs to be between ' + str(self.MIN_ROTATION) + \

--- a/ai2thor_wrapper/controller_ai2thor.py
+++ b/ai2thor_wrapper/controller_ai2thor.py
@@ -52,9 +52,11 @@ class Controller_AI2THOR(Controller_MCS):
         return self.wrap_output(self.__controller.step(self.wrap_step(action='Initialize', sceneConfig=config_data)))
 
     # TODO: may need to reevaluate validation strategy/error handling in the future
-    # Need a validation/conversion step for what ai2thor will accept as input
-    # to keep parameters more simple for the user (in this case, wrapping
-    # rotation degrees into an object)
+    """
+    Need a validation/conversion step for what ai2thor will accept as input
+    to keep parameters more simple for the user (in this case, wrapping
+    rotation degrees into an object)
+    """
     def validate_and_convert_params(self, **kwargs):
         rotation = kwargs.get(self.ROTATION_KEY, 0)
         horizon = kwargs.get(self.HORIZON_KEY, 0)
@@ -85,8 +87,7 @@ class Controller_AI2THOR(Controller_MCS):
 
         params = self.validate_and_convert_params(**kwargs)
 
-        return self.wrap_output(self.__controller.step(self.wrap_step(action=action, \
-            rotation=params.get(self.ROTATION_KEY), horizon=params.get(self.HORIZON_KEY))))
+        return self.wrap_output(self.__controller.step(self.wrap_step(action=action, **params)))
 
     def retrieve_action_list(self, scene_event):
         # TODO Return the list of AI2-THOR actions based on the player's simulated age, position (lying, crawling, or standing), and nearby or held objects

--- a/ai2thor_wrapper/controller_ai2thor.py
+++ b/ai2thor_wrapper/controller_ai2thor.py
@@ -79,12 +79,6 @@ class Controller_AI2THOR(Controller_MCS):
            print('Value of horizon needs to be a number. Will be set to 0.')
            horizon = 0
 
-        if rotation > self.MAX_ROTATION or rotation < self.MIN_ROTATION:
-            print('Value of rotation needs to be between ' + str(self.MIN_ROTATION) + \
-                ' and ' + str(self.MAX_ROTATION) + '. Current value: ' + str(rotation) + \
-                '. Will be reset to 0.')
-            rotation = 0
-
         if horizon > self.MAX_HORIZON or horizon < self.MIN_HORIZON:
             print('Value of horizon needs to be between ' + str(self.MIN_HORIZON) + \
                 ' and ' + str(self.MAX_HORIZON) + '. Current value: ' + str(horizon)+ \

--- a/ai2thor_wrapper/run_mcs_environment.py
+++ b/ai2thor_wrapper/run_mcs_environment.py
@@ -35,7 +35,7 @@ def run_scene(controller, config_name, config_data):
         print('step=' + str(output.step_number))
 
     # Test error case for invalid params for RotateLook (will log a message and then Pass)
-    rotateAngle = 400
+    lookAngle = 180
     output = controller.step('RotateLook', rotation=rotateAngle, horizon=lookAngle)
     print('step=' + str(output.step_number))
 

--- a/ai2thor_wrapper/run_mcs_environment.py
+++ b/ai2thor_wrapper/run_mcs_environment.py
@@ -21,11 +21,16 @@ def run_scene(controller, config_name, config_data):
     #    print('step=' + str(output.step_number))
 
     # Testing RotateLook
+    # Rotate and look starting angles
     rotateAngle = -45
     lookAngle = -15
-    for i in range(1, 7):
-        rotateAngle += 10
-        lookAngle += 5
+    output = controller.step('RotateLook', rotation=rotateAngle, horizon=lookAngle)
+    print('step=' + str(output.step_number))
+
+    # Relative values to continue rotating/looking
+    rotateAngle = 10
+    lookAngle = 5
+    for i in range(1, 6):
         output = controller.step('RotateLook', rotation=rotateAngle, horizon=lookAngle)
         print('step=' + str(output.step_number))
 

--- a/ai2thor_wrapper/run_mcs_environment.py
+++ b/ai2thor_wrapper/run_mcs_environment.py
@@ -15,9 +15,23 @@ def run_scene(controller, config_name, config_data):
     output = controller.reset_scene(config_name, config_data)
     print('step=' + str(output.step_number))
 
-    for i in range(1, 31):
-        output = controller.step('Pass')
+    #for i in range(1, 31):
+    #    output = controller.step('Pass')
+    #    print('step=' + str(output.step_number))
+
+    # Testing RotateLook
+    rotateAngle = -45
+    lookAngle = -15
+    for i in range(1, 7):
+        rotateAngle += 10
+        lookAngle += 5
+        output = controller.step('RotateLook', rotation=rotateAngle, horizon=lookAngle)
         print('step=' + str(output.step_number))
+
+    # Test error case for invalid params for RotateLook (will log a message and then Pass)
+    rotateAngle = 400
+    output = controller.step('RotateLook', rotation=rotateAngle, horizon=lookAngle)
+    print('step=' + str(output.step_number))
 
 if __name__ == "__main__":
     config_data = {}

--- a/ai2thor_wrapper/run_mcs_environment.py
+++ b/ai2thor_wrapper/run_mcs_environment.py
@@ -15,7 +15,8 @@ def run_scene(controller, config_name, config_data):
     output = controller.reset_scene(config_name, config_data)
     print('step=' + str(output.step_number))
 
-    #for i in range(1, 31):
+    # Default test code for a scene
+    # for i in range(1, 31):
     #    output = controller.step('Pass')
     #    print('step=' + str(output.step_number))
 


### PR DESCRIPTION
Adding support for RotateLook by allowing rotation and horizon arguments to be passed in. Currently, the run_mcs_environment script will rotate/look to the upper left, then rotate and look towards the right and the floor for a few steps. There will be an additional step for seeing what happens when an invalid rotation or horizon angle is specified. 

Associated ai2thor fork changes here:
https://github.com/NextCenturyCorporation/ai2thor/pull/2