### PR TITLE
MCS 109 Return visible objects only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,44 @@
+# Environments
+.env
+.venv
+env
+venv
+ENV/
+env.bak/
+venv.bak/
+
+# Editors
+.vscode
+*.swp
+
+# Mac OS
 .DS_Store
+ingest_results/__MACOSX/*
+
+# Byte-compiled
+**/__pycache__/
+
+# Packaging and distribution
+*.egg-info/
+*.egg
+eggs/
+.eggs/
+dist/
+sdist/
+wheels/
+
+# Neon
+mcs_docker_setup/neon-jan-2020*
+
+# Scenes config ?
 python_api/scenes/*.json
-python_api/machine_common_sense/__pycache__/*
+
+# machine common sense
 python_api/machine_common_sense/**/*.gif
 python_api/machine_common_sense/**/*.json
 python_api/machine_common_sense/**/*.mp4
 python_api/machine_common_sense/**/*.png
-python_api/test/__pycache__/*
-mcs_docker_setup/neon-jan-2020/*
-mcs_docker_setup/neon-jan-2020.tar.gz
-truthing/__pycache__
+
+# truthing
 truthing/pyqtgraph
 truthing/node_modules
-*.swp

--- a/python_api/machine_common_sense/mcs_controller_ai2thor.py
+++ b/python_api/machine_common_sense/mcs_controller_ai2thor.py
@@ -308,7 +308,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
     def retrieve_object_list(self, scene_event):
         return sorted([self.retrieve_object_output(object_metadata, scene_event.object_id_to_color) for \
-                object_metadata in scene_event.metadata['objects']], key=lambda x: x.uuid)
+                object_metadata in scene_event.metadata['objects'] if object_metadata['visibleInCamera']], key=lambda x: x.uuid)
 
     def retrieve_object_output(self, object_metadata, object_id_to_color):
         material_list = list(filter(MCS_Util.verify_material_enum_string, [material.upper() for material in \

--- a/python_api/test/test_mcs_controller_ai2thor.py
+++ b/python_api/test/test_mcs_controller_ai2thor.py
@@ -139,7 +139,7 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                         "z": 9
                     }],
                     "salientMaterials": [],
-                    "visibleInCamera": False
+                    "visibleInCamera": True
                 }, {
                     "direction": {
                         "x": 90,


### PR DESCRIPTION
Added visibility filter in retrieve_object_list method to filter out objects not visible to the camera. Also took a whack at the gitignore file to be slightly more standard for a python project. I'm not sure what to do about the MCS files yet.