### PR TITLE
MCS-257 Python API Config File

### DIFF
--- a/python_api/API.md
+++ b/python_api/API.md
@@ -918,7 +918,7 @@ Whether the image of the target object (`target.image`) exactly matches the actu
 
 ## Config File
 
-To use an MCS config file, set the `MCS_CONFIG_FILE_PATH` environment variable to the path of your MCS config file.
+To use an MCS configuration file, set the `MCS_CONFIG_FILE_PATH` environment variable to the path of your MCS configuration file.
 
 ### Config File Properties
 
@@ -933,3 +933,30 @@ The `metadata` property describes what metadata will be returned by the MCS Pyth
 
 Otherwise, return the metadata for the visible and held objects.
 
+### Using the Config File to Generate Scene Graphs or Maps
+
+1. Save your MCS configuration file with `metadata: full`
+
+2. Create a simple Python script to loop over one or more JSON scene configuration files, load each scene in the MCS controller, and save the output data in your own scene graph or scene map format.
+
+```python
+import os
+from machine_common_sense.mcs import MCS
+
+os.environ['MCS_CONFIG_FILE_PATH'] = # Path to your MCS configuration file
+
+scene_files = # List of scene configuration file paths
+
+unity_app = # Path to your MCS Unity application
+
+controller = MCS.create_controller(unity_app)
+
+for scene_file in scene_files:
+    config_data, status = MCS.load_config_json(scene_file)
+
+    if status is not None:
+        print(status)
+    else:
+        output = controller.start_scene(config_data)
+        # Use the output to save your scene graph or map
+```

