### PR TITLE
MCS-190 Switching from sympy to shapely for reward calculations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     ],
     license='Apache-2',
     install_requires=[
-        'sympy',
+        'shapely',
         'ai2thor @ https://github.com/NextCenturyCorporation/ai2thor/tarball/master#egg=ai2thor'
     ],
     package_dir={'':'python_api'},


### PR DESCRIPTION
Traversal and transferral reward calculations are now very similar to the retrieval task.

Retrieval
RAN 1080 SCENES WITH 21600 TOTAL STEPS IN 4727.9391 SECONDS
Average single step took 0.2133 seconds
Longest single step took 0.6135 seconds
Shortest single step took 0.1619 seconds
Average single scene took 4.3777 seconds
Longest single scene took 5.5090 seconds
Shortest single scene took 3.4500 seconds

Traversal
RAN 1080 SCENES WITH 21600 TOTAL STEPS IN 4872.9901 SECONDS
Average single step took 0.2198 seconds
Longest single step took 0.4485 seconds
Shortest single step took 0.1624 seconds
Average single scene took 4.5120 seconds
Longest single scene took 5.5844 seconds
Shortest single scene took 3.4575 seconds

Transferral
RAN 1080 SCENES WITH 21600 TOTAL STEPS IN 4917.1122 SECONDS
Average single step took 0.2218 seconds
Longest single step took 0.6508 seconds
Shortest single step took 0.1625 seconds
Average single scene took 4.5529 seconds
Longest single scene took 5.7666 seconds
Shortest single scene took 3.4686 seconds