### PR TITLE
MCS-296 Cleanup of Interactive Goals

### DIFF
--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -15,7 +15,6 @@ MIN_WALL_WIDTH = 1
 WALL_Y_POS = 1.5
 WALL_HEIGHT = 3
 WALL_DEPTH = 0.1
-MAX_OBJECTS = 5
 WALL_COUNTS = [0, 1, 2, 3]
 WALL_PROBS = [60, 20, 10, 10]
 
@@ -126,33 +125,12 @@ class Goal(ABC):
             }
         return self._performer_start
 
-    def choose_object_def(self) -> Dict[str, Any]:
-        """Pick one object definition (to be added to the scene) and return a copy of it."""
-        object_def_list = random.choices([objects.OBJECTS_PICKUPABLE, objects.OBJECTS_MOVEABLE,
-                                          objects.OBJECTS_IMMOBILE],
-                                         [50, 25, 25])[0]
-        return util.finalize_object_definition(random.choice(object_def_list))
-
     @abstractmethod
     def compute_objects(self, wall_material_name: str) -> \
             Tuple[Dict[str, List[Dict[str, Any]]], List[List[Dict[str, float]]]]:
         """Compute object instances for the scene. Returns a tuple:
         (dict that maps tag strings to object lists, bounding rectangles)"""
         pass
-
-    def add_objects(self, object_list: List[Dict[str, Any]], rectangles: List[List[Dict[str, float]]],
-                    performer_position: Dict[str, float]) -> None:
-        """Add random objects to fill object_list to some random number of objects up to MAX_OBJECTS. If object_list
-        already has more than this randomly determined number, no new objects are added."""
-        object_count = random.randint(1, MAX_OBJECTS)
-        for i in range(len(object_list), object_count):
-            object_def = self.choose_object_def()
-            obj_location = geometry.calc_obj_pos(performer_position, rectangles, object_def)
-            obj_info = object_def['info'][-1]
-            targets_info = [tgt['info'][-1] for tgt in self._targets]
-            if obj_info not in targets_info and obj_location is not None:
-                obj = util.instantiate_object(object_def, obj_location)
-                object_list.append(obj)
 
     def _update_goal_info_list(self, goal: Dict[str, Any], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> None:
         info_set = set(goal.get('info_list', []))

--- a/scene_generator/goal_test.py
+++ b/scene_generator/goal_test.py
@@ -4,65 +4,6 @@ from goals import *
 from util import instantiate_object
 
 
-def test_Goal_duplicate_object():
-    goal_obj = RetrievalGoal()
-    obj = {
-        'id': str(uuid.uuid4()),
-        'info': [str(uuid.uuid4())],
-        'type': 'sphere',
-        "choose": [{
-            "mass": 0.25,
-            "materialCategory": ["plastic"],
-            "salientMaterials": ["plastic", "hollow"]
-        }, {
-            "mass": 0.5625,
-            "materialCategory": ["rubber"],
-            "salientMaterials": ["rubber"]
-        }, {
-            "mass": 0.5625,
-            "materialCategory": ["block_blank"],
-            "salientMaterials": ["wood"]
-        }, {
-            "mass": 0.5625,
-            "materialCategory": ["wood"],
-            "salientMaterials": ["wood"]
-        }, {
-            "mass": 1,
-            "materialCategory": ["metal"],
-            "salientMaterials": ["metal"]
-        }],
-        "attributes": ["moveable", "pickupable"],
-        "dimensions": {
-            "x": 0.1,
-            "y": 0.1,
-            "z": 0.1
-        },
-        "position_y": 0.05,
-        "scale": {
-            "x": 0.1,
-            "y": 0.1,
-            "z": 0.1
-        }
-    }
-    object_location = {
-        'position': {
-            'x': 0.0,
-            'y': 0.0,
-            'z': 0.0
-        },
-        'rotation': {
-            'x': 0.0,
-            'y': 0.0,
-            'z': 0.0
-        }
-    }
-    sphere = instantiate_object(obj, object_location)
-    bounding_rect = [[{'x': 3.7346446609406727, 'y': 0, 'z': 4.23}, {'x': 3.77, 'y': 0, 'z': 4.265355339059328}, {'x': 3.8053553390593273, 'y': 0, 'z': 4.23}, {'x': 3.77, 'y': 0, 'z': 4.194644660940673}], [{'x': 3.846, 'y': 0, 'z': -1.9685000000000001}, {'x': 3.846, 'y': 0, 'z': -2.4715000000000003}, {'x': 3.1340000000000003, 'y': 0, 'z': -2.4715000000000003}, {'x': 3.1340000000000003, 'y': 0, 'z': -1.9685000000000001}]]
-    performer_position = {'x': 0.77, 'y': 0, 'z': -0.41}
-    goal = goal_obj.get_config([sphere], { 'target': [sphere] })
-    goal_obj.add_objects([sphere], bounding_rect, performer_position)
-
-
 def create_tags_test_object_1():
     return {
         'id': 'test_sphere',

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -24,16 +24,15 @@ def test_move_to_container():
         obj_def = finalize_object_definition(obj_def)
         if 'tiny' in obj_def['info']:
             obj = instantiate_object(obj_def, geometry.ORIGIN_LOCATION)
-            all_objects = [obj]
             tries = 0
             while tries < 100:
-                if move_to_container(obj, all_objects, [], geometry.ORIGIN):
+                container = move_to_container(obj, [], geometry.ORIGIN)
+                if container:
                     break
                 tries += 1
             if tries == 100:
                 logging.error('could not put the object in any container')
-            container_id = all_objects[1]['id']
-            assert obj['locationParent'] == container_id
+            assert obj['locationParent'] == container['id']
             return
     assert False, 'could not find a tiny object'
 

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -12,10 +12,9 @@ MAX_TRIES = 200
 MIN_RANDOM_INTERVAL = 0.05
 PERFORMER_WIDTH = 0.1
 PERFORMER_HALF_WIDTH = PERFORMER_WIDTH / 2.0
-TARGET_CONTAINED_CHANCE = 0.5
-"""Chance that the target will be in a container"""
 
-TARGET_CONTAINED_CHANCE = 0.25
+# TODO MCS-306 DELETE
+TARGET_CONTAINED_CHANCE = 0.5
 """Chance that the target will be in a container"""
 
 


### PR DESCRIPTION
- MCS-296: All InteractionGoals now have the possibility of adding 0-10 distractors to the scene.
- Created ObjectRule classes that are used by InteractionGoals to describe the number of target and distractor objects needed by the goal type, as well as how those objects are selected and positioned.
  - This simplifies the code for the InteractiveGoals a lot.
  - This will be very helpful for MCS-306 when each InteractionPair will have its own InteractionGoal.  Each Pair will define specific Rules (the object definition must be similar to an existing object; the object must be positioned within specific parameters; the object must be positioned inside a container; etc.) and give them to its Goal.  Hopefully it will also be easy to mix-and-match Rules to create new Pairs in the future.