### PR TITLE
MCS-266 Traversal reward fix

### DIFF
--- a/python_api/machine_common_sense/mcs_reward.py
+++ b/python_api/machine_common_sense/mcs_reward.py
@@ -91,8 +91,13 @@ class MCS_Reward(object):
         goal_id = goal.metadata['target'].get('id', None)
         goal_object = MCS_Reward.__get_object_from_list(objects, goal_id)
 
+        agent_pos = agent['position']
+        agent_xz = geometry.Point(agent_pos['x'], agent_pos['z'])
+        
         if goal_object is not None:
-            reward = int(goal_object['distanceXZ'] < MAX_REACH_DISTANCE)
+            goal_polygon = MCS_Reward._convert_object_to_planar_polygon(goal_object)
+            polygonal_distance = agent_xz.distance(goal_polygon)
+            reward = int(polygonal_distance <= MAX_REACH_DISTANCE)
 
         return reward
 

--- a/python_api/test/test_mcs_reward.py
+++ b/python_api/test/test_mcs_reward.py
@@ -138,12 +138,117 @@ class Test_MCS_Reward(unittest.TestCase):
         goal.metadata['target'] = {'id': '0'}
         obj_list = []
         for i in range(10):
-            obj = {"objectId":str(i), "distanceXZ": 0.5}
+            obj = {"objectId":str(i), "objectBounds": {"objectBoundsCorners": []}}
+            # create lower plane (y = 0)
+            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 1.0})
+            # create upper plane (y = 1)
+            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['position'] = {'x': 0.0 + i, 'z': 0.0}
+            
             obj_list.append(obj)
+
         agent = {'position': {'x':-0.9, 'y': 0.5, 'z':0.0}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 1)
         self.assertIsInstance(reward, int)
+
+    def test_traversal_reward_large_object_long_side(self):
+        goal = MCS_Goal()
+        goal.metadata['target'] = {'id': '0'}
+        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        # create lower plane (y = 0)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        # create upper plane (y = 1)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        obj['position'] = {'x': 0.0, 'z': 0.0}
+        obj_list = []
+        obj_list.append(obj)
+        
+        agent = {'position': {'x': 10.1, 'y': 0.5, 'z': 1.1}}
+        reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
+        self.assertEqual(reward, 1)
+        self.assertIsInstance(reward, int)        
+
+    def test_traversal_reward_large_object_long_side_out_of_reach(self):
+        goal = MCS_Goal()
+        goal.metadata['target'] = {'id': '0'}
+        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        # create lower plane (y = 0)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        # create upper plane (y = 1)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        obj['position'] = {'x': 0.0, 'z': 0.0}
+        obj_list = []
+        obj_list.append(obj)
+        
+        agent = {'position': {'x': 11.1, 'y': 0.5, 'z': 1.1}}
+        reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
+        self.assertEqual(reward, 0)
+        self.assertIsInstance(reward, int)   
+
+    def test_traversal_reward_large_object_short_side(self):
+        goal = MCS_Goal()
+        goal.metadata['target'] = {'id': '0'}
+        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        # create lower plane (y = 0)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        # create upper plane (y = 1)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        obj['position'] = {'x': 0.0, 'z': 0.0}
+        obj_list = []
+        obj_list.append(obj)
+        
+        agent = {'position': {'x': -0.5, 'y': 0.5, 'z': 0.0}}
+        reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
+        self.assertEqual(reward, 1)
+        self.assertIsInstance(reward, int)        
+
+    def test_traversal_reward_large_object_short_side_out_of_reach(self):
+        goal = MCS_Goal()
+        goal.metadata['target'] = {'id': '0'}
+        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        # create lower plane (y = 0)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        # create upper plane (y = 1)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        obj['position'] = {'x': 0.0, 'z': 0.0}
+        obj_list = []
+        obj_list.append(obj)
+        
+        agent = {'position': {'x': -1.5, 'y': 0.5, 'z': 0.0}}
+        reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
+        self.assertEqual(reward, 0)
+        self.assertIsInstance(reward, int)     
 
     def test_traversal_reward_outside_agent_reach(self):
         goal = MCS_Goal()

--- a/python_api/test/test_mcs_reward.py
+++ b/python_api/test/test_mcs_reward.py
@@ -158,6 +158,29 @@ class Test_MCS_Reward(unittest.TestCase):
         self.assertEqual(reward, 1)
         self.assertIsInstance(reward, int)
 
+    def test_traversal_reward_large_object_inside(self):
+        goal = MCS_Goal()
+        goal.metadata['target'] = {'id': '0'}
+        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        # create lower plane (y = 0)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 10.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 10.0})
+        # create upper plane (y = 1)
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 10.0})
+        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 10.0})
+        obj['position'] = {'x': 0.0, 'z': 0.0}
+        obj_list = []
+        obj_list.append(obj)
+        
+        agent = {'position': {'x': 5.0, 'y': 0.5, 'z': 5.0}}
+        reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
+        self.assertEqual(reward, 1)
+        self.assertIsInstance(reward, int) 
+
     def test_traversal_reward_large_object_long_side(self):
         goal = MCS_Goal()
         goal.metadata['target'] = {'id': '0'}


### PR DESCRIPTION
Initially, the traversal reward was relying on the ai2thor object metadata field distanceXZ. We were misinformed what the distance measure represented which turned out to be the distance from the agent to the object center. For oblong objects like a couch, the agent could be near the arm of the couch but nowhere near the center. The fix was to use the object extents and shapely distance from agent center to polygon edge like we do for the transferral reward calculation. Added tests for oblong objects on long and short sides as well as within.