### PR TITLE
MCS-281 Shape Constancy Scene Generator Use Same Object ID

### DIFF
--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -381,6 +381,7 @@ class ShapeConstancyQuartet(Quartet):
         b_def = random.choice(possible_defs)
         b_def = util.finalize_object_definition(b_def)
         b = util.instantiate_object(b_def, a['original_location'], a['materials_list'])
+        b['id'] = a['id']
         logging.debug(f'a type: {a["type"]}\tb type: {b["type"]}')
         return b
 

--- a/scene_generator/quartets_test.py
+++ b/scene_generator/quartets_test.py
@@ -69,6 +69,7 @@ def test_ShapeConstancyQuartet():
     assert quartet is not None
     a = quartet._scenes[0]['objects'][0]
     assert a['type'] != quartet._b['type']
+    assert a['id'] == quartet._b['id']
     assert a['shows'][0]['scale']['x'] == quartet._b['shows'][0]['scale']['x']
     assert a['shows'][0]['scale']['z'] == quartet._b['shows'][0]['scale']['z']
     assert a['materials'] == quartet._b['materials']
@@ -81,6 +82,7 @@ def test_ShapeConstancyQuartet_get_scene_2():
     scene = quartet.get_scene(2)
     a = scene['objects'][0]
     b = scene['objects'][-1]
+    assert a['id'] == b['id']
     assert a['hides'][0]['stepBegin'] == b['shows'][0]['stepBegin']
     if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
         assert a['forces'] == b['forces']
@@ -97,6 +99,7 @@ def test_ShapeConstancyQuartet_get_scene_3():
     scene = quartet.get_scene(3)
     a = scene['objects'][0]
     b = scene['objects'][-1]
+    assert a['id'] == b['id']
     assert b['hides'][0]['stepBegin'] == a['shows'][0]['stepBegin']
     if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
         assert a['forces'] == b['forces']


### PR DESCRIPTION
Use the same object ID for the target object in implausible shape constancy scenes from the scene generator.