### PR TITLE
MCS-201 MCS-290 MCS-294 Tags for Eval 2 IntPhys Dataset

### DIFF
--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -24,7 +24,7 @@ DIST_WALL_APART = 1
 SAFE_DIST_FROM_ROOM_WALL = 3.5
     
 
-def generate_wall(wall_mat_choice: str, performer_position: Dict[str, float],
+def generate_wall(wall_material: str, wall_colors: List[str], performer_position: Dict[str, float],
                   other_rects: List[List[Dict[str, float]]]) -> Optional[Dict[str, Any]]:
     # Wanted to reuse written functions, but this is a bit more of a special snowflake
     # Generates obstacle walls placed in the scene.
@@ -54,11 +54,13 @@ def generate_wall(wall_mat_choice: str, performer_position: Dict[str, float],
     if tries < util.MAX_TRIES:
         new_object = {
             'id': 'wall_' + str(uuid.uuid4()),
-            'materials': [wall_mat_choice],
+            'materials': [wall_material],
             'type': 'cube',
             'kinematic': 'true',
             'structure': 'true',
-            'mass': 100
+            'mass': 100,
+            'info': wall_colors,
+            'info_string': ' '.join(wall_colors)
         }
         shows_object = {
             'stepBegin': 0,
@@ -74,6 +76,7 @@ def generate_wall(wall_mat_choice: str, performer_position: Dict[str, float],
     return None
 
 
+
 class Goal(ABC):
     """An abstract Goal. Subclasses must implement compute_objects and
     get_config. Users of a goal object should normally only need to call 
@@ -82,20 +85,27 @@ class Goal(ABC):
     def __init__(self):
         self._performer_start = None
         self._targets = []
-        self._goal_objects = []
+        self._object_dict = []
 
     def update_body(self, body: Dict[str, Any], find_path: bool) -> Dict[str, Any]:
         """Helper method that calls other Goal methods to set performerStart, objects, and goal. Returns the goal body
         object."""
         body['performerStart'] = self.compute_performer_start()
-        goal_objects, all_objects, bounding_rects = self.compute_objects(body['wallMaterial'])
-        self._goal_objects = goal_objects
-        walls = self.generate_walls(body['wallMaterial'], body['performerStart']['position'],
-                                    bounding_rects)
-        body['objects'] = all_objects + walls
-        body['goal'] = self.get_config(goal_objects, all_objects + walls)
+
+        object_dict, bounding_rects = self.compute_objects(body['wallMaterial'])
+        self._object_dict = object_dict
+        self._targets = object_dict['target']
+
+        walls = self.generate_walls(body['wallMaterial'], body['wallColors'], body['performerStart']['position'], \
+                bounding_rects)
+        if walls is not None:
+            object_dict['wall'] = walls
+
+        body['objects'] = [element for key, value in object_dict.items() for element in value]
+        body['goal'] = self.get_config(self._targets, object_dict)
+
         if find_path:
-            body['answer']['actions'] = self.find_optimal_path(goal_objects, all_objects + walls)
+            body['answer']['actions'] = self.find_optimal_path(self._targets, body['objects'])
 
         return body
 
@@ -123,8 +133,8 @@ class Goal(ABC):
         return util.finalize_object_definition(random.choice(object_def_list))
 
     @abstractmethod
-    def compute_objects(self, wall_material_name: str) \
-        -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[List[Dict[str, float]]]]:
+    def compute_objects(self, wall_material_name: str) -> \
+            Tuple[Dict[str, List[Dict[str, Any]]], List[List[Dict[str, float]]]]:
         """Compute object instances for the scene. Returns a tuple:
         (objects required for the goal, all objects in the scene including objects required for the goal, bounding rectangles)"""
         pass
@@ -143,18 +153,57 @@ class Goal(ABC):
                 obj = util.instantiate_object(object_def, obj_location)
                 object_list.append(obj)
 
-    def _update_goal_info_list(self, goal: Dict[str, Any], all_objects: List[Dict[str, Any]]):
+    def _update_goal_info_list(self, goal: Dict[str, Any], object_dict: Dict[str, List[Dict[str, Any]]]) -> None:
         info_set = set(goal.get('info_list', []))
-        for obj in all_objects:
-            info_set |= frozenset(obj.get('info', []))
+
+        for key, value in object_dict.items():
+            for obj in value:
+                info_list = obj.get('info', []).copy()
+                if 'info_string' in obj:
+                    info_list.append(obj['info_string'])
+                info_set |= frozenset([(key + ' ' + info) for info in info_list])
+
         goal['info_list'] = list(info_set)
 
-    def get_config(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _update_goal_tags(self, goal: Dict[str, Any], object_dict: Dict[str, List[Dict[str, Any]]]) -> None:
+        self._update_goal_tags_of_type(goal, object_dict['target'], 'target')
+        if 'distractor' in object_dict:
+            self._update_goal_tags_of_type(goal, object_dict['distractor'], 'distractor')
+        for item in ['background object', 'distractor', 'occluder', 'target', 'wall']:
+            if item in object_dict:
+                number = len(object_dict[item])
+                if item == 'occluder':
+                    number = (int)(number / 2)
+                goal['type_list'].append(item + 's ' + str(number))
+        self._update_goal_info_list(goal, object_dict)
+
+    def _update_goal_tags_of_type(self, goal: Dict[str, Any], objs: List[Dict[str, Any]], name: str) -> None:
+        for obj in objs:
+            enclosed_tag = (name + ' not enclosed') if obj.get('locationParent', None) is None else (name + ' enclosed')
+            novel_color_tag = (name + ' novel color') if 'novel_color' in obj and obj['novel_color'] else \
+                    (name + ' not novel color')
+            novel_combination_tag = (name + ' novel combination') if 'novel_combination' in obj and \
+                    obj['novel_combination'] else (name + ' not novel combination')
+            novel_shape_tag = (name + ' novel shape') if 'novel_shape' in obj and obj['novel_shape'] else \
+                    (name + ' not novel shape')
+            for new_tag in [enclosed_tag, novel_color_tag, novel_combination_tag, novel_shape_tag]:
+                if new_tag not in goal['type_list']:
+                    goal['type_list'].append(new_tag)
+
+    def get_config(self, goal_objects: List[Dict[str, Any]], object_dict: Dict[str, List[Dict[str, Any]]]) -> \
+            Dict[str, Any]:
         """Get the goal configuration. goal_objects is the objects required for the goal (as returned from
         compute_objects)."""
+        goal_config = self._get_subclass_config(goal_objects)
+        self._update_goal_tags(goal_config, object_dict)
+        return goal_config
+
+    @abstractmethod
+    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Get the goal configuration of this specific subclass."""
         pass
 
-    def generate_walls(self, material: str, performer_position: Dict[str, Any],
+    def generate_walls(self, material: str, colors: List[str], performer_position: Dict[str, Any],
                        bounding_rects: List[List[Dict[str, float]]]) -> List[Dict[str, Any]]:
         wall_count = random.choices(WALL_COUNTS, weights=WALL_PROBS, k=1)[0]
         
@@ -162,7 +211,7 @@ class Goal(ABC):
         # Add bounding rects to walls
         all_bounding_rects = [bounding_rect.copy() for bounding_rect in bounding_rects] 
         for x in range(0, wall_count):
-            wall = generate_wall(material, performer_position, all_bounding_rects)
+            wall = generate_wall(material, colors, performer_position, all_bounding_rects)
 
             if wall is not None:
                 walls.append(wall)
@@ -184,11 +233,11 @@ class EmptyGoal(Goal):
     def __init__(self):
         super(EmptyGoal, self).__init__()
 
-    def compute_objects(self, wall_material_name: str) \
-        -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[List[Dict[str, float]]]]:
-        return [], [], []
+    def compute_objects(self, wall_material_name: str) -> \
+            Tuple[Dict[str, List[Dict[str, Any]]], List[List[Dict[str, float]]]]:
+        return { 'target': [] }, []
 
-    def get_config(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         return {}
 
     def find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \

--- a/scene_generator/goal_test.py
+++ b/scene_generator/goal_test.py
@@ -57,11 +57,568 @@ def test_Goal_duplicate_object():
         }
     }
     sphere = instantiate_object(obj, object_location)
-    object_list = [sphere]
     bounding_rect = [[{'x': 3.7346446609406727, 'y': 0, 'z': 4.23}, {'x': 3.77, 'y': 0, 'z': 4.265355339059328}, {'x': 3.8053553390593273, 'y': 0, 'z': 4.23}, {'x': 3.77, 'y': 0, 'z': 4.194644660940673}], [{'x': 3.846, 'y': 0, 'z': -1.9685000000000001}, {'x': 3.846, 'y': 0, 'z': -2.4715000000000003}, {'x': 3.1340000000000003, 'y': 0, 'z': -2.4715000000000003}, {'x': 3.1340000000000003, 'y': 0, 'z': -1.9685000000000001}]]
     performer_position = {'x': 0.77, 'y': 0, 'z': -0.41}
-    goal = goal_obj.get_config(object_list, object_list)
-    goal_obj.add_objects(object_list, bounding_rect, performer_position)
+    goal = goal_obj.get_config([sphere], { 'target': [sphere] })
+    goal_obj.add_objects([sphere], bounding_rect, performer_position)
 
 
+def create_tags_test_object_1():
+    return {
+        'id': 'test_sphere',
+        'type': 'sphere',
+        'dimensions': {
+            'x': 0.1,
+            'y': 0.1,
+            'z': 0.1
+        },
+        'info': ['tiny', 'light', 'blue', 'plastic', 'ball'],
+        'info_string': 'tiny light blue plastic ball',
+        'mass': 0.5,
+        'materials': ['test_material'],
+        'materialCategory': ['plastic'],
+        'salientMaterials': ['plastic'],
+        'moveable': True,
+        'novel_color': False,
+        'novel_combination': False,
+        'novel_shape': False,
+        'pickupable': True,
+        'shows': [{
+            'stepBegin': 0,
+            'position': {
+                'x': 0,
+                'y': 0,
+                'z': 0
+            }
+        }]
+    }
+
+
+def create_tags_test_object_2():
+    return {
+        'id': 'test_cube',
+        'type': 'cube',
+        'dimensions': {
+            'x': 0.5,
+            'y': 0.5,
+            'z': 0.5
+        },
+        'info': ['medium', 'light', 'yellow', 'plastic', 'cube'],
+        'info_string': 'medium light yellow plastic cube',
+        'mass': 2.5,
+        'materials': ['test_material'],
+        'materialCategory': ['plastic'],
+        'salientMaterials': ['plastic'],
+        'moveable': True,
+        'novel_color': False,
+        'novel_combination': False,
+        'novel_shape': False,
+        'pickupable': True,
+        'shows': [{
+            'stepBegin': 0,
+            'position': {
+                'x': 1,
+                'y': 2,
+                'z': 3
+            }
+        }]
+    }
+
+
+def test_Goal_tags():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    goal = goal_object.get_config([target], { 'target': [target] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball'
+    }
+
+    # Assert positives
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+
+    # Assert negatives
+    assert 'target novel color' not in goal['type_list']
+    assert 'target novel combination' not in goal['type_list']
+    assert 'target novel shape' not in goal['type_list']
+    assert 'target enclosed' not in goal['type_list']
+    assert 'distractor not novel color' not in goal['type_list']
+    assert 'distractor not novel combination' not in goal['type_list']
+    assert 'distractor not novel shape' not in goal['type_list']
+    assert 'distractor not enclosed' not in goal['type_list']
+    assert 'distractor novel color' not in goal['type_list']
+    assert 'distractor novel combination' not in goal['type_list']
+    assert 'distractor novel shape' not in goal['type_list']
+    assert 'distractor enclosed' not in goal['type_list']
+    assert 'background objects 0' not in goal['type_list']
+    assert 'distractors 0' not in goal['type_list']
+    assert 'occluders 0' not in goal['type_list']
+    assert 'ramps 0' not in goal['type_list']
+    assert 'walls 0' not in goal['type_list']
+
+
+def test_Goal_tags_multiple_target():
+    goal_object = RetrievalGoal()
+    target_1 = create_tags_test_object_1()
+    target_2 = create_tags_test_object_2()
+    goal = goal_object.get_config([target_1, target_2], { 'target': [target_1, target_2] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'target medium',
+        'target yellow',
+        'target cube',
+        'target medium light yellow plastic cube'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'targets 2' in goal['type_list']
+
+
+def test_Goal_tags_with_distractor():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    distractor = create_tags_test_object_2()
+    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'distractor medium',
+        'distractor light',
+        'distractor yellow',
+        'distractor plastic',
+        'distractor cube',
+        'distractor medium light yellow plastic cube'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'distractor not novel color' in goal['type_list']
+    assert 'distractor not novel combination' in goal['type_list']
+    assert 'distractor not novel shape' in goal['type_list']
+    assert 'distractor not enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'distractors 1' in goal['type_list']
+
+
+def test_Goal_tags_multiple_target_multiple_distractor():
+    goal_object = RetrievalGoal()
+    target_1 = create_tags_test_object_1()
+    target_2 = create_tags_test_object_1()
+    distractor_1 = create_tags_test_object_2()
+    distractor_2 = create_tags_test_object_2()
+    goal = goal_object.get_config([target_1, target_2], { 'target': [target_1, target_2], \
+            'distractor': [distractor_1, distractor_2] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'distractor medium',
+        'distractor light',
+        'distractor yellow',
+        'distractor plastic',
+        'distractor cube',
+        'distractor medium light yellow plastic cube'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'distractor not novel color' in goal['type_list']
+    assert 'distractor not novel combination' in goal['type_list']
+    assert 'distractor not novel shape' in goal['type_list']
+    assert 'distractor not enclosed' in goal['type_list']
+    assert 'targets 2' in goal['type_list']
+    assert 'distractors 2' in goal['type_list']
+
+
+def test_Goal_tags_with_occluder():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    occluder_wall = { 'info': ['white'] }
+    occluder_pole = { 'info': ['brown'] }
+    goal = goal_object.get_config([target], { 'target': [target], 'occluder': [occluder_wall, occluder_pole] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'occluder white',
+        'occluder brown'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'occluders 1' in goal['type_list']
+
+
+def test_Goal_tags_with_wall():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    wall = { 'info': ['white'] }
+    goal = goal_object.get_config([target], { 'target': [target], 'wall': [wall] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'wall white'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'walls 1' in goal['type_list']
+
+
+def test_Goal_tags_with_background_object():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    background_object = { 'info': ['red'] }
+    goal = goal_object.get_config([target], { 'target': [target], 'background object': [background_object] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'background object red'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'background objects 1' in goal['type_list']
+
+
+def test_Goal_tags_target_enclosed():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    target['locationParent'] = 'parent'
+    goal = goal_object.get_config([target], { 'target': [target] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'target enclosed' in goal['type_list']
+
+
+def test_Goal_tags_target_novel_color():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    target['novel_color'] = True
+    goal = goal_object.get_config([target], { 'target': [target] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball'
+    }
+    assert 'target novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+
+
+def test_Goal_tags_target_novel_combination():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    target['novel_combination'] = True
+    goal = goal_object.get_config([target], { 'target': [target] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+
+
+def test_Goal_tags_target_novel_shape():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    target['novel_shape'] = True
+    goal = goal_object.get_config([target], { 'target': [target] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target novel shape' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+
+
+def test_Goal_tags_target_enclosed_novel_color_novel_shape():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    target['locationParent'] = 'parent'
+    target['novel_color'] = True
+    target['novel_shape'] = True
+    goal = goal_object.get_config([target], { 'target': [target] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball'
+    }
+    assert 'target novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target novel shape' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'target enclosed' in goal['type_list']
+
+
+def test_Goal_tags_distractor_enclosed():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    distractor = create_tags_test_object_2()
+    distractor['locationParent'] = 'parent'
+    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'distractor medium',
+        'distractor light',
+        'distractor yellow',
+        'distractor plastic',
+        'distractor cube',
+        'distractor medium light yellow plastic cube'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'distractor not novel color' in goal['type_list']
+    assert 'distractor not novel combination' in goal['type_list']
+    assert 'distractor not novel shape' in goal['type_list']
+    assert 'distractor enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'distractors 1' in goal['type_list']
+
+
+def test_Goal_tags_distractor_novel_color():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    distractor = create_tags_test_object_2()
+    distractor['novel_color'] = True
+    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'distractor medium',
+        'distractor light',
+        'distractor yellow',
+        'distractor plastic',
+        'distractor cube',
+        'distractor medium light yellow plastic cube'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'distractor novel color' in goal['type_list']
+    assert 'distractor not novel combination' in goal['type_list']
+    assert 'distractor not novel shape' in goal['type_list']
+    assert 'distractor not enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'distractors 1' in goal['type_list']
+
+
+def test_Goal_tags_distractor_novel_combination():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    distractor = create_tags_test_object_2()
+    distractor['novel_combination'] = True
+    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'distractor medium',
+        'distractor light',
+        'distractor yellow',
+        'distractor plastic',
+        'distractor cube',
+        'distractor medium light yellow plastic cube'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'distractor not novel color' in goal['type_list']
+    assert 'distractor novel combination' in goal['type_list']
+    assert 'distractor not novel shape' in goal['type_list']
+    assert 'distractor not enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'distractors 1' in goal['type_list']
+
+
+def test_Goal_tags_distractor_novel_shape():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    distractor = create_tags_test_object_2()
+    distractor['novel_shape'] = True
+    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'distractor medium',
+        'distractor light',
+        'distractor yellow',
+        'distractor plastic',
+        'distractor cube',
+        'distractor medium light yellow plastic cube'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'distractor not novel color' in goal['type_list']
+    assert 'distractor not novel combination' in goal['type_list']
+    assert 'distractor novel shape' in goal['type_list']
+    assert 'distractor not enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'distractors 1' in goal['type_list']
+
+
+def test_Goal_tags_distractor_enclosed_novel_color_novel_shape():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    distractor = create_tags_test_object_2()
+    distractor['locationParent'] = 'parent'
+    distractor['novel_color'] = True
+    distractor['novel_shape'] = True
+    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'distractor medium',
+        'distractor light',
+        'distractor yellow',
+        'distractor plastic',
+        'distractor cube',
+        'distractor medium light yellow plastic cube'
+    }
+    assert 'target not novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target not novel shape' in goal['type_list']
+    assert 'target not enclosed' in goal['type_list']
+    assert 'distractor novel color' in goal['type_list']
+    assert 'distractor not novel combination' in goal['type_list']
+    assert 'distractor novel shape' in goal['type_list']
+    assert 'distractor enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'distractors 1' in goal['type_list']
+
+
+def test_Goal_tags_target_distractor_enclosed_novel_color_novel_shape():
+    goal_object = RetrievalGoal()
+    target = create_tags_test_object_1()
+    target['locationParent'] = 'parent'
+    target['novel_color'] = True
+    target['novel_shape'] = True
+    distractor = create_tags_test_object_2()
+    distractor['locationParent'] = 'parent'
+    distractor['novel_color'] = True
+    distractor['novel_shape'] = True
+    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    assert set(goal['info_list']) == {
+        'target tiny',
+        'target light',
+        'target blue',
+        'target plastic',
+        'target ball',
+        'target tiny light blue plastic ball',
+        'distractor medium',
+        'distractor light',
+        'distractor yellow',
+        'distractor plastic',
+        'distractor cube',
+        'distractor medium light yellow plastic cube'
+    }
+    assert 'target novel color' in goal['type_list']
+    assert 'target not novel combination' in goal['type_list']
+    assert 'target novel shape' in goal['type_list']
+    assert 'target enclosed' in goal['type_list']
+    assert 'distractor novel color' in goal['type_list']
+    assert 'distractor not novel combination' in goal['type_list']
+    assert 'distractor novel shape' in goal['type_list']
+    assert 'distractor enclosed' in goal['type_list']
+    assert 'targets 1' in goal['type_list']
+    assert 'distractors 1' in goal['type_list']
 

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -194,7 +194,7 @@ class InteractionGoal(Goal, ABC):
         if self._target_location is None:
             raise GoalException(f'could not place target object (type={self._target_def["type"]})')
 
-    def _generate_additional_target_objs(self) -> None:
+    def _generate_additional_target_objs(self) -> List[Dict[str, Any]]:
         """Returns target objects required for the goal other than the first target, if any.
         May update _bounding_rects."""
         return []
@@ -318,7 +318,7 @@ class TransferralGoal(InteractionGoal):
     def __init__(self):
         super(TransferralGoal, self).__init__()
 
-    def _generate_additional_target_objs(self) -> None:
+    def _generate_additional_target_objs(self) -> List[Dict[str, Any]]:
         targets = objects.get_all_object_defs()
         random.shuffle(targets)
         target2_def = next((tgt for tgt in targets if 'stackTarget' in tgt.get('attributes', [])), None)

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -320,104 +320,107 @@ def test_RetrievalGoal_get_goal():
     goal_obj = RetrievalGoal()
     obj = {
         'id': str(uuid.uuid4()),
-        'info': [str(uuid.uuid4())],
+        'info': ['blue', 'rubber', 'ball'],
+        'info_string': 'blue rubber ball',
         'type': 'sphere'
     }
-    object_list = [obj]
-    goal = goal_obj.get_config(object_list, object_list)
-    assert goal['info_list'] == obj['info']
+    goal = goal_obj.get_config([obj], { 'target': [obj] })
+    assert goal['description'] == 'Find and pick up the blue rubber ball.'
+    assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball'}
     target = goal['metadata']['target']
     assert target['id'] == obj['id']
-    assert target['info'] == obj['info']
+    assert target['info'] == ['blue', 'rubber', 'ball']
 
 
 def test_TraversalGoal_get_goal():
     goal_obj = TraversalGoal()
     obj = {
         'id': str(uuid.uuid4()),
-        'info': [str(uuid.uuid4())],
+        'info': ['blue', 'rubber', 'ball'],
+        'info_string': 'blue rubber ball',
         'type': 'sphere'
     }
-    object_list = [obj]
-    goal = goal_obj.get_config(object_list, object_list)
-    assert goal['info_list'] == obj['info']
+    goal = goal_obj.get_config([obj], { 'target': [obj] })
+    assert goal['description'] == 'Find the blue rubber ball and move near it.'
+    assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball'}
     target = goal['metadata']['target']
     assert target['id'] == obj['id']
-    assert target['info'] == obj['info']
+    assert target['info'] == ['blue', 'rubber', 'ball']
 
 
 def test_TransferralGoal_get_goal_argcount():
     goal_obj = TransferralGoal()
     with pytest.raises(ValueError):
-        goal_obj.get_config(['one object'], ['one object'])
+        goal_obj.get_config(['one object'], { 'target': ['one object'] })
 
 
 def test_TransferralGoal_get_goal_argvalid():
     goal_obj = TransferralGoal()
+    target_list = [{'attributes': ['']}, {'attributes': ['']}]
     with pytest.raises(ValueError):
-        goal_obj.get_config([{'attributes': ['']}, {'attributes': ['']}], [])
+        goal_obj.get_config(target_list, { 'target': target_list })
 
 
 def test__generate_transferral_goal():
     goal_obj = TransferralGoal()
-    extra_info = str(uuid.uuid4())
     pickupable_id = str(uuid.uuid4())
-    pickupable_info_item = str(uuid.uuid4())
     pickupable_obj = {
         'id': pickupable_id,
-        'info': [pickupable_info_item, extra_info],
+        'info': ['blue', 'rubber', 'ball'],
+        'info_string': 'blue rubber ball',
         'pickupable': True,
         'type': 'sphere'
     }
     other_id = str(uuid.uuid4())
-    other_info_item = str(uuid.uuid4())
     other_obj = {
         'id': other_id,
-        'info': [other_info_item, extra_info],
+        'info': ['yellow', 'wood', 'changing table'],
+        'info_string': 'yellow wood changing table',
         'attributes': [],
         'type': 'changing_table',
         'stackTarget': True
     }
-    obj_list = [pickupable_obj, other_obj]
-    goal = goal_obj.get_config(obj_list, obj_list)
+    goal = goal_obj.get_config([pickupable_obj, other_obj], { 'target': [pickupable_obj, other_obj] })
 
-    combined_info = goal['info_list']
-    assert set(combined_info) == {pickupable_info_item, other_info_item, extra_info}
+    assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball', \
+            'target yellow', 'target wood', 'target changing table', 'target yellow wood changing table'}
 
     target1 = goal['metadata']['target_1']
     assert target1['id'] == pickupable_id
-    assert target1['info'] == [pickupable_info_item, extra_info]
+    assert target1['info'] == ['blue', 'rubber', 'ball']
     target2 = goal['metadata']['target_2']
     assert target2['id'] == other_id
-    assert target2['info'] == [other_info_item, extra_info]
+    assert target2['info'] == ['yellow', 'wood', 'changing table']
 
     relationship = goal['metadata']['relationship']
     relationship_type = relationship[1]
     assert relationship_type in [g.value for g in TransferralGoal.RelationshipType]
 
+    assert goal['description'] == 'Find and pick up the blue rubber ball and move it ' + \
+            relationship_type + ' the yellow wood changing table.'
+
 
 def test__generate_transferral_goal_with_nonstackable_goal():
     goal_obj = TransferralGoal()
-    extra_info = str(uuid.uuid4())
     pickupable_id = str(uuid.uuid4())
-    pickupable_info_item = str(uuid.uuid4())
     pickupable_obj = {
         'id': pickupable_id,
-        'info': [pickupable_info_item, extra_info],
+        'info': ['blue', 'rubber', 'ball'],
+        'info_string': 'blue rubber ball',
         'pickupable': True,
         'type': 'sphere',
         'attributes': ['pickupable']
     }
     other_id = str(uuid.uuid4())
-    other_info_item = str(uuid.uuid4())
     other_obj = {
         'id': other_id,
-        'info': [other_info_item, extra_info],
+        'info': ['yellow', 'wood', 'changing table'],
+        'info_string': 'yellow wood changing table',
         'type': 'changing_table',
         'attributes': []
     }
     with pytest.raises(ValueError) as excinfo:
-        goal = goal_obj.get_config([pickupable_obj, other_obj], [])
+        goal = goal_obj.get_config([pickupable_obj, other_obj], { 'target': [pickupable_obj, other_obj] })
     assert "second object must be" in str(excinfo.value)
 
 
@@ -429,6 +432,7 @@ def test_TransferralGoal_ensure_pickup_action():
         'ceilingMaterial': 'AI2-THOR/Materials/Walls/Drywall',
         'floorMaterial': 'AI2-THOR/Materials/Fabrics/CarpetWhite 3',
         'wallMaterial': 'AI2-THOR/Materials/Walls/DrywallBeige',
+        'wallColors': ['white'],
         'performerStart': {
             'position': {
                 'x': 0,

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -161,7 +161,7 @@ class IntPhysGoal(Goal, ABC):
         scenery_list = []
         scenery_rects = []
         scenery_defs = objects.OBJECTS_MOVEABLE + objects.OBJECTS_IMMOBILE
-        for i in range(scenery_count):
+        for _ in range(scenery_count):
             location = None
             while location is None:
                 scenery_def = finalize_object_definition(random.choice(scenery_defs))

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -137,7 +137,7 @@ class IntPhysGoal(Goal, ABC):
 
         return {
             'target': [moving_objs[0]],
-            'distractor': moving_objs[1:] if len(moving_objs) > 1 else [],
+            'distractor': moving_objs[1:],
             'background object': background_objs,
             'occluder': occluder_objs
         }, []
@@ -560,7 +560,7 @@ class GravityGoal(IntPhysGoal):
 
         return {
             'target': [moving_objs[0]],
-            'distractor': moving_objs[1:] if len(moving_objs) > 1 else [],
+            'distractor': moving_objs[1:],
             'background object': background_objs,
             'ramp': ramp_objs
         }, []

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -223,7 +223,7 @@ class IntPhysGoal(Goal, ABC):
         """Create additional, non-paired occluders and add them to occluder_list."""
         for _ in range(num_to_add):
             occluder_fits = False
-            for try_num in range(IntPhysGoal.MAX_OCCLUDER_TRIES):
+            for try_num in range(util.MAX_TRIES):
                 # try random position and scale until we find one that fits (or try too many times)
                 min_scale = IntPhysGoal.MIN_OCCLUDER_SCALE
                 x_scale = util.random_real(min_scale, IntPhysGoal.MAX_OCCLUDER_SCALE, util.MIN_RANDOM_INTERVAL)

--- a/scene_generator/intphys_goals_test.py
+++ b/scene_generator/intphys_goals_test.py
@@ -16,8 +16,8 @@ def test_random_real():
 
 def test_GravityGoal_compute_objects():
     goal = GravityGoal()
-    object_dict, rects = goal.compute_objects('dummy wall material')
-    assert len(object_dict['target']) > 0
+    tag_to_objects, rects = goal.compute_objects('dummy wall material')
+    assert len(tag_to_objects['target']) > 0
     assert len(rects) == 0
 
 

--- a/scene_generator/intphys_goals_test.py
+++ b/scene_generator/intphys_goals_test.py
@@ -16,9 +16,8 @@ def test_random_real():
 
 def test_GravityGoal_compute_objects():
     goal = GravityGoal()
-    target_objs, all_objs, rects = goal.compute_objects('dummy wall material')
-    assert len(target_objs) > 0
-    assert len(all_objs) > 0
+    object_dict, rects = goal.compute_objects('dummy wall material')
+    assert len(object_dict['target']) > 0
     assert len(rects) == 0
 
 
@@ -124,6 +123,6 @@ def test_mcs_209():
     for obj in objs:
         assert obj['shows'][0]['stepBegin'] == obj['forces'][0]['stepBegin']
 
-    body = {'wallMaterial': 'dummy'}
+    body = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     goal._scenery_count = 0
     goal.update_body(body, False)

--- a/scene_generator/materials.py
+++ b/scene_generator/materials.py
@@ -2,6 +2,10 @@
 #Names here are matching the object material types
 #I.R.: an object with the "Ceramic" property will use "CERAMIC_MATERIALS"
 
+NOVEL_COLOR_LIST = [
+    # TODO
+]
+
 BLOCK_BLANK_MATERIALS = [
     ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/blue_1x1", ["blue"]),
     ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/red_1x1", ["red"]),

--- a/scene_generator/objects.py
+++ b/scene_generator/objects.py
@@ -1804,8 +1804,11 @@ OBJECTS_IMMOBILE = [{
     }]
 }]
 
+
 OCCLUDER_INSTANCE_NORMAL = [{
     "id": "occluder_wall_",
+    "info": [],
+    "info_string": "",
     "type": "cube",
     "kinematic": True,
     "structure": True,
@@ -1876,6 +1879,8 @@ OCCLUDER_INSTANCE_NORMAL = [{
     }]
 }, {
     "id": "occluder_pole_",
+    "info": [],
+    "info_string": "",
     "type": "cylinder",
     "kinematic": True,
     "structure": True,
@@ -1921,8 +1926,11 @@ OCCLUDER_INSTANCE_NORMAL = [{
     }]
 }]
 
+
 OCCLUDER_INSTANCE_SIDEWAYS = [{
     "id": "occluder_wall_",
+    "info": [],
+    "info_string": "",
     "type": "cube",
     "kinematic": True,
     "structure": True,
@@ -1993,6 +2001,8 @@ OCCLUDER_INSTANCE_SIDEWAYS = [{
     }]
 }, {
     "id": "occluder_pole_",
+    "info": [],
+    "info_string": "",
     "type": "cylinder",
     "kinematic": True,
     "structure": True,
@@ -3874,7 +3884,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
 }]
 
 
-def create_occluder(wall_material: str, pole_material: str,
+def create_occluder(wall_material: Tuple[str, List[str]], pole_material: Tuple[str, List[str]],
                     x_position: float, x_scale: float, sideways: bool = False) \
         -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Create an occluder pair of objects: (wall, pole)."""
@@ -3890,8 +3900,14 @@ def create_occluder(wall_material: str, pole_material: str,
     occluder[WALL]['id'] = occluder[WALL]['id'] + occluder_id
     occluder[POLE]['id'] = occluder[POLE]['id'] + occluder_id
 
-    occluder[WALL]['materials'] = [wall_material]
-    occluder[POLE]['materials'] = [pole_material]
+    occluder[WALL]['materials'] = [wall_material[0]]
+    occluder[POLE]['materials'] = [pole_material[0]]
+
+    occluder[WALL]['info'] = wall_material[1]
+    occluder[POLE]['info'] = pole_material[1]
+
+    occluder[WALL]['info_string'] = ' '.join(occluder[WALL]['info'])
+    occluder[POLE]['info_string'] = ' '.join(occluder[POLE]['info'])
 
     occluder[WALL]['shows'][0]['position']['x'] = x_position
     occluder[POLE]['shows'][0]['position']['x'] = x_position

--- a/scene_generator/objects_test.py
+++ b/scene_generator/objects_test.py
@@ -4,8 +4,8 @@ import random
 
 
 def test_create_occluder_normal():
-    wall_material = str(uuid.uuid4())
-    pole_material = str(uuid.uuid4())
+    wall_material = ['test_material_wall', ['white']]
+    pole_material = ['test_material_pole', ['brown']]
     x_position = random.uniform(-1, 1)
     x_scale = random.uniform(0.1, 2)
 
@@ -15,15 +15,19 @@ def test_create_occluder_normal():
     # make sure we got them back in the right order
     assert wall['type'] == 'cube'
     assert pole['type'] == 'cylinder'
-    assert wall['materials'] == [wall_material]
-    assert pole['materials'] == [pole_material]
+    assert wall['materials'] == ['test_material_wall']
+    assert pole['materials'] == ['test_material_pole']
+    assert wall['info'] == ['white']
+    assert pole['info'] == ['brown']
+    assert wall['info_string'] == 'white'
+    assert pole['info_string'] == 'brown'
     for x in wall, pole:
         assert x['shows'][0]['position']['x'] == x_position
 
         
 def test_create_occluder_sideways():
-    wall_material = str(uuid.uuid4())
-    pole_material = str(uuid.uuid4())
+    wall_material = ['test_material_wall', ['white']]
+    pole_material = ['test_material_pole', ['brown']]
     x_position = random.uniform(-1, 1)
     x_scale = random.uniform(0.1, 2)
 
@@ -33,8 +37,12 @@ def test_create_occluder_sideways():
     # make sure we got them back in the right order
     assert wall['type'] == 'cube'
     assert pole['type'] == 'cylinder'
-    assert wall['materials'] == [wall_material]
-    assert pole['materials'] == [pole_material]
+    assert wall['materials'] == ['test_material_wall']
+    assert pole['materials'] == ['test_material_pole']
+    assert wall['info'] == ['white']
+    assert pole['info'] == ['brown']
+    assert wall['info_string'] == 'white'
+    assert pole['info_string'] == 'brown'
 
     
 def test_get_all_object_defs():

--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -464,7 +464,7 @@ class ShapeConstancyQuartet(Quartet):
             # May have added and/or deleted an object, so regenerate
             # goal.info_list
             del scene['goal']['info_list']
-            self._goal._update_goal_info_list(scene['goal'], self._goal._object_dict)
+            self._goal._update_goal_info_list(scene['goal'], self._goal._tag_to_objects)
             self._scenes[q - 1] = scene
         logging.debug(f'get_scene: q={q}\thides? {scene["objects"][0].get("hides", None)}')
         return scene

--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -116,7 +116,7 @@ class ObjectPermanenceQuartet(Quartet):
                 self._appear_behind_occluder(scene)
             elif q == 4:
                 # target not in the scene (plausible)
-                target_id = self._goal._targets[0]
+                target_id = self._goal._targets[0]['id']
                 for i in range(len(scene['objects'])):
                     obj = scene['objects'][i]
                     if obj['id'] == target_id:

--- a/scene_generator/quartets_test.py
+++ b/scene_generator/quartets_test.py
@@ -14,7 +14,7 @@ def test_get_position_step():
 
 
 def test_STCQ_get_scene():
-    template = {'wallMaterial': 'dummy'}
+    template = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     quartet = SpatioTemporalContinuityQuartet(template, False)
     for q in range(1, 5):
         scene = quartet.get_scene(q)
@@ -22,10 +22,10 @@ def test_STCQ_get_scene():
 
 
 def test_STCQ__teleport_forward():
-    template = {'wallMaterial': 'dummy'}
+    template = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     quartet = SpatioTemporalContinuityQuartet(template, False)
     scene = quartet.get_scene(2)
-    target = find_targets(scene)[0]
+    target = find_targets(scene, quartet._goal)[0]
     if 'teleports' in target:
         assert target['teleports'][0]['stepBegin'] == target['teleports'][0]['stepEnd']
         if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
@@ -37,10 +37,10 @@ def test_STCQ__teleport_forward():
 
 
 def test_STCQ__teleport_backward():
-    template = {'wallMaterial': 'dummy'}
+    template = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     quartet = SpatioTemporalContinuityQuartet(template, False)
     scene = quartet.get_scene(3)
-    target = find_targets(scene)[0]
+    target = find_targets(scene, quartet._goal)[0]
     assert target['teleports'][0]['stepBegin'] == target['teleports'][0]['stepEnd']
     if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
         implausible_event_index1 = target['intphys_option']['occluder_indices'][0]
@@ -51,20 +51,20 @@ def test_STCQ__teleport_backward():
 
 
 def test_STCQ__move_later():
-    template = {'wallMaterial': 'dummy'}
+    template = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     quartet = SpatioTemporalContinuityQuartet(template, False)
     scene = quartet.get_scene(4)
-    target = find_targets(scene)[0]
+    target = find_targets(scene, quartet._goal)[0]
     assert 'teleports' not in target
     if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
         later_step_begin = target['shows'][0]['stepBegin']
-        orig_target = find_targets(quartet.get_scene(1))[0]
+        orig_target = find_targets(quartet.get_scene(1), quartet._goal)[0]
         orig_step_begin = orig_target['shows'][0]['stepBegin']
         assert later_step_begin > orig_step_begin
 
 
 def test_ShapeConstancyQuartet():
-    template = {'wallMaterial': 'dummy'}
+    template = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     quartet = ShapeConstancyQuartet(template, False)
     assert quartet is not None
     a = quartet._scenes[0]['objects'][0]
@@ -76,7 +76,7 @@ def test_ShapeConstancyQuartet():
 
 def test_ShapeConstancyQuartet_get_scene_2():
     # tests _turn_a_into_b
-    template = {'wallMaterial': 'dummy'}
+    template = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     quartet = ShapeConstancyQuartet(template, False)
     scene = quartet.get_scene(2)
     a = scene['objects'][0]
@@ -92,7 +92,7 @@ def test_ShapeConstancyQuartet_get_scene_2():
 
 def test_ShapeConstancyQuartet_get_scene_3():
     # tests turn_b_into_a
-    template = {'wallMaterial': 'dummy'}
+    template = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     quartet = ShapeConstancyQuartet(template, False)
     scene = quartet.get_scene(3)
     a = scene['objects'][0]
@@ -106,7 +106,7 @@ def test_ShapeConstancyQuartet_get_scene_3():
 
 
 def test_ObjectPermanenceQuartet_get_scene():
-    template = {'wallMaterial': 'dummy'}
+    template = {'wallMaterial': 'dummy', 'wallColors': ['color']}
     quartet = ObjectPermanenceQuartet(template, False)
     for q in range(1, 5):
         scene = quartet.get_scene(q)

--- a/scene_generator/scene_generator.py
+++ b/scene_generator/scene_generator.py
@@ -27,6 +27,7 @@ OUTPUT_TEMPLATE_JSON = """
   "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
   "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",
   "wallMaterial": "AI2-THOR/Materials/Walls/DrywallBeige",
+  "wallColors": ["white"],
   "performerStart": {
     "position": {
       "x": 0,
@@ -47,6 +48,7 @@ OUTPUT_TEMPLATE = json.loads(OUTPUT_TEMPLATE_JSON)
 
 def strip_debug_info(body: Dict[str, Any]) -> None:
     """Remove info that's only for our internal use (e.g., for debugging)"""
+    body.pop('wallColors', None)
     for obj in body['objects']:
         clean_object(obj)
     for goal_key in ('domain_list', 'type_list', 'task_list', 'info_list'):
@@ -62,11 +64,16 @@ def strip_debug_info(body: Dict[str, Any]) -> None:
 def clean_object(obj: Dict[str, Any]) -> None:
     """Remove properties we do not want TA1s to have access to."""
     obj.pop('info', None)
+    obj.pop('info_string', None)
     obj.pop('dimensions', None)
     obj.pop('intphys_option', None)
     obj.pop('materials_list', None)
     obj.pop('materialCategory', None)
     obj.pop('original_location', None)
+    obj.pop('novel_color', None)
+    obj.pop('novel_combination', None)
+    obj.pop('novel_shape', None)
+    obj.pop('shape', None)
     if 'shows' in obj:
         obj['shows'][0].pop('bounding_box', None)
 
@@ -78,6 +85,7 @@ def generate_body_template(name: str) -> Dict[str, Any]:
     ceil_wall_mat_choice = random.choice(CEILING_AND_WALL_MATERIALS)
     body['ceilingMaterial'] = ceil_wall_mat_choice[0]
     body['wallMaterial'] = ceil_wall_mat_choice[0]
+    body['wallColors'] = ceil_wall_mat_choice[1]
     body['floorMaterial'] = random.choice(FLOOR_MATERIALS)[0]
     return body
 

--- a/scene_generator/scene_generator_test.py
+++ b/scene_generator/scene_generator_test.py
@@ -8,32 +8,6 @@ def find_object(id, obj_list):
     return None
 
 
-def test_generate_scene_target_enclosed():
-    for _ in range(20):
-        scene = generate_scene('test', 'interaction', False)
-        metadata = scene['goal']['metadata']
-        type_list = scene['goal']['type_list']
-        assert len(type_list) == len(set(type_list))
-        for target_key in ('target', 'target_1', 'target_2'):
-            if target_key in metadata:
-                target_md = metadata[target_key]
-                target = find_object(target_md['id'], scene['objects'])
-                if target.get('locationParent', None) is None:
-                    assert 'target_not_enclosed' in type_list
-                else:
-                    assert 'target_enclosed' in type_list
-
-
-def test_generate_scene_goal_info():
-    scene = generate_scene('test', 'interaction', False)
-    info_list = scene['goal']['info_list']
-    info_set = set(info_list)
-    assert len(info_list) == len(info_set)
-    for obj in scene['objects']:
-        obj_info_set = set(obj.get('info', []))
-        assert obj_info_set <= info_set
-
-
 def test_clean_object():
     obj = {
         'id': 'thing1',
@@ -41,7 +15,13 @@ def test_clean_object():
             'x': 13,
             'z': 42
         },
+        'info': ['a', 'b', 'c', 'd'],
+        'info_string': 'abcd',
         'intphys_option': 'stuff',
+        'novel_color': True,
+        'novel_combination': False,
+        'novel_shape': True,
+        'shape': 'shape',
         'shows': [{
             'stepBegin': 0,
             'bounding_box': 'dummy'

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -31,9 +31,9 @@ def test_finalize_object_definition():
 
 def test_instantiate_object():
     object_def = {
-        'type': str(uuid.uuid4()),
-        'info': [str(uuid.uuid4()), str(uuid.uuid4())],
-        'mass': random.random(),
+        'type': 'sofa_1',
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
         'attributes': ['foo', 'bar'],
         'scale': 1.0
     }
@@ -51,12 +51,74 @@ def test_instantiate_object():
     }
     obj = instantiate_object(object_def, object_location)
     assert type(obj['id']) is str
-    for prop in ('type', 'mass'):
-        assert object_def[prop] == obj[prop]
-    for attribute in object_def['attributes']:
-        assert obj[attribute] is True
+    assert obj['type'] == 'sofa_1'
+    assert obj['goal_string'] == 'huge massive sofa'
+    assert obj['info'] == ['huge', 'massive', 'sofa']
+    assert obj['info_string'] == 'huge massive sofa'
+    assert obj['mass'] == 12.34
+    assert obj['novel_color'] is False
+    assert obj['novel_combination'] is False
+    assert obj['novel_shape'] is False
+    assert obj['shape'] == 'sofa'
+    assert obj['foo'] is True
+    assert obj['bar'] is True
     assert obj['shows'][0]['position'] == object_location['position']
     assert obj['shows'][0]['rotation'] == object_location['rotation']
+
+
+def test_instantiate_object_heavy_moveable():
+    object_def = {
+        'type': 'sofa_1',
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
+        'attributes': ['moveable'],
+        'scale': 1.0
+    }
+    object_location = {
+        'position': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        },
+        'rotation': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        }
+    }
+    obj = instantiate_object(object_def, object_location)
+    assert obj['goal_string'] == 'huge heavy sofa'
+    assert obj['info'] == ['huge', 'heavy', 'sofa']
+    assert obj['info_string'] == 'huge heavy sofa'
+    assert obj['moveable'] is True
+
+
+def test_instantiate_object_light_pickupable():
+    object_def = {
+        'type': 'sofa_1',
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
+        'attributes': ['moveable', 'pickupable'],
+        'scale': 1.0
+    }
+    object_location = {
+        'position': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        },
+        'rotation': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        }
+    }
+    obj = instantiate_object(object_def, object_location)
+    assert obj['goal_string'] == 'huge light sofa'
+    assert obj['info'] == ['huge', 'light', 'sofa']
+    assert obj['info_string'] == 'huge light sofa'
+    assert obj['moveable'] is True
+    assert obj['pickupable'] is True
 
 
 def test_instantiate_object_offset():
@@ -65,9 +127,9 @@ def test_instantiate_object_offset():
         'z': random.random()
     }
     object_def = {
-        'type': str(uuid.uuid4()),
-        'info': [str(uuid.uuid4()), str(uuid.uuid4())],
-        'mass': random.random(),
+        'type': 'sofa_1',
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
         'scale': 1.0,
         'attributes': [],
         'offset': offset
@@ -93,15 +155,14 @@ def test_instantiate_object_offset():
 
 
 def test_instantiate_object_materials():
-    material_category = ['plastic']
-    materials_list = materials.PLASTIC_MATERIALS
+    materials.TEST_MATERIALS = [('test_material', ['blue', 'yellow'])]
     object_def = {
-        'type': str(uuid.uuid4()),
-        'info': [str(uuid.uuid4()), str(uuid.uuid4())],
-        'mass': random.random(),
+        'type': 'sofa_1',
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
         'scale': 1.0,
         'attributes': [],
-        'materialCategory': material_category
+        'materialCategory': ['test']
     }
     object_location = {
         'position': {
@@ -116,18 +177,50 @@ def test_instantiate_object_materials():
         }
     }
     obj = instantiate_object(object_def, object_location)
-    assert obj['materials'][0] in (mat[0] for mat in materials_list)
+    assert obj['materials'] == ['test_material']
+    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa']
+    assert obj['info_string'] == 'huge massive blue yellow sofa'
+
+
+def test_instantiate_object_multiple_materials():
+    materials.TEST1_MATERIALS = [('test_material_1', ['blue'])]
+    materials.TEST2_MATERIALS = [('test_material_2', ['yellow'])]
+    object_def = {
+        'type': 'sofa_1',
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
+        'scale': 1.0,
+        'attributes': [],
+        'materialCategory': ['test1', 'test2']
+    }
+    object_location = {
+        'position': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        },
+        'rotation': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        }
+    }
+    obj = instantiate_object(object_def, object_location)
+    assert obj['materials'] == ['test_material_1', 'test_material_2']
+    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa']
+    assert obj['info_string'] == 'huge massive blue yellow sofa'
 
 
 def test_instantiate_object_salient_materials():
-    salient_materials = ["plastic", "hollow"]
     object_def = {
-        'type': str(uuid.uuid4()),
-        'info': [str(uuid.uuid4()), str(uuid.uuid4())],
-        'mass': random.random(),
+        'type': 'sofa_1',
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
         'scale': 1.0,
         'attributes': [],
-        'salientMaterials': salient_materials
+        'salientMaterials': ['fabric', 'wood']
     }
     object_location = {
         'position': {
@@ -142,16 +235,17 @@ def test_instantiate_object_salient_materials():
         }
     }
     obj = instantiate_object(object_def, object_location)
-    assert obj['salientMaterials'] == salient_materials
-    for sm in salient_materials:
-        assert sm in obj['info']
+    assert obj['salientMaterials'] == ['fabric', 'wood']
+    assert obj['goal_string'] == 'huge massive fabric wood sofa'
+    assert obj['info'] == ['huge', 'massive', 'fabric', 'wood', 'sofa']
+    assert obj['info_string'] == 'huge massive fabric wood sofa'
 
 
 def test_instantiate_object_size():
     object_def = {
-        'type': str(uuid.uuid4()),
-        'info': [str(uuid.uuid4()), str(uuid.uuid4())],
-        'mass': random.random(),
+        'type': 'sofa_1',
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
         'scale': 1.0,
         'attributes': [],
     }
@@ -203,4 +297,92 @@ def test_get_similar_defs():
     similar_defs = get_similar_defs(obj, ('type', 'materialCategory'), ('mass',))
     for obj_def in similar_defs:
         assert check_same_and_different(obj_def, obj, ('type', 'materialCategory'), ('mass',))
-    
+
+
+def test_instantiate_object_novel_color():
+    materials.TEST_MATERIALS = [('test_material', ['blue', 'yellow'])]
+    object_def = {
+        'type': 'sofa_1',
+        'novel_color': True,
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
+        'scale': 1.0,
+        'attributes': [],
+        'materialCategory': ['test']
+    }
+    object_location = {
+        'position': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        },
+        'rotation': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        }
+    }
+    obj = instantiate_object(object_def, object_location)
+    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel blue', 'novel yellow']
+    assert obj['info_string'] == '(novel color) huge massive blue yellow sofa'
+
+
+def test_instantiate_object_novel_combination():
+    materials.TEST_MATERIALS = [('test_material', ['blue', 'yellow'])]
+    object_def = {
+        'type': 'sofa_1',
+        'novel_combination': True,
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
+        'scale': 1.0,
+        'attributes': [],
+        'materialCategory': ['test']
+    }
+    object_location = {
+        'position': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        },
+        'rotation': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        }
+    }
+    obj = instantiate_object(object_def, object_location)
+    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel blue sofa', 'novel yellow sofa']
+    assert obj['info_string'] == '(novel combination) huge massive blue yellow sofa'
+
+
+def test_instantiate_object_novel_shape():
+    materials.TEST_MATERIALS = [('test_material', ['blue', 'yellow'])]
+    object_def = {
+        'type': 'sofa_1',
+        'novel_shape': True,
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
+        'scale': 1.0,
+        'attributes': [],
+        'materialCategory': ['test']
+    }
+    object_location = {
+        'position': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        },
+        'rotation': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        }
+    }
+    obj = instantiate_object(object_def, object_location)
+    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel sofa']
+    assert obj['info_string'] == '(novel shape) huge massive blue yellow sofa'
+
+


### PR DESCRIPTION
Accomplishments:
- Scene generator tags will now identify novel colors, shapes, and combinations in object definitions.
- Scene generator object tags now differentiate between target, distractor, and other objects.
- Scene generator now lists all targets, distractors, occluders, walls, and background objects in scenes.
- Fixed the scene generator so that all IntPhys goal types may add background objects (a.k.a. "scenery"), not just gravity goals.  (This probably should have been in its own commit, but oh well.)

Apologies for the long PR.