### PR TITLE
MCS-51 Preview Phase

### DIFF
--- a/python_api/machine_common_sense/mcs_controller_ai2thor.py
+++ b/python_api/machine_common_sense/mcs_controller_ai2thor.py
@@ -132,7 +132,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         output = self.wrap_output(self.__controller.step(self.wrap_step(action='Initialize', sceneConfig=config_data)))
 
         if not skip_preview_phase:
-            if self.__goal is not None and self.__goal.last_preview_phase_step >= 0:
+            if self.__goal is not None and self.__goal.last_preview_phase_step > 0:
                 image_list = output.image_list
                 depth_mask_list = output.depth_mask_list
                 object_mask_list = output.object_mask_list
@@ -316,10 +316,9 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
     def retrieve_action_list(self, goal, step_number):
         if goal is not None and goal.action_list is not None:
-            if step_number <= goal.last_preview_phase_step:
+            if step_number < goal.last_preview_phase_step:
                 return ['Pass']
             adjusted_step = step_number - goal.last_preview_phase_step
-            print('adjusted_step ' + str(adjusted_step))
             if len(goal.action_list) > adjusted_step:
                 if len(goal.action_list[adjusted_step]) > 0:
                     return goal.action_list[adjusted_step]
@@ -333,7 +332,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             action_list=(goal_config['action_list'] if 'action_list' in goal_config else None),
             info_list=(goal_config['info_list'] if 'type_list' in goal_config else []),
             last_preview_phase_step=(goal_config['last_preview_phase_step'] if 'last_preview_phase_step' \
-                    in goal_config else -1),
+                    in goal_config else 0),
             last_step=(goal_config['last_step'] if 'last_step' in goal_config else None),
             task_list=(goal_config['task_list'] if 'type_list' in goal_config else []),
             type_list=(goal_config['type_list'] if 'type_list' in goal_config else []),

--- a/python_api/machine_common_sense/mcs_goal.py
+++ b/python_api/machine_common_sense/mcs_goal.py
@@ -13,12 +13,14 @@ class MCS_Goal:
         actions are always available. An empty inner list means that all actions are available for that specific step.
     info_list : list
         The list of information for the visualization interface associated with this goal.
+    last_preview_phase_step : integer
+        The last step of the preview phase of this scene (scripted in its configuration), if any. Default: -1
     last_step : integer
         The last step of this scene. This scene will automatically end following this step.
     task_list : list of strings
-        The list of tasks associated with this goal (secondary to its types).
+        The list of tasks for the visualization interface associated with this goal (secondary to its types).
     type_list : list of strings
-        The list of types associated with this goal, including the relevant MCS core domains.
+        The list of types for the visualization interface associated with this goal, including relevant core domains.
     metadata : dict
         The metadata specific to this goal.
     """
@@ -27,6 +29,7 @@ class MCS_Goal:
         self,
         action_list=None,
         info_list=None,
+        last_preview_phase_step=-1,
         last_step=None,
         task_list=None,
         type_list=None,
@@ -34,6 +37,7 @@ class MCS_Goal:
     ):
         self.action_list = action_list
         self.info_list = [] if info_list is None else info_list
+        self.last_preview_phase_step = last_preview_phase_step
         self.last_step = last_step
         self.task_list = [] if task_list is None else task_list
         self.type_list = [] if type_list is None else type_list

--- a/python_api/machine_common_sense/mcs_goal.py
+++ b/python_api/machine_common_sense/mcs_goal.py
@@ -14,7 +14,7 @@ class MCS_Goal:
     info_list : list
         The list of information for the visualization interface associated with this goal.
     last_preview_phase_step : integer
-        The last step of the preview phase of this scene (scripted in its configuration), if any. Default: -1
+        The last step of the preview phase of this scene (scripted in its configuration), if any. Default: 0
     last_step : integer
         The last step of this scene. This scene will automatically end following this step.
     task_list : list of strings
@@ -29,7 +29,7 @@ class MCS_Goal:
         self,
         action_list=None,
         info_list=None,
-        last_preview_phase_step=-1,
+        last_preview_phase_step=0,
         last_step=None,
         task_list=None,
         type_list=None,


### PR DESCRIPTION
Added support for the `last_preview_phase_step` property in the `goal`.  All actions until that step will automatically run during initialization as though the player had Passed, and we return the images from all of those steps as part of the initialization output.

You can find examples in the current IntPhys sample scenes like this:
https://github.com/NextCenturyCorporation/MCS/blob/latest/python_api/scenes/intphys_energy_conservation_plausible_sample_1.json