### PR TITLE
Remove top drawer of changing table from enclosed areas list (MCS-213).

### DIFF
--- a/scene_generator/objects.py
+++ b/scene_generator/objects.py
@@ -1326,17 +1326,6 @@ OBJECTS_IMMOBILE = [{
     "enclosed_areas": [{
         "position": {
             "x": 0.165,
-            "y": 0.47,
-            "z": -0.03
-        },
-        "dimensions": {
-            "x": 0.68,
-            "y": 0.22,
-            "z": 0.41
-        }
-    }, {
-        "position": {
-            "x": 0.165,
             "y": 0.19,
             "z": -0.03
         },


### PR DESCRIPTION
This was blocked by MCS-227, since I needed to confirm which drawers its actually possible to see objects in without getting stuck in them. 

I think this fix was simple and straightforward, but PR-ing just in case. 