--- a/python_api/API.md
+++ b/python_api/API.md
@@ -9,6 +9,7 @@
 - [Future Actions (Not Yet Supported)](#future-actions)
 - [Goal Descriptions](#goal-description)
 - [Goal Metadata](#goal-metadata)
+- [Config File](#config-file)
 
 ## MCS
 
@@ -914,3 +915,21 @@ Human-readable information describing the target object needed for the visualiza
 #### target.match_image : string
 
 Whether the image of the target object (`target.image`) exactly matches the actual target object in the scene. If `false`, then the actual object will be different in one way (for example, the image may depict a blue ball, but the actual object is a yellow ball, or a blue cube).
+
+## Config File
+
+To use an MCS config file, set the `MCS_CONFIG_FILE_PATH` environment variable to the path of your MCS config file.
+
+### Config File Properties
+
+#### metadata
+
+The `metadata` property describes what metadata will be returned by the MCS Python library. The `metadata` property is available so that users can run baseline or ablation studies during training. It can be set to one of the following strings:
+
+- `full`: Returns the metadata for all the objects in the scene, including visible, held, and hidden objects.
+- `no_navigation`: Does not return the position or rotation of the player or the objects in the scene.
+- `no_vision`: Does not return the depth or object masks, camera properties, or object dimensions, directions, or distances.
+- `none`: Only returns the images (but not the masks), object IDs, and properties corresponding to the player themself (like head tilt or pose) and haptic feedback (like mass or materials of held objects).
+
+Otherwise, return the metadata for the visible and held objects.
+

--- a/python_api/machine_common_sense/mcs_controller_ai2thor.py
+++ b/python_api/machine_common_sense/mcs_controller_ai2thor.py
@@ -371,8 +371,9 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         if os.path.exists(self.CONFIG_FILE):
             with open(self.CONFIG_FILE, 'r') as config_file:
                 config = yaml.load(config_file)
-                print("CONFIG!")
-                print(config)
+                if self.__debug_to_terminal:
+                    print('Read MCS Config File:')
+                    print(config)
                 if self.CONFIG_METADATA_MODE not in config:
                     config[self.CONFIG_METADATA_MODE] = ''
                 return config

--- a/python_api/machine_common_sense/mcs_controller_ai2thor.py
+++ b/python_api/machine_common_sense/mcs_controller_ai2thor.py
@@ -1,9 +1,10 @@
+import datetime
 import glob
 import json
-import os
 import math
 import numpy
-import datetime
+import os
+import yaml
 from PIL import Image
 
 import ai2thor.controller
@@ -97,6 +98,13 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
     HISTORY_DIRECTORY = "SCENE_HISTORY"
 
+    CONFIG_FILE = os.getenv('MCS_CONFIG_FILE_PATH', './mcs_config.yaml')
+    CONFIG_METADATA_MODE = 'metadata'
+    CONFIG_METADATA_MODE_FULL = 'full' # Normal metadata plus metadata for all hidden objects
+    CONFIG_METADATA_MODE_NO_NAVIGATION = 'no_navigation' # No navigation metadata like 3D coordinates
+    CONFIG_METADATA_MODE_NO_VISION = 'no_vision' # No vision (image feature) metadata, except for the images
+    CONFIG_METADATA_MODE_NONE = 'none' # No metadata, except for the images and haptic/audio feedback
+
     def __init__(self, unity_app_file_path, debug=False, enable_noise=False):
         super().__init__()
 
@@ -133,6 +141,8 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
         if not os.path.exists(self.HISTORY_DIRECTORY):
             os.makedirs(self.HISTORY_DIRECTORY)
+
+        self._config = self.read_config_file()
 
     # Write the history file
     def write_history_file(self, history_item):
@@ -357,6 +367,64 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
         return action
 
+    def read_config_file(self):
+        if os.path.exists(self.CONFIG_FILE):
+            with open(self.CONFIG_FILE, 'r') as config_file:
+                config = yaml.load(config_file)
+                print("CONFIG!")
+                print(config)
+                if self.CONFIG_METADATA_MODE not in config:
+                    config[self.CONFIG_METADATA_MODE] = ''
+                return config
+        return {}
+
+    def restrict_goal_output_metadata(self, goal_output):
+        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+
+        if mode == self.CONFIG_METADATA_MODE_NO_VISION or mode == self.CONFIG_METADATA_MODE_NONE:
+            if 'target' in goal_output.metadata and 'image' in goal_output.metadata['target']:
+                goal_output.metadata['target']['image'] = None
+            if 'target_1' in goal_output.metadata and 'image' in goal_output.metadata['target_1']:
+                goal_output.metadata['target_1']['image'] = None
+            if 'target_2' in goal_output.metadata and 'image' in goal_output.metadata['target_2']:
+                goal_output.metadata['target_2']['image'] = None
+
+        return goal_output
+
+    def restrict_object_output_metadata(self, object_output):
+        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+
+        if mode == self.CONFIG_METADATA_MODE_NO_VISION or mode == self.CONFIG_METADATA_MODE_NONE:
+            object_output.color = None
+            object_output.dimensions = None
+            object_output.direction = None
+            object_output.distance = None
+            object_output.distance_in_steps = None
+            object_output.distance_in_world = None
+
+        if mode == self.CONFIG_METADATA_MODE_NO_NAVIGATION or mode == self.CONFIG_METADATA_MODE_NONE:
+            object_output.position = None
+            object_output.rotation = None
+
+        return object_output
+
+    def restrict_step_output_metadata(self, step_output):
+        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+
+        if mode == self.CONFIG_METADATA_MODE_NO_VISION or mode == self.CONFIG_METADATA_MODE_NONE:
+            step_output.camera_aspect_ratio = None
+            step_output.camera_clipping_planes = None
+            step_output.camera_field_of_view = None
+            step_output.camera_height = None
+            step_output.depth_mask_list = []
+            step_output.object_mask_list = []
+
+        if mode == self.CONFIG_METADATA_MODE_NO_NAVIGATION or mode == self.CONFIG_METADATA_MODE_NONE:
+            step_output.position = None
+            step_output.rotation = None
+
+        return step_output
+
     def retrieve_action_list(self, goal, step_number):
         if goal is not None and goal.action_list is not None:
             if step_number < goal.last_preview_phase_step:
@@ -373,7 +441,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         if 'category' in goal_config:
             goal_config['metadata']['category'] = goal_config['category']
 
-        return MCS_Goal(
+        return self.restrict_goal_output_metadata(MCS_Goal(
             action_list=(goal_config['action_list'] if 'action_list' in goal_config else None),
             info_list=(goal_config['info_list'] if 'type_list' in goal_config else []),
             last_preview_phase_step=(goal_config['last_preview_phase_step'] if 'last_preview_phase_step' \
@@ -382,7 +450,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             task_list=(goal_config['task_list'] if 'type_list' in goal_config else []),
             type_list=(goal_config['type_list'] if 'type_list' in goal_config else []),
             metadata=(goal_config['metadata'] if 'metadata' in goal_config else {})
-        )
+        ))
 
     def retrieve_head_tilt(self, scene_event):
         return scene_event.metadata['agent']['cameraHorizon']
@@ -395,6 +463,12 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         return scene_event.events[len(scene_event.events) - 1].object_id_to_color
 
     def retrieve_object_list(self, scene_event):
+        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+
+        if mode == self.CONFIG_METADATA_MODE_FULL:
+            return sorted([self.retrieve_object_output(object_metadata, self.retrieve_object_colors(scene_event)) for \
+                    object_metadata in scene_event.metadata['objects']], key=lambda x: x.uuid)
+
         return sorted([self.retrieve_object_output(object_metadata, self.retrieve_object_colors(scene_event)) for \
                 object_metadata in scene_event.metadata['objects'] if object_metadata['visibleInCamera'] or \
                 object_metadata['isPickedUp']], key=lambda x: x.uuid)
@@ -409,7 +483,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         bounds = object_metadata['objectBounds'] if 'objectBounds' in object_metadata and \
             object_metadata['objectBounds'] is not None else {}
 
-        return MCS_Object(
+        return self.restrict_object_output_metadata(MCS_Object(
             uuid=object_metadata['objectId'],
             color={
                 'r': rgb[0],
@@ -427,7 +501,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             position=object_metadata['position'],
             rotation=object_metadata['rotation']['y'],
             visible=(object_metadata['visibleInCamera'] or object_metadata['isPickedUp'])
-        )
+        ))
 
     def retrieve_pose(self, scene_event):
         # TODO MCS-18 Return pose from Unity in step output object
@@ -449,6 +523,12 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             return return_status
 
     def retrieve_structural_object_list(self, scene_event):
+        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+
+        if mode == self.CONFIG_METADATA_MODE_FULL:
+            return sorted([self.retrieve_object_output(object_metadata, self.retrieve_object_colors(scene_event)) for \
+                    object_metadata in scene_event.metadata['structuralObjects']], key=lambda x: x.uuid)
+
         return sorted([self.retrieve_object_output(object_metadata, self.retrieve_object_colors(scene_event)) for \
                 object_metadata in scene_event.metadata['structuralObjects'] if object_metadata['visibleInCamera']], \
                 key=lambda x: x.uuid)
@@ -489,7 +569,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
         objects = scene_event.metadata.get('objects', None)
         agent = scene_event.metadata.get('agent', None)
-        step_output = MCS_Step_Output(
+        step_output = self.restrict_step_output_metadata(MCS_Step_Output(
             action_list=self.retrieve_action_list(self.__goal, self.__step_number),
             camera_aspect_ratio=(self.SCREEN_WIDTH, self.SCREEN_HEIGHT),
             camera_clipping_planes=(scene_event.metadata.get('clippingPlaneNear', 0), \
@@ -509,7 +589,7 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             rotation=self.retrieve_rotation(scene_event),
             step_number=self.__step_number,
             structural_object_list=self.retrieve_structural_object_list(scene_event)
-        )
+        ))
 
         self.__head_tilt = step_output.head_tilt
 

--- a/python_api/test/mock_mcs_controller_ai2thor.py
+++ b/python_api/test/mock_mcs_controller_ai2thor.py
@@ -16,3 +16,6 @@ class Mock_MCS_Controller_AI2THOR(MCS_Controller_AI2THOR):
         self.__controller = Mock_AI2THOR_Controller()
         self.on_init()
 
+    def set_config(self, config):
+        self._config = config
+

--- a/python_api/test/test_mcs_controller_ai2thor.py
+++ b/python_api/test/test_mcs_controller_ai2thor.py
@@ -16,6 +16,7 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
 
     def setUp(self):
         self.controller = Mock_MCS_Controller_AI2THOR()
+        self.controller.set_config({ 'metadata': '' })
 
     def create_mock_scene_event(self, mock_scene_event_data):
         # Wrap the dict in a SimpleNamespace object to permit property access with dotted notation since the actual
@@ -270,7 +271,6 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         pass
 
     def test_restrict_goal_output_metadata(self):
-        self.controller.set_config({ 'metadata': '' })
         goal = MCS_Goal(metadata={
             'target': { 'image': [0] },
             'target_1': { 'image': [1] },
@@ -340,7 +340,6 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         })
 
     def test_restrict_object_output_metadata(self):
-        self.controller.set_config({ 'metadata': '' })
         test_object = MCS_Object(
             color={ 'r': 1, 'g': 2, 'b': 3 },
             dimensions={ 'x': 1, 'y': 2, 'z': 3 },
@@ -440,7 +439,6 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.rotation, None)
 
     def test_restrict_step_output_metadata(self):
-        self.controller.set_config({ 'metadata': '' })
         step = MCS_Step_Output(
             camera_aspect_ratio=(1, 2),
             camera_clipping_planes=(3, 4),

--- a/python_api/test/test_mcs_controller_ai2thor.py
+++ b/python_api/test/test_mcs_controller_ai2thor.py
@@ -1,3 +1,4 @@
+import mock
 import numpy
 from PIL import Image
 from types import SimpleNamespace
@@ -21,6 +22,241 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         # variable is a class, not a dict.
         return SimpleNamespace(**mock_scene_event_data)
 
+    def create_retrieve_object_list_scene_event(self):
+        return {
+            "events": [self.create_mock_scene_event({
+                "object_id_to_color": {
+                    "testId1": (12, 34, 56),
+                    "testId2": (98, 76, 54),
+                    "testId3": (101, 102, 103)
+                }
+            })],
+            "metadata": {
+                "objects": [{
+                    "direction": {
+                        "x": 0,
+                        "y": 0,
+                        "z": 0
+                    },
+                    "distance": 0,
+                    "distanceXZ": 0,
+                    "isPickedUp": True,
+                    "mass": 1,
+                    "objectId": "testId1",
+                    "position": {
+                        "x": 1,
+                        "y": 1,
+                        "z": 2
+                    },
+                    "rotation": {
+                        "x": 1.0,
+                        "y": 2.0,
+                        "z": 3.0
+                    },
+                    "salientMaterials": [],
+                    "visibleInCamera": True
+                }, {
+                    "direction": {
+                        "x": 90,
+                        "y": -30,
+                        "z": 0
+                    },
+                    "distance": 1.5,
+                    "distanceXZ": 1.1,
+                    "isPickedUp": False,
+                    "mass": 12.34,
+                    "objectBounds": {
+                        "objectBoundsCorners": ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
+                    },
+                    "objectId": "testId2",
+                    "position": {
+                        "x": 1,
+                        "y": 2,
+                        "z": 3
+                    },
+                    "rotation": {
+                        "x": 1.0,
+                        "y": 2.0,
+                        "z": 3.0
+                    },
+                    "salientMaterials": ["Foobar", "Metal", "Plastic"],
+                    "visibleInCamera": True
+                }, {
+                    "direction": {
+                        "x": -90,
+                        "y": 180,
+                        "z": 270
+                    },
+                    "distance": 2.5,
+                    "distanceXZ": 2,
+                    "isPickedUp": False,
+                    "mass": 34.56,
+                    "objectBounds": {
+                        "objectBoundsCorners": ["pA", "pB", "pC", "pD", "pE", "pF", "pG", "pH"]
+                    },
+                    "objectId": "testId3",
+                    "position": {
+                        "x": -3,
+                        "y": -2,
+                        "z": -1
+                    },
+                    "rotation": {
+                        "x": 11.0,
+                        "y": 12.0,
+                        "z": 13.0
+                    },
+                    "salientMaterials": ["Wood"],
+                    "visibleInCamera": False
+                }]
+            }
+        }
+
+    def create_wrap_output_scene_event(self):
+        image_data = numpy.array([[0]], dtype=numpy.uint8)
+        depth_mask_data = numpy.array([[128]], dtype=numpy.uint8)
+        object_mask_data = numpy.array([[192]], dtype=numpy.uint8)
+
+        return {
+            "events": [self.create_mock_scene_event({
+                "depth_frame": depth_mask_data,
+                "frame": image_data,
+                "instance_segmentation_frame": object_mask_data,
+                "object_id_to_color": {
+                    "testId": (12, 34, 56),
+                    "testWallId": (101, 102, 103)
+                }
+            })],
+            "metadata": {
+                "agent": {
+                    "cameraHorizon": 12.34,
+                    "position": {
+                        "x": 0.12,
+                        "y": -0.23,
+                        "z": 4.5
+                    },
+                    "rotation": {
+                        "x": 1.111,
+                        "y": 2.222,
+                        "z": 3.333
+                    }
+                },
+                "cameraPosition": {
+                    "y": 0.1234
+                },
+                "clippingPlaneFar": 25,
+                "clippingPlaneNear": 0,
+                "fov": 42.5,
+                "lastActionStatus": "SUCCESSFUL",
+                "lastActionSuccess": True,
+                "objects": [{
+                    "direction": {
+                        "x": 90,
+                        "y": -30,
+                        "z": 0
+                    },
+                    "distance": 1.5,
+                    "distanceXZ": 1.1,
+                    "isPickedUp": False,
+                    "mass": 12.34,
+                    "objectBounds": {
+                        "objectBoundsCorners": ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
+                    },
+                    "objectId": "testId",
+                    "position": {
+                        "x": 10,
+                        "y": 11,
+                        "z": 12
+                    },
+                    "rotation": {
+                        "x": 1.0,
+                        "y": 2.0,
+                        "z": 3.0
+                    },
+                    "salientMaterials": ["Wood"],
+                    "visibleInCamera": True
+                }, {
+                    "direction": {
+                        "x": -90,
+                        "y": 180,
+                        "z": 270
+                    },
+                    "distance": 2.5,
+                    "distanceXZ": 2.0,
+                    "isPickedUp": False,
+                    "mass": 34.56,
+                    "objectBounds": {
+                        "objectBoundsCorners": ["pA", "pB", "pC", "pD", "pE", "pF", "pG", "pH"]
+                    },
+                    "objectId": "testIdHidden",
+                    "position": {
+                        "x": -3,
+                        "y": -2,
+                        "z": -1
+                    },
+                    "rotation": {
+                        "x": 11.0,
+                        "y": 12.0,
+                        "z": 13.0
+                    },
+                    "salientMaterials": ["Wood"],
+                    "visibleInCamera": False
+                }],
+                "structuralObjects": [{
+                    "direction": {
+                        "x": 180,
+                        "y": -60,
+                        "z": 0
+                    },
+                    "distance": 2.5,
+                    "distanceXZ": 2.2,
+                    "isPickedUp": False,
+                    "mass": 56.78,
+                    "objectBounds": {
+                        "objectBoundsCorners": ["p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18"]
+                    },
+                    "objectId": "testWallId",
+                    "position": {
+                        "x": 20,
+                        "y": 21,
+                        "z": 22
+                    },
+                    "rotation": {
+                        "x": 4.0,
+                        "y": 5.0,
+                        "z": 6.0
+                    },
+                    "salientMaterials": ["Ceramic"],
+                    "visibleInCamera": True
+                }, {
+                    "direction": {
+                        "x": -180,
+                        "y": 60,
+                        "z": 90
+                    },
+                    "distance": 3.5,
+                    "distanceXZ": 3.3,
+                    "isPickedUp": False,
+                    "mass": 78.90,
+                    "objectBounds": {
+                        "objectBoundsCorners": ["pAA", "pBB", "pCC", "pDD", "pEE", "pFF", "pGG", "pHH"]
+                    },
+                    "objectId": "testWallIdHidden",
+                    "position": {
+                        "x": 30,
+                        "y": 31,
+                        "z": 32
+                    },
+                    "rotation": {
+                        "x": 14.0,
+                        "y": 15.0,
+                        "z": 16.0
+                    },
+                    "salientMaterials": ["Ceramic"],
+                    "visibleInCamera": False
+                }]
+            }
+        }, image_data, depth_mask_data, object_mask_data
+
     def test_end_scene(self):
         # TODO When this function actually does anything
         pass
@@ -32,6 +268,286 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
     def test_step(self):
         # TODO MCS-15
         pass
+
+    def test_restrict_goal_output_metadata(self):
+        self.controller.set_config({ 'metadata': '' })
+        goal = MCS_Goal(metadata={
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+        actual = self.controller.restrict_goal_output_metadata(goal)
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+
+    def test_restrict_goal_output_metadata_full(self):
+        self.controller.set_config({ 'metadata': 'full' })
+        goal = MCS_Goal(metadata={
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+        actual = self.controller.restrict_goal_output_metadata(goal)
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+
+    def test_restrict_goal_output_metadata_no_navigation(self):
+        self.controller.set_config({ 'metadata': 'no_navigation' })
+        goal = MCS_Goal(metadata={
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+        actual = self.controller.restrict_goal_output_metadata(goal)
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+
+    def test_restrict_goal_output_metadata_no_vision(self):
+        self.controller.set_config({ 'metadata': 'no_vision' })
+        goal = MCS_Goal(metadata={
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+        actual = self.controller.restrict_goal_output_metadata(goal)
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': None },
+            'target_1': { 'image': None },
+            'target_2': { 'image': None }
+        })
+
+    def test_restrict_goal_output_metadata_none(self):
+        self.controller.set_config({ 'metadata': 'none' })
+        goal = MCS_Goal(metadata={
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+        actual = self.controller.restrict_goal_output_metadata(goal)
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': None },
+            'target_1': { 'image': None },
+            'target_2': { 'image': None }
+        })
+
+    def test_restrict_object_output_metadata(self):
+        self.controller.set_config({ 'metadata': '' })
+        test_object = MCS_Object(
+            color={ 'r': 1, 'g': 2, 'b': 3 },
+            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            distance=12.34,
+            distance_in_steps=34.56,
+            distance_in_world=56.78,
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_object_output_metadata(test_object)
+        self.assertEqual(actual.color, { 'r': 1, 'g': 2, 'b': 3 })
+        self.assertEqual(actual.dimensions, { 'x': 1, 'y': 2, 'z': 3 })
+        self.assertEqual(actual.distance, 12.34)
+        self.assertEqual(actual.distance_in_steps, 34.56)
+        self.assertEqual(actual.distance_in_world, 56.78)
+        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
+        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+
+    def test_restrict_object_output_metadata_full(self):
+        self.controller.set_config({ 'metadata': 'full' })
+        test_object = MCS_Object(
+            color={ 'r': 1, 'g': 2, 'b': 3 },
+            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            distance=12.34,
+            distance_in_steps=34.56,
+            distance_in_world=56.78,
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_object_output_metadata(test_object)
+        self.assertEqual(actual.color, { 'r': 1, 'g': 2, 'b': 3 })
+        self.assertEqual(actual.dimensions, { 'x': 1, 'y': 2, 'z': 3 })
+        self.assertEqual(actual.distance, 12.34)
+        self.assertEqual(actual.distance_in_steps, 34.56)
+        self.assertEqual(actual.distance_in_world, 56.78)
+        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
+        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+
+    def test_restrict_object_output_metadata_no_navigation(self):
+        self.controller.set_config({ 'metadata': 'no_navigation' })
+        test_object = MCS_Object(
+            color={ 'r': 1, 'g': 2, 'b': 3 },
+            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            distance=12.34,
+            distance_in_steps=34.56,
+            distance_in_world=56.78,
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_object_output_metadata(test_object)
+        self.assertEqual(actual.color, { 'r': 1, 'g': 2, 'b': 3 })
+        self.assertEqual(actual.dimensions, { 'x': 1, 'y': 2, 'z': 3 })
+        self.assertEqual(actual.distance, 12.34)
+        self.assertEqual(actual.distance_in_steps, 34.56)
+        self.assertEqual(actual.distance_in_world, 56.78)
+        self.assertEqual(actual.position, None)
+        self.assertEqual(actual.rotation, None)
+
+    def test_restrict_object_output_metadata_no_vision(self):
+        self.controller.set_config({ 'metadata': 'no_vision' })
+        test_object = MCS_Object(
+            color={ 'r': 1, 'g': 2, 'b': 3 },
+            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            distance=12.34,
+            distance_in_steps=34.56,
+            distance_in_world=56.78,
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_object_output_metadata(test_object)
+        self.assertEqual(actual.color, None)
+        self.assertEqual(actual.dimensions, None)
+        self.assertEqual(actual.distance, None)
+        self.assertEqual(actual.distance_in_steps, None)
+        self.assertEqual(actual.distance_in_world, None)
+        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
+        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+
+    def test_restrict_object_output_metadata_none(self):
+        self.controller.set_config({ 'metadata': 'none' })
+        test_object = MCS_Object(
+            color={ 'r': 1, 'g': 2, 'b': 3 },
+            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            distance=12.34,
+            distance_in_steps=34.56,
+            distance_in_world=56.78,
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_object_output_metadata(test_object)
+        self.assertEqual(actual.color, None)
+        self.assertEqual(actual.dimensions, None)
+        self.assertEqual(actual.distance, None)
+        self.assertEqual(actual.distance_in_steps, None)
+        self.assertEqual(actual.distance_in_world, None)
+        self.assertEqual(actual.position, None)
+        self.assertEqual(actual.rotation, None)
+
+    def test_restrict_step_output_metadata(self):
+        self.controller.set_config({ 'metadata': '' })
+        step = MCS_Step_Output(
+            camera_aspect_ratio=(1, 2),
+            camera_clipping_planes=(3, 4),
+            camera_field_of_view=5,
+            camera_height=6,
+            depth_mask_list=[7],
+            object_mask_list=[8],
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_step_output_metadata(step)
+        self.assertEqual(actual.camera_aspect_ratio, (1, 2))
+        self.assertEqual(actual.camera_clipping_planes, (3, 4))
+        self.assertEqual(actual.camera_field_of_view, 5)
+        self.assertEqual(actual.camera_height, 6)
+        self.assertEqual(actual.depth_mask_list, [7])
+        self.assertEqual(actual.object_mask_list, [8])
+        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
+        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+
+    def test_restrict_step_output_metadata_full(self):
+        self.controller.set_config({ 'metadata': 'full' })
+        step = MCS_Step_Output(
+            camera_aspect_ratio=(1, 2),
+            camera_clipping_planes=(3, 4),
+            camera_field_of_view=5,
+            camera_height=6,
+            depth_mask_list=[7],
+            object_mask_list=[8],
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_step_output_metadata(step)
+        self.assertEqual(actual.camera_aspect_ratio, (1, 2))
+        self.assertEqual(actual.camera_clipping_planes, (3, 4))
+        self.assertEqual(actual.camera_field_of_view, 5)
+        self.assertEqual(actual.camera_height, 6)
+        self.assertEqual(actual.depth_mask_list, [7])
+        self.assertEqual(actual.object_mask_list, [8])
+        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
+        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+
+    def test_restrict_step_output_metadata_no_navigation(self):
+        self.controller.set_config({ 'metadata': 'no_navigation' })
+        step = MCS_Step_Output(
+            camera_aspect_ratio=(1, 2),
+            camera_clipping_planes=(3, 4),
+            camera_field_of_view=5,
+            camera_height=6,
+            depth_mask_list=[7],
+            object_mask_list=[8],
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_step_output_metadata(step)
+        self.assertEqual(actual.camera_aspect_ratio, (1, 2))
+        self.assertEqual(actual.camera_clipping_planes, (3, 4))
+        self.assertEqual(actual.camera_field_of_view, 5)
+        self.assertEqual(actual.camera_height, 6)
+        self.assertEqual(actual.depth_mask_list, [7])
+        self.assertEqual(actual.object_mask_list, [8])
+        self.assertEqual(actual.position, None)
+        self.assertEqual(actual.rotation, None)
+
+    def test_restrict_step_output_metadata_no_vision(self):
+        self.controller.set_config({ 'metadata': 'no_vision' })
+        step = MCS_Step_Output(
+            camera_aspect_ratio=(1, 2),
+            camera_clipping_planes=(3, 4),
+            camera_field_of_view=5,
+            camera_height=6,
+            depth_mask_list=[7],
+            object_mask_list=[8],
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_step_output_metadata(step)
+        self.assertEqual(actual.camera_aspect_ratio, None)
+        self.assertEqual(actual.camera_clipping_planes, None)
+        self.assertEqual(actual.camera_field_of_view, None)
+        self.assertEqual(actual.camera_height, None)
+        self.assertEqual(actual.depth_mask_list, [])
+        self.assertEqual(actual.object_mask_list, [])
+        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
+        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+
+    def test_restrict_step_output_metadata_none(self):
+        self.controller.set_config({ 'metadata': 'none' })
+        step = MCS_Step_Output(
+            camera_aspect_ratio=(1, 2),
+            camera_clipping_planes=(3, 4),
+            camera_field_of_view=5,
+            camera_height=6,
+            depth_mask_list=[7],
+            object_mask_list=[8],
+            position={ 'x': 4, 'y': 5, 'z': 6 },
+            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+        )
+        actual = self.controller.restrict_step_output_metadata(step)
+        self.assertEqual(actual.camera_aspect_ratio, None)
+        self.assertEqual(actual.camera_clipping_planes, None)
+        self.assertEqual(actual.camera_field_of_view, None)
+        self.assertEqual(actual.camera_height, None)
+        self.assertEqual(actual.depth_mask_list, [])
+        self.assertEqual(actual.object_mask_list, [])
+        self.assertEqual(actual.position, None)
+        self.assertEqual(actual.rotation, None)
 
     def test_retrieve_action_list(self):
         self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(), 0), self.controller.ACTION_LIST)
@@ -91,6 +607,71 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             "key": "value"
         })
 
+    def test_retrieve_goal_with_config_metadata(self):
+        self.controller.set_config({ 'metadata': 'full' })
+        actual = self.controller.retrieve_goal({
+            'goal': {
+                'metadata': {
+                    'target': { 'image': [0] },
+                    'target_1': { 'image': [1] },
+                    'target_2': { 'image': [2] }
+                }
+            }
+        })
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+
+        self.controller.set_config({ 'metadata': 'no_navigation' })
+        actual = self.controller.retrieve_goal({
+            'goal': {
+                'metadata': {
+                    'target': { 'image': [0] },
+                    'target_1': { 'image': [1] },
+                    'target_2': { 'image': [2] }
+                }
+            }
+        })
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': [0] },
+            'target_1': { 'image': [1] },
+            'target_2': { 'image': [2] }
+        })
+
+        self.controller.set_config({ 'metadata': 'no_vision' })
+        actual = self.controller.retrieve_goal({
+            'goal': {
+                'metadata': {
+                    'target': { 'image': [0] },
+                    'target_1': { 'image': [1] },
+                    'target_2': { 'image': [2] }
+                }
+            }
+        })
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': None },
+            'target_1': { 'image': None },
+            'target_2': { 'image': None }
+        })
+
+        self.controller.set_config({ 'metadata': 'none' })
+        actual = self.controller.retrieve_goal({
+            'goal': {
+                'metadata': {
+                    'target': { 'image': [0] },
+                    'target_1': { 'image': [1] },
+                    'target_2': { 'image': [2] }
+                }
+            }
+        })
+        self.assertEqual(actual.metadata, {
+            'target': { 'image': None },
+            'target_1': { 'image': None },
+            'target_2': { 'image': None }
+        })
+
     def test_retrieve_head_tilt(self):
         mock_scene_event_data = {
             "metadata": {
@@ -113,67 +694,7 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual, -56.78)
 
     def test_retrieve_object_list(self):
-        mock_scene_event_data = {
-            "events": [self.create_mock_scene_event({
-                "object_id_to_color": {
-                    "testId1": (12, 34, 56),
-                    "testId2": (98, 76, 54)
-                }
-            })],
-            "metadata": {
-                "objects": [{
-                    "direction": {
-                        "x": 0,
-                        "y": 0,
-                        "z": 0
-                    },
-                    "distance": 0,
-                    "distanceXZ": 0,
-                    "isPickedUp": True,
-                    "mass": 1,
-                    "objectId": "testId1",
-                    "position": {
-                        "x": 1,
-                        "y": 1,
-                        "z": 2
-                    },
-                    "rotation": {
-                        "x": 1.0,
-                        "y": 2.0,
-                        "z": 3.0
-                    },
-                    "salientMaterials": [],
-                    "visibleInCamera": True
-                }, {
-                    "direction": {
-                        "x": 90,
-                        "y": -30,
-                        "z": 0
-                    },
-                    "distance": 1.5,
-                    "distanceXZ": 1.1,
-                    "isPickedUp": False,
-                    "mass": 12.34,
-                    "objectBounds": {
-                        "objectBoundsCorners": ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
-                    },
-                    "objectId": "testId2",
-                    "position": {
-                        "x": 1,
-                        "y": 2,
-                        "z": 3
-                    },
-                    "rotation": {
-                        "x": 1.0,
-                        "y": 2.0,
-                        "z": 3.0
-                    },
-                    "salientMaterials": ["Foobar", "Metal", "Plastic"],
-                    "visibleInCamera": True
-                }]
-            }
-        }
-
+        mock_scene_event_data = self.create_retrieve_object_list_scene_event()
         actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(len(actual), 2)
 
@@ -195,6 +716,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[0].held, True)
         self.assertEqual(actual[0].mass, 1)
         self.assertEqual(actual[0].material_list, [])
+        self.assertEqual(actual[0].position, { "x": 1, "y": 1, "z": 2 })
+        self.assertEqual(actual[0].rotation, 2.0)
         self.assertEqual(actual[0].visible, True)
 
         self.assertEqual(actual[1].uuid, "testId2")
@@ -215,6 +738,198 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[1].held, False)
         self.assertEqual(actual[1].mass, 12.34)
         self.assertEqual(actual[1].material_list, ["METAL", "PLASTIC"])
+        self.assertEqual(actual[1].position, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[1].rotation, 2)
+        self.assertEqual(actual[1].visible, True)
+
+    def test_retrieve_object_list_with_config_metadata_full(self):
+        self.controller.set_config({ 'metadata': 'full' })
+        mock_scene_event_data = self.create_retrieve_object_list_scene_event()
+        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        self.assertEqual(len(actual), 3)
+
+        self.assertEqual(actual[0].uuid, "testId1")
+        self.assertEqual(actual[0].color, {
+            "r": 12,
+            "g": 34,
+            "b": 56
+        })
+        self.assertEqual(actual[0].dimensions, {})
+        self.assertEqual(actual[0].direction, {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        })
+        self.assertEqual(actual[0].distance, 0)
+        self.assertEqual(actual[0].distance_in_steps, 0)
+        self.assertEqual(actual[0].distance_in_world, 0)
+        self.assertEqual(actual[0].held, True)
+        self.assertEqual(actual[0].mass, 1)
+        self.assertEqual(actual[0].material_list, [])
+        self.assertEqual(actual[0].position, { "x": 1, "y": 1, "z": 2 })
+        self.assertEqual(actual[0].rotation, 2.0)
+        self.assertEqual(actual[0].visible, True)
+
+        self.assertEqual(actual[1].uuid, "testId2")
+        self.assertEqual(actual[1].color, {
+            "r": 98,
+            "g": 76,
+            "b": 54
+        })
+        self.assertEqual(actual[1].dimensions, ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
+        self.assertEqual(actual[1].direction, {
+            "x": 90,
+            "y": -30,
+            "z": 0
+        })
+        self.assertEqual(actual[1].distance, 2.2)
+        self.assertEqual(actual[1].distance_in_steps, 2.2)
+        self.assertEqual(actual[1].distance_in_world, 1.5)
+        self.assertEqual(actual[1].held, False)
+        self.assertEqual(actual[1].mass, 12.34)
+        self.assertEqual(actual[1].material_list, ["METAL", "PLASTIC"])
+        self.assertEqual(actual[1].position, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[1].rotation, 2)
+        self.assertEqual(actual[1].visible, True)
+
+        self.assertEqual(actual[2].uuid, "testId3")
+        self.assertEqual(actual[2].color, {
+            "r": 101,
+            "g": 102,
+            "b": 103
+        })
+        self.assertEqual(actual[2].dimensions, ["pA", "pB", "pC", "pD", "pE", "pF", "pG", "pH"])
+        self.assertEqual(actual[2].direction, {
+            "x": -90,
+            "y": 180,
+            "z": 270
+        })
+        self.assertEqual(actual[2].distance, 4)
+        self.assertEqual(actual[2].distance_in_steps, 4)
+        self.assertEqual(actual[2].distance_in_world, 2.5)
+        self.assertEqual(actual[2].held, False)
+        self.assertEqual(actual[2].mass, 34.56)
+        self.assertEqual(actual[2].material_list, ["WOOD"])
+        self.assertEqual(actual[2].position, { "x": -3, "y": -2, "z": -1 })
+        self.assertEqual(actual[2].rotation, 12)
+        self.assertEqual(actual[2].visible, False)
+
+    def test_retrieve_object_list_with_config_metadata_no_navigation(self):
+        self.controller.set_config({ 'metadata': 'no_navigation' })
+        mock_scene_event_data = self.create_retrieve_object_list_scene_event()
+        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        self.assertEqual(len(actual), 2)
+
+        self.assertEqual(actual[0].uuid, "testId1")
+        self.assertEqual(actual[0].color, {
+            "r": 12,
+            "g": 34,
+            "b": 56
+        })
+        self.assertEqual(actual[0].dimensions, {})
+        self.assertEqual(actual[0].direction, {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        })
+        self.assertEqual(actual[0].distance, 0)
+        self.assertEqual(actual[0].distance_in_steps, 0)
+        self.assertEqual(actual[0].distance_in_world, 0)
+        self.assertEqual(actual[0].held, True)
+        self.assertEqual(actual[0].mass, 1)
+        self.assertEqual(actual[0].material_list, [])
+        self.assertEqual(actual[0].position, None)
+        self.assertEqual(actual[0].rotation, None)
+        self.assertEqual(actual[0].visible, True)
+
+        self.assertEqual(actual[1].uuid, "testId2")
+        self.assertEqual(actual[1].color, {
+            "r": 98,
+            "g": 76,
+            "b": 54
+        })
+        self.assertEqual(actual[1].dimensions, ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
+        self.assertEqual(actual[1].direction, {
+            "x": 90,
+            "y": -30,
+            "z": 0
+        })
+        self.assertEqual(actual[1].distance, 2.2)
+        self.assertEqual(actual[1].distance_in_steps, 2.2)
+        self.assertEqual(actual[1].distance_in_world, 1.5)
+        self.assertEqual(actual[1].held, False)
+        self.assertEqual(actual[1].mass, 12.34)
+        self.assertEqual(actual[1].material_list, ["METAL", "PLASTIC"])
+        self.assertEqual(actual[1].position, None)
+        self.assertEqual(actual[1].rotation, None)
+        self.assertEqual(actual[1].visible, True)
+
+    def test_retrieve_object_list_with_config_metadata_no_vision(self):
+        self.controller.set_config({ 'metadata': 'no_vision' })
+        mock_scene_event_data = self.create_retrieve_object_list_scene_event()
+        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        self.assertEqual(len(actual), 2)
+
+        self.assertEqual(actual[0].uuid, "testId1")
+        self.assertEqual(actual[0].color, None)
+        self.assertEqual(actual[0].dimensions, None)
+        self.assertEqual(actual[0].direction, None)
+        self.assertEqual(actual[0].distance, None)
+        self.assertEqual(actual[0].distance_in_steps, None)
+        self.assertEqual(actual[0].distance_in_world, None)
+        self.assertEqual(actual[0].held, True)
+        self.assertEqual(actual[0].mass, 1)
+        self.assertEqual(actual[0].material_list, [])
+        self.assertEqual(actual[0].position, { "x": 1, "y": 1, "z": 2 })
+        self.assertEqual(actual[0].rotation, 2.0)
+        self.assertEqual(actual[0].visible, True)
+
+        self.assertEqual(actual[1].uuid, "testId2")
+        self.assertEqual(actual[1].color, None)
+        self.assertEqual(actual[1].dimensions, None)
+        self.assertEqual(actual[1].direction, None)
+        self.assertEqual(actual[1].distance, None)
+        self.assertEqual(actual[1].distance_in_steps, None)
+        self.assertEqual(actual[1].distance_in_world, None)
+        self.assertEqual(actual[1].held, False)
+        self.assertEqual(actual[1].mass, 12.34)
+        self.assertEqual(actual[1].material_list, ["METAL", "PLASTIC"])
+        self.assertEqual(actual[1].position, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[1].rotation, 2)
+        self.assertEqual(actual[1].visible, True)
+
+    def test_retrieve_object_list_with_config_metadata_none(self):
+        self.controller.set_config({ 'metadata': 'none' })
+        mock_scene_event_data = self.create_retrieve_object_list_scene_event()
+        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        self.assertEqual(len(actual), 2)
+
+        self.assertEqual(actual[0].uuid, "testId1")
+        self.assertEqual(actual[0].color, None)
+        self.assertEqual(actual[0].dimensions, None)
+        self.assertEqual(actual[0].direction, None)
+        self.assertEqual(actual[0].distance, None)
+        self.assertEqual(actual[0].distance_in_steps, None)
+        self.assertEqual(actual[0].distance_in_world, None)
+        self.assertEqual(actual[0].held, True)
+        self.assertEqual(actual[0].mass, 1)
+        self.assertEqual(actual[0].material_list, [])
+        self.assertEqual(actual[0].position, None)
+        self.assertEqual(actual[0].rotation, None)
+        self.assertEqual(actual[0].visible, True)
+
+        self.assertEqual(actual[1].uuid, "testId2")
+        self.assertEqual(actual[1].color, None)
+        self.assertEqual(actual[1].dimensions, None)
+        self.assertEqual(actual[1].direction, None)
+        self.assertEqual(actual[1].distance, None)
+        self.assertEqual(actual[1].distance_in_steps, None)
+        self.assertEqual(actual[1].distance_in_world, None)
+        self.assertEqual(actual[1].held, False)
+        self.assertEqual(actual[1].mass, 12.34)
+        self.assertEqual(actual[1].material_list, ["METAL", "PLASTIC"])
+        self.assertEqual(actual[1].position, None)
+        self.assertEqual(actual[1].rotation, None)
         self.assertEqual(actual[1].visible, True)
 
     def test_retrieve_pose(self):
@@ -323,99 +1038,7 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         pass
 
     def test_wrap_output(self):
-        image_data = numpy.array([[0]], dtype=numpy.uint8)
-        depth_mask_data = numpy.array([[128]], dtype=numpy.uint8)
-        object_mask_data = numpy.array([[192]], dtype=numpy.uint8)
-
-        mock_scene_event_data = {
-            "events": [self.create_mock_scene_event({
-                "depth_frame": depth_mask_data,
-                "frame": image_data,
-                "instance_segmentation_frame": object_mask_data,
-                "object_id_to_color": {
-                    "testId": (12, 34, 56),
-                    "testWallId": (101, 102, 103)
-                }
-            })],
-            "metadata": {
-                "agent": {
-                    "cameraHorizon": 12.34,
-                    "position": {
-                        "x": 0.12,
-                        "y": -0.23,
-                        "z": 4.5
-                    },
-                    "rotation": {
-                        "x": 1.111,
-                        "y": 2.222,
-                        "z": 3.333
-                    }
-                },
-                "cameraPosition": {
-                    "y": 0.1234
-                },
-                "clippingPlaneFar": 25,
-                "clippingPlaneNear": 0,
-                "fov": 42.5,
-                "lastActionStatus": "SUCCESSFUL",
-                "lastActionSuccess": True,
-                "objects": [{
-                    "direction": {
-                        "x": 90,
-                        "y": -30,
-                        "z": 0
-                    },
-                    "distance": 1.5,
-                    "distanceXZ": 1.1,
-                    "isPickedUp": False,
-                    "mass": 12.34,
-                    "objectBounds": {
-                        "objectBoundsCorners": ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
-                    },
-                    "objectId": "testId",
-                    "position": {
-                        "x": 10,
-                        "y": 11,
-                        "z": 12
-                    },
-                    "rotation": {
-                        "x": 1.0,
-                        "y": 2.0,
-                        "z": 3.0
-                    },
-                    "salientMaterials": ["Wood"],
-                    "visibleInCamera": True
-                }],
-                "structuralObjects": [{
-                    "direction": {
-                        "x": 180,
-                        "y": -60,
-                        "z": 0
-                    },
-                    "distance": 2.5,
-                    "distanceXZ": 2.2,
-                    "isPickedUp": False,
-                    "mass": 56.78,
-                    "objectBounds": {
-                        "objectBoundsCorners": ["p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18"]
-                    },
-                    "objectId": "testWallId",
-                    "position": {
-                        "x": 20,
-                        "y": 21,
-                        "z": 22
-                    },
-                    "rotation": {
-                        "x": 4.0,
-                        "y": 5.0,
-                        "z": 6.0
-                    },
-                    "salientMaterials": ["Ceramic"],
-                    "visibleInCamera": True
-                }]
-            }
-        }
-
+        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
         actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
 
         self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
@@ -426,6 +1049,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         # self.assertEqual(actual.goal, MCS_Goal()) # TODO MCS-15
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.pose, MCS_Pose.STAND.value) # TODO MCS-18
+        self.assertEqual(actual.position, { 'x': 0.12, 'y': -0.23, 'z': 4.5 })
+        self.assertEqual(actual.rotation, 2.222)
         self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
         self.assertEqual(actual.step_number, 0)
 
@@ -478,6 +1103,116 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
         self.assertEqual(numpy.array(actual.object_mask_list[0]), object_mask_data)
 
+    def test_wrap_output_with_config_metadata_full(self):
+        self.controller.set_config({ 'metadata': 'full' })
+        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+
+        self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
+        self.assertEqual(actual.camera_aspect_ratio, (600, 400))
+        self.assertEqual(actual.camera_clipping_planes, (0, 25))
+        self.assertEqual(actual.camera_field_of_view, 42.5)
+        self.assertEqual(actual.camera_height, 0.1234)
+        # self.assertEqual(actual.goal, MCS_Goal()) # TODO MCS-15
+        self.assertEqual(actual.head_tilt, 12.34)
+        self.assertEqual(actual.pose, MCS_Pose.STAND.value) # TODO MCS-18
+        self.assertEqual(actual.position, { 'x': 0.12, 'y': -0.23, 'z': 4.5 })
+        self.assertEqual(actual.rotation, 2.222)
+        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(actual.step_number, 0)
+
+        # Correct object metadata properties tested elsewhere
+        self.assertEqual(len(actual.object_list), 2)
+        self.assertEqual(len(actual.structural_object_list), 2)
+
+        self.assertEqual(len(actual.depth_mask_list), 1)
+        self.assertEqual(len(actual.image_list), 1)
+        self.assertEqual(len(actual.object_mask_list), 1)
+        self.assertEqual(numpy.array(actual.depth_mask_list[0]), depth_mask_data)
+        self.assertEqual(numpy.array(actual.image_list[0]), image_data)
+        self.assertEqual(numpy.array(actual.object_mask_list[0]), object_mask_data)
+
+    def test_wrap_output_with_config_metadata_no_navigation(self):
+        self.controller.set_config({ 'metadata': 'no_navigation' })
+        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+
+        self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
+        self.assertEqual(actual.camera_aspect_ratio, (600, 400))
+        self.assertEqual(actual.camera_clipping_planes, (0, 25))
+        self.assertEqual(actual.camera_field_of_view, 42.5)
+        self.assertEqual(actual.camera_height, 0.1234)
+        # self.assertEqual(actual.goal, MCS_Goal()) # TODO MCS-15
+        self.assertEqual(actual.head_tilt, 12.34)
+        self.assertEqual(actual.pose, MCS_Pose.STAND.value) # TODO MCS-18
+        self.assertEqual(actual.position, None)
+        self.assertEqual(actual.rotation, None)
+        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(actual.step_number, 0)
+
+        # Correct object metadata properties tested elsewhere
+        self.assertEqual(len(actual.object_list), 1)
+        self.assertEqual(len(actual.structural_object_list), 1)
+
+        self.assertEqual(len(actual.depth_mask_list), 1)
+        self.assertEqual(len(actual.image_list), 1)
+        self.assertEqual(len(actual.object_mask_list), 1)
+        self.assertEqual(numpy.array(actual.depth_mask_list[0]), depth_mask_data)
+        self.assertEqual(numpy.array(actual.image_list[0]), image_data)
+        self.assertEqual(numpy.array(actual.object_mask_list[0]), object_mask_data)
+
+    def test_wrap_output_with_config_metadata_no_vision(self):
+        self.controller.set_config({ 'metadata': 'no_vision' })
+        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+
+        self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
+        self.assertEqual(actual.camera_aspect_ratio, None)
+        self.assertEqual(actual.camera_clipping_planes, None)
+        self.assertEqual(actual.camera_field_of_view, None)
+        self.assertEqual(actual.camera_height, None)
+        # self.assertEqual(actual.goal, MCS_Goal()) # TODO MCS-15
+        self.assertEqual(actual.head_tilt, 12.34)
+        self.assertEqual(actual.pose, MCS_Pose.STAND.value) # TODO MCS-18
+        self.assertEqual(actual.position, { 'x': 0.12, 'y': -0.23, 'z': 4.5 })
+        self.assertEqual(actual.rotation, 2.222)
+        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(actual.step_number, 0)
+
+        # Correct object metadata properties tested elsewhere
+        self.assertEqual(len(actual.object_list), 1)
+        self.assertEqual(len(actual.structural_object_list), 1)
+
+        self.assertEqual(len(actual.depth_mask_list), 0)
+        self.assertEqual(len(actual.image_list), 1)
+        self.assertEqual(len(actual.object_mask_list), 0)
+
+    def test_wrap_output_with_config_metadata_none(self):
+        self.controller.set_config({ 'metadata': 'none' })
+        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+
+        self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
+        self.assertEqual(actual.camera_aspect_ratio, None)
+        self.assertEqual(actual.camera_clipping_planes, None)
+        self.assertEqual(actual.camera_field_of_view, None)
+        self.assertEqual(actual.camera_height, None)
+        # self.assertEqual(actual.goal, MCS_Goal()) # TODO MCS-15
+        self.assertEqual(actual.head_tilt, 12.34)
+        self.assertEqual(actual.pose, MCS_Pose.STAND.value) # TODO MCS-18
+        self.assertEqual(actual.position, None)
+        self.assertEqual(actual.rotation, None)
+        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(actual.step_number, 0)
+
+        # Correct object metadata properties tested elsewhere
+        self.assertEqual(len(actual.object_list), 1)
+        self.assertEqual(len(actual.structural_object_list), 1)
+
+        self.assertEqual(len(actual.depth_mask_list), 0)
+        self.assertEqual(len(actual.image_list), 1)
+        self.assertEqual(len(actual.object_mask_list), 0)
+
     def test_wrap_step(self):
         actual = self.controller.wrap_step(action="TestAction", numberProperty=1234, stringProperty="test_property")
         expected = {
@@ -503,3 +1238,4 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
 
         currentNoise = self.controller.generate_noise()
         self.assertTrue(minValue <= currentNoise <= maxValue)
+


### PR DESCRIPTION
The Python library can now read from an optional config file and can withhold specific metadata.

Open question: Currently we read the file path from an environment variable.  Will that be OK?