### PR TITLE
MCS-306 Add Interactive Goals to Scenes in Interactive Pairs

### DIFF
--- a/scene_generator/containers.py
+++ b/scene_generator/containers.py
@@ -116,11 +116,12 @@ def how_can_contain(container: Dict[str, Any],
         angles = []
         fits = True
         for target in targets:
-            angle = can_enclose(space, target)
-            if angle is None:
-                fits = False
-                break
-            angles.append(angle)
+            if target:
+                angle = can_enclose(space, target)
+                if angle is None:
+                    fits = False
+                    break
+                angles.append(angle)
         if fits:
             return i, angles
     return None

--- a/scene_generator/containers.py
+++ b/scene_generator/containers.py
@@ -139,8 +139,9 @@ def get_enclosable_containments(objs: Sequence[Dict[str, Any]],
     for container_def in container_defs:
         containment = how_can_contain(container_def, *objs)
         if containment is not None:
+            new_def = util.finalize_object_definition(container_def)
             index, angles = containment
-            valid_containments.append((container_def, index, angles))
+            valid_containments.append((new_def, index, angles))
         elif 'choose' in container_def:
             # try choose
             for choice in container_def['choose']:
@@ -232,7 +233,8 @@ def can_contain_both(container_def: Dict[str, Any],
         if result is None:
             return None
         index, orientation, angle_a, angle_b = result
-        return container_def, index, orientation, angle_a, angle_b
+        new_def = util.finalize_object_definition(container_def)
+        return new_def, index, orientation, angle_a, angle_b
     elif 'choose' in container_def:
         found_choice = None
         for choice in container_def['choose']:

--- a/scene_generator/containers.py
+++ b/scene_generator/containers.py
@@ -285,3 +285,32 @@ def get_parent(obj: Dict[str, Any], all_objects: Iterable[Dict[str, Any]]) \
     parent_id = obj['locationParent']
     parent = next((o for o in all_objects if o['id'] == parent_id))
     return parent
+
+
+def is_too_big_to_fit_any(obj: Dict[str, Any]) -> bool:
+    """Return if the given object is too big to fit inside any available containers."""
+    valid_defs = []
+    for obj_def in objects.get_enclosed_containers():
+        if 'choose' in obj_def:
+            valid_choices = []
+            for choice in obj_def['choose']:
+                possible_obj_def = util.finalize_object_definition(copy.deepcopy(obj_def), choice)
+                for area in possible_obj_def['enclosed_areas']:
+                    if area['dimensions']['x'] >= obj['dimensions']['x'] and \
+                            area['dimensions']['y'] >= obj['dimensions']['y'] and \
+                            area['dimensions']['z'] >= obj['dimensions']['z']:
+                        valid_choices.append(choice)
+                        break
+            if len(valid_choices) > 0:
+                new_def = copy.deepcopy(obj_def)
+                new_def['choose'] = valid_choices
+                valid_defs.append(new_def)
+        else:
+            possible_obj_def = util.finalize_object_definition(copy.deepcopy(obj_def))
+            for area in possible_obj_def['enclosed_areas']:
+                if area['dimensions']['x'] >= obj['dimensions']['x'] and \
+                        area['dimensions']['y'] >= obj['dimensions']['y'] and \
+                        area['dimensions']['z'] >= obj['dimensions']['z']:
+                    valid_defs.append(obj_def)
+    return len(valid_defs) > 0
+

--- a/scene_generator/containers.py
+++ b/scene_generator/containers.py
@@ -287,10 +287,13 @@ def get_parent(obj: Dict[str, Any], all_objects: Iterable[Dict[str, Any]]) \
     return parent
 
 
-def is_too_big_to_fit_any(obj: Dict[str, Any]) -> bool:
-    """Return if the given object is too big to fit inside any available containers."""
+def find_suitable_enclosable_list(obj: Dict[str, Any], container_defs: Sequence[Dict[str, Any]] = None) -> \
+        List[Dict[str, Any]]:
+    """Find and return the list of enclosable receptacle definitions into which the given object can fit."""
     valid_defs = []
-    for obj_def in objects.get_enclosed_containers():
+    if container_defs is None:
+        container_defs = objects.get_enclosed_containers()
+    for obj_def in container_defs:
         if 'choose' in obj_def:
             valid_choices = []
             for choice in obj_def['choose']:
@@ -300,7 +303,6 @@ def is_too_big_to_fit_any(obj: Dict[str, Any]) -> bool:
                             area['dimensions']['y'] >= obj['dimensions']['y'] and \
                             area['dimensions']['z'] >= obj['dimensions']['z']:
                         valid_choices.append(choice)
-                        break
             if len(valid_choices) > 0:
                 new_def = copy.deepcopy(obj_def)
                 new_def['choose'] = valid_choices
@@ -312,5 +314,5 @@ def is_too_big_to_fit_any(obj: Dict[str, Any]) -> bool:
                         area['dimensions']['y'] >= obj['dimensions']['y'] and \
                         area['dimensions']['z'] >= obj['dimensions']['z']:
                     valid_defs.append(obj_def)
-    return len(valid_defs) > 0
+    return valid_defs
 

--- a/scene_generator/geometry_test.py
+++ b/scene_generator/geometry_test.py
@@ -330,7 +330,7 @@ def test_get_visible_segment():
     assert segment == expected_segment
 
 
-def test_get_position_behind_performer():
+def test_get_position_in_back_of_performer():
     target_def = objects.OBJECTS_PICKUPABLE_BALLS[0]
     start = {
         'position': ORIGIN,
@@ -338,12 +338,12 @@ def test_get_position_behind_performer():
             'y': 90
         }
     }
-    negative_x = get_location_behind_performer(start, target_def)
+    negative_x = get_location_in_back_of_performer(start, target_def)
     assert 0 >= negative_x['position']['x'] >= ROOM_DIMENSIONS[0][0]
     assert ROOM_DIMENSIONS[1][1] >= negative_x['position']['z'] >= ROOM_DIMENSIONS[1][0]
 
     start['rotation']['y'] = 0
-    negative_z = get_location_behind_performer(start, target_def)
+    negative_z = get_location_in_back_of_performer(start, target_def)
     assert 0 >= negative_z['position']['z'] >= ROOM_DIMENSIONS[1][0]
     assert ROOM_DIMENSIONS[0][1] >= negative_z['position']['z'] >= ROOM_DIMENSIONS[0][0]
 

--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -89,8 +89,9 @@ class Goal(ABC):
         object."""
         self._tag_to_objects = self.compute_objects(body['wallMaterial'], body['wallColors'])
 
-        body['objects'] = [element for value in tag_to_objects.values() for element in value]
-        body['goal'] = self.get_config(self._tag_to_objects['target'], tag_to_objects)
+        body['performerStart'] = self._performer_start
+        body['objects'] = [element for value in self._tag_to_objects.values() for element in value]
+        body['goal'] = self.get_config(self._tag_to_objects)
 
         if find_path:
             body['answer']['actions'] = self._find_optimal_path(self._tag_to_objects['target'], body['objects'])
@@ -104,17 +105,19 @@ class Goal(ABC):
             self._performer_start = {
                 'position': {
                     'x': round(random.uniform(
-                        ROOM_DIMENSIONS[0][0] + util.PERFORMER_HALF_WIDTH,
-                        ROOM_DIMENSIONS[0][1] - util.PERFORMER_HALF_WIDTH
+                        geometry.ROOM_DIMENSIONS[0][0] + util.PERFORMER_HALF_WIDTH,
+                        geometry.ROOM_DIMENSIONS[0][1] - util.PERFORMER_HALF_WIDTH
                     ), geometry.POSITION_DIGITS),
                     'y': 0,
                     'z': round(random.uniform(
-                        ROOM_DIMENSIONS[1][0] + util.PERFORMER_HALF_WIDTH,
-                        ROOM_DIMENSIONS[1][1] - util.PERFORMER_HALF_WIDTH
+                        geometry.ROOM_DIMENSIONS[1][0] + util.PERFORMER_HALF_WIDTH,
+                        geometry.ROOM_DIMENSIONS[1][1] - util.PERFORMER_HALF_WIDTH
                     ), geometry.POSITION_DIGITS)
                 },
                 'rotation': {
-                    'y': geometry.random_rotation()
+                    'x': 0,
+                    'y': geometry.random_rotation(),
+                    'z': 0
                 }
             }
         return self._performer_start
@@ -162,11 +165,9 @@ class Goal(ABC):
                 if new_tag not in goal['type_list']:
                     goal['type_list'].append(new_tag)
 
-    def get_config(self, goal_objects: List[Dict[str, Any]], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> \
-            Dict[str, Any]:
-        """Get the goal configuration. goal_objects is the objects required for the goal (as returned from
-        compute_objects)."""
-        goal_config = self._get_subclass_config(goal_objects)
+    def get_config(self, tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+        """Create and return the goal configuration."""
+        goal_config = self._get_subclass_config(tag_to_objects['target'])
         self._update_goal_tags(goal_config, tag_to_objects)
         return goal_config
 

--- a/scene_generator/goal_test.py
+++ b/scene_generator/goal_test.py
@@ -69,7 +69,7 @@ def create_tags_test_object_2():
 def test_Goal_tags():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    goal = goal_object.get_config([target], { 'target': [target] })
+    goal = goal_object.get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -110,7 +110,7 @@ def test_Goal_tags_multiple_target():
     goal_object = RetrievalGoal()
     target_1 = create_tags_test_object_1()
     target_2 = create_tags_test_object_2()
-    goal = goal_object.get_config([target_1, target_2], { 'target': [target_1, target_2] })
+    goal = goal_object.get_config({ 'target': [target_1, target_2] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -134,7 +134,7 @@ def test_Goal_tags_with_distractor():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
-    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -167,7 +167,7 @@ def test_Goal_tags_multiple_target_multiple_distractor():
     target_2 = create_tags_test_object_1()
     distractor_1 = create_tags_test_object_2()
     distractor_2 = create_tags_test_object_2()
-    goal = goal_object.get_config([target_1, target_2], { 'target': [target_1, target_2], \
+    goal = goal_object.get_config({ 'target': [target_1, target_2], \
             'distractor': [distractor_1, distractor_2] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -200,7 +200,7 @@ def test_Goal_tags_with_occluder():
     target = create_tags_test_object_1()
     occluder_wall = { 'info': ['white'] }
     occluder_pole = { 'info': ['brown'] }
-    goal = goal_object.get_config([target], { 'target': [target], 'occluder': [occluder_wall, occluder_pole] })
+    goal = goal_object.get_config({ 'target': [target], 'occluder': [occluder_wall, occluder_pole] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -223,7 +223,7 @@ def test_Goal_tags_with_wall():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     wall = { 'info': ['white'] }
-    goal = goal_object.get_config([target], { 'target': [target], 'wall': [wall] })
+    goal = goal_object.get_config({ 'target': [target], 'wall': [wall] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -245,7 +245,7 @@ def test_Goal_tags_with_background_object():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     background_object = { 'info': ['red'] }
-    goal = goal_object.get_config([target], { 'target': [target], 'background object': [background_object] })
+    goal = goal_object.get_config({ 'target': [target], 'background object': [background_object] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -267,7 +267,7 @@ def test_Goal_tags_target_enclosed():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['locationParent'] = 'parent'
-    goal = goal_object.get_config([target], { 'target': [target] })
+    goal = goal_object.get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -287,7 +287,7 @@ def test_Goal_tags_target_novel_color():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novel_color'] = True
-    goal = goal_object.get_config([target], { 'target': [target] })
+    goal = goal_object.get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -307,7 +307,7 @@ def test_Goal_tags_target_novel_combination():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novel_combination'] = True
-    goal = goal_object.get_config([target], { 'target': [target] })
+    goal = goal_object.get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -327,7 +327,7 @@ def test_Goal_tags_target_novel_shape():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novel_shape'] = True
-    goal = goal_object.get_config([target], { 'target': [target] })
+    goal = goal_object.get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -349,7 +349,7 @@ def test_Goal_tags_target_enclosed_novel_color_novel_shape():
     target['locationParent'] = 'parent'
     target['novel_color'] = True
     target['novel_shape'] = True
-    goal = goal_object.get_config([target], { 'target': [target] })
+    goal = goal_object.get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -370,7 +370,7 @@ def test_Goal_tags_distractor_enclosed():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['locationParent'] = 'parent'
-    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -402,7 +402,7 @@ def test_Goal_tags_distractor_novel_color():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novel_color'] = True
-    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -434,7 +434,7 @@ def test_Goal_tags_distractor_novel_combination():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novel_combination'] = True
-    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -466,7 +466,7 @@ def test_Goal_tags_distractor_novel_shape():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novel_shape'] = True
-    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -500,7 +500,7 @@ def test_Goal_tags_distractor_enclosed_novel_color_novel_shape():
     distractor['locationParent'] = 'parent'
     distractor['novel_color'] = True
     distractor['novel_shape'] = True
-    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -537,7 +537,7 @@ def test_Goal_tags_target_distractor_enclosed_novel_color_novel_shape():
     distractor['locationParent'] = 'parent'
     distractor['novel_color'] = True
     distractor['novel_shape'] = True
-    goal = goal_object.get_config([target], { 'target': [target], 'distractor': [distractor] })
+    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -202,9 +202,9 @@ def move_to_container(target: Dict[str, Any], bounds_list: List[List[Dict[str, f
 class ObjectRule():
     """Defines rules for how a specific object can be made and positioned as part of a specific goal."""
 
-    def __init__(self, position_in_receptacle = False, position_on_receptacle = False):
-        self.position_in_receptacle = position_in_receptacle
-        self.position_on_receptacle = position_on_receptacle
+    def __init__(self, is_position_in_receptacle = False, is_position_on_receptacle = False):
+        self.is_position_in_receptacle = is_position_in_receptacle
+        self.is_position_on_receptacle = is_position_on_receptacle
 
     def choose_definition(self) -> Dict[str, Any]:
         """Choose and return an object definition."""
@@ -230,8 +230,8 @@ class ObjectRule():
 
 
 class PickupableObjectRule(ObjectRule):
-    def __init__(self, position_in_receptacle = False, position_on_receptacle = False):
-        super(PickupableObjectRule, self).__init__(position_in_receptacle, position_on_receptacle)
+    def __init__(self, is_position_in_receptacle = False, is_position_on_receptacle = False):
+        super(PickupableObjectRule, self).__init__(is_position_in_receptacle, is_position_on_receptacle)
 
     def choose_definition(self) -> Dict[str, Any]:
         object_definition_list = random.choice(objects.OBJECTS_PICKUPABLE_LISTS)
@@ -239,8 +239,8 @@ class PickupableObjectRule(ObjectRule):
 
 
 class TransferToObjectRule(ObjectRule):
-    def __init__(self, position_in_receptacle = False, position_on_receptacle = False):
-        super(TransferToObjectRule, self).__init__(position_in_receptacle, position_on_receptacle)
+    def __init__(self, is_position_in_receptacle = False, is_position_on_receptacle = False):
+        super(TransferToObjectRule, self).__init__(is_position_in_receptacle, is_position_on_receptacle)
 
     def choose_definition(self) -> Dict[str, Any]:
         stack_targets_pickupable = [definition for definition in objects.OBJECTS_PICKUPABLE \
@@ -281,8 +281,8 @@ class TransferToObjectRule(ObjectRule):
 
 
 class FarOffObjectRule(ObjectRule):
-    def __init__(self, position_in_receptacle = False, position_on_receptacle = False):
-        super(FarOffObjectRule, self).__init__(position_in_receptacle, position_on_receptacle)
+    def __init__(self, is_position_in_receptacle = False, is_position_on_receptacle = False):
+        super(FarOffObjectRule, self).__init__(is_position_in_receptacle, is_position_on_receptacle)
 
     def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
             performer_start: Dict[str, Dict[str, float]]) -> bool:
@@ -294,9 +294,9 @@ class FarOffObjectRule(ObjectRule):
 
 
 class DistractorObjectRule(ObjectRule):
-    def __init__(self, target_list: List[Dict[str, Any]], position_in_receptacle = False, \
-            position_on_receptacle = False):
-        super(DistractorObjectRule, self).__init__(position_in_receptacle, position_on_receptacle)
+    def __init__(self, target_list: List[Dict[str, Any]], is_position_in_receptacle = False, \
+            is_position_on_receptacle = False):
+        super(DistractorObjectRule, self).__init__(is_position_in_receptacle, is_position_on_receptacle)
         self._target_list = target_list
 
     def choose_definition(self) -> Dict[str, Any]:
@@ -383,7 +383,7 @@ class InteractionGoal(Goal, ABC):
             # Automatically generate a random number of distractors with random parameters.
             distractor_rule_list = []
             for _ in range(random.randint(0, InteractionGoal.MAX_DISTRACTORS) + 1):
-                distractor_rule_list.append(self.get_distractor_rule(position_in_receptacle = \
+                distractor_rule_list.append(self.get_distractor_rule(is_position_in_receptacle = \
                         (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)))
             self.__generate_object_list(self._distractor_list, distractor_rule_list, self._target_list, \
                     self._distractor_list)
@@ -427,11 +427,11 @@ class InteractionGoal(Goal, ABC):
         """Returns the distractors in this goal."""
         return self._distractor_list
 
-    def get_distractor_rule(self, target_list: List[Dict[str, Any]] = None, position_in_receptacle: bool = False) -> \
-            ObjectRule:
+    def get_distractor_rule(self, target_list: List[Dict[str, Any]] = None, \
+            is_position_in_receptacle: bool = False) -> ObjectRule:
         """Returns the rule for any distractors compatible with this goal."""
         return DistractorObjectRule(target_list = (target_list if target_list is not None else self._target_list), \
-                position_in_receptacle = position_in_receptacle)
+                is_position_in_receptacle = is_position_in_receptacle)
 
     def get_obstructor_rule(self, target_definition: Dict[str, Any], obstruct_vision: bool = False) -> ObjectRule:
         """Returns the rule for any obstructors compatible with this goal."""
@@ -465,10 +465,10 @@ class InteractionGoal(Goal, ABC):
             object_instance = instantiate_object(object_definition, object_location)
             object_list.append(object_instance)
             receptacle_instance = None
-            if rule.position_in_receptacle:
+            if rule.is_position_in_receptacle:
                 receptacle_instance = self.__move_into_receptacle(object_instance, self._performer_start, \
                         self._bounds_list)
-            if rule.position_on_receptacle:
+            if rule.is_position_on_receptacle:
                 receptacle_instance = self.__move_onto_receptacle(object_instance, self._performer_start, \
                         self._bounds_list)
             if receptacle_instance:
@@ -507,7 +507,7 @@ class RetrievalGoal(InteractionGoal):
     def __init__(self):
         super(RetrievalGoal, self).__init__(target_rule_list = [
             PickupableObjectRule(
-                position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                is_position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             )
         ])
 
@@ -587,7 +587,7 @@ class TransferralGoal(InteractionGoal):
     def __init__(self):
         super(TransferralGoal, self).__init__(target_rule_list = [
             PickupableObjectRule(
-                position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                is_position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             ),
             TransferToObjectRule()
         ])
@@ -717,7 +717,7 @@ class TraversalGoal(InteractionGoal):
     def __init__(self):
         super(TraversalGoal, self).__init__(target_rule_list = [
             FarOffObjectRule(
-                position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                is_position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             )
         ])
 

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -13,7 +13,7 @@ import geometry
 import objects
 import util
 from geometry import POSITION_DIGITS
-from goal import GoalException, Goal
+from goal import GoalException, Goal, generate_wall
 from machine_common_sense.mcs_controller_ai2thor import MAX_MOVE_DISTANCE, MAX_REACH_DISTANCE, PERFORMER_CAMERA_Y
 from optimal_path import generatepath
 from util import finalize_object_definition, instantiate_object
@@ -178,10 +178,10 @@ def trim_actions_to_reach(actions: List[Dict[str, Any]],
     return new_actions, (new_x, new_z)
 
 
-def move_to_container(target: Dict[str, Any], bounding_rectangles: List[List[Dict[str, float]]],
+def move_to_container(target: Dict[str, Any], bounds_list: List[List[Dict[str, float]]],
                       performer_position: Dict[str, float]) -> Dict[str, Any]:
     """Try to find a random container that target will fit in. If found, set the target's locationParent, and add
-    container to bounding_rectangles. Return the container, or None if the target was not put into a container."""
+    container to bounds_list. Return the container, or None if the target was not put into a container."""
     shuffled_containers = objects.get_enclosed_containers().copy()
     random.shuffle(shuffled_containers)
     for container_definition in shuffled_containers:
@@ -189,7 +189,7 @@ def move_to_container(target: Dict[str, Any], bounding_rectangles: List[List[Dic
         containment = containers.how_can_contain(container_definition, target)
         if containment is not None:
             # try to place the container before we accept it
-            container_location = geometry.calc_obj_pos(performer_position, bounding_rectangles, container_definition)
+            container_location = geometry.calc_obj_pos(performer_position, bounds_list, container_definition)
             if container_location is not None:
                 container = instantiate_object(container_definition, container_location)
                 area, angles = containment
@@ -201,55 +201,47 @@ def move_to_container(target: Dict[str, Any], bounding_rectangles: List[List[Dic
 class ObjectRule():
     """Defines rules for how a specific object can be made and positioned as part of a specific goal."""
 
-    def __init__(self, position_inside_receptacle=False):
-        self._position_inside_receptacle = position_inside_receptacle
+    def __init__(self, position_in_receptacle = False, position_on_receptacle = False):
+        self.position_in_receptacle = position_in_receptacle
+        self.position_on_receptacle = position_on_receptacle
 
-    def choose_definition(self, target_list: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def choose_definition(self) -> Dict[str, Any]:
         """Choose and return an object definition."""
         # Same chance to pick each list.
         object_definition_list = random.choice(
-            [objects.OBJECTS_PICKUPABLE, objects.OBJECTS_MOVEABLE, objects.OBJECTS_IMMOBILE],
+            [objects.OBJECTS_PICKUPABLE, objects.OBJECTS_MOVEABLE, objects.OBJECTS_IMMOBILE]
         )
         # Same chance to pick each object definition from the list.
         return finalize_object_definition(random.choice(object_definition_list))
 
-    def choose_location(self, object_definition: Dict[str, Any], target_list: List[Dict[str, Any]], \
-            performer_start_position: Dict[str, float], bounding_rectangles: List[List[Dict[str, float]]]) -> \
-            Tuple[Dict[str, Any], List[List[Dict[str, float]]]]:
-        """Choose and return the location for the given object definition. Will update bounding_rectangles."""
-        object_location = geometry.calc_obj_pos(performer_start_position, bounding_rectangles, object_definition)
-        if object_location is None:
+    def choose_location(self, object_definition: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], \
+            bounds_list: List[List[Dict[str, float]]]) -> Tuple[Dict[str, Any], List[List[Dict[str, float]]]]:
+        """Choose and return the location for the given object definition. Will modify bounds_list."""
+        object_location = geometry.calc_obj_pos(performer_start['position'], bounds_list, object_definition)
+        if not object_location:
             raise GoalException(f'cannot position object (type={object_definition["type"]})')
-        return object_location, bounding_rectangles
+        return object_location, bounds_list
 
-    def move_to_receptacle(self, object_instance: Dict[str, Any], performer_start_position: Dict[str, float],
-                           bounding_rectangles: List[List[Dict[str, float]]]) -> Dict[str, Any]:
-        """If needed, create and return a receptacle object, moving the given object into or onto the new receptacle.
-        May update bounding_rectangles."""
-        # Only a pickupable object can be positioned inside a receptacle.
-        if self._position_inside_receptacle and object_instance.get('pickupable', False):
-            # Receptacles that can have objects positioned inside them are sometimes called "containers"
-            receptacle = move_to_container(object_instance, bounding_rectangles, performer_start_position)
-            if receptacle:
-                return receptacle
-        # TODO If needed, position objects on top of receptacles.
-        return None
+    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
+            performer_start: Dict[str, Dict[str, float]]) -> bool:
+        """Returns if the given object location is valid."""
+        return True
 
 
 class PickupableObjectRule(ObjectRule):
-    def __init__(self, position_inside_receptacle=False):
-        super(PickupableObjectRule, self).__init__(position_inside_receptacle=position_inside_receptacle)
+    def __init__(self, position_in_receptacle = False, position_on_receptacle = False):
+        super(PickupableObjectRule, self).__init__(position_in_receptacle, position_on_receptacle)
 
-    def choose_definition(self, target_list: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def choose_definition(self) -> Dict[str, Any]:
         object_definition_list = random.choice(objects.OBJECTS_PICKUPABLE_LISTS)
         return finalize_object_definition(random.choice(object_definition_list))
 
 
 class TransferToObjectRule(ObjectRule):
-    def __init__(self):
-        super(TransferToObjectRule, self).__init__(position_inside_receptacle=False)
+    def __init__(self, position_in_receptacle = False, position_on_receptacle = False):
+        super(TransferToObjectRule, self).__init__(position_in_receptacle, position_on_receptacle)
 
-    def choose_definition(self, target_list: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def choose_definition(self) -> Dict[str, Any]:
         stack_targets_pickupable = [definition for definition in objects.OBJECTS_PICKUPABLE \
                 if 'stackTarget' in definition.get('attributes', [])]
         stack_targets_moveable = [definition for definition in objects.OBJECTS_MOVEABLE \
@@ -266,62 +258,50 @@ class TransferToObjectRule(ObjectRule):
             choice_list.append(stack_targets_immobile)
 
         if len(choice_list) == 0:
-            raise ValueError(f'TransferToObjectRule cannot find any stack target object definition')
+            raise exceptions.SceneException('cannot find any stack target definition')
 
         # Same chance to pick each list.
         object_definition_list = random.choice(choice_list)
         # Same chance to pick each object definition from the list.
         return finalize_object_definition(random.choice(object_definition_list))
 
-    def choose_location(self, object_definition: Dict[str, Any], target_list: List[Dict[str, Any]], \
-            performer_start_position: Dict[str, float], bounding_rectangles: List[List[Dict[str, float]]]) -> \
-            Tuple[Dict[str, Any], List[List[Dict[str, float]]]]:
+    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
+            performer_start: Dict[str, Dict[str, float]]) -> bool:
 
         if len(target_list) == 0:
-            raise ValueError(f'TransferToObjectRule cannot find existing target object')
+            raise exceptions.SceneException('cannot find existing target to transfer')
 
         target_1_position = target_list[0]['shows'][0]['position']
 
-        while True:
-            # Copy the bounding_rectangles because we don't want to modify them if the distance not right.
-            object_location, bounding_rectangles_modified = super(TransferToObjectRule, self).choose_location(\
-                    object_definition, target_list, performer_start_position, bounding_rectangles.copy())
-            distance = geometry.position_distance(target_1_position, object_location['position'])
-            # Cannot be positioned too close to the existing target object.
-            if distance >= geometry.MINIMUM_TARGET_SEPARATION:
-                break
+        distance = geometry.position_distance(target_1_position, object_location['position'])
 
-        return object_location, bounding_rectangles_modified
+        # Cannot be positioned too close to the existing target object.
+        return distance >= geometry.MINIMUM_TARGET_SEPARATION
 
 
 class FarOffObjectRule(ObjectRule):
-    def __init__(self, position_inside_receptacle=False):
-        super(FarOffObjectRule, self).__init__(position_inside_receptacle=position_inside_receptacle)
+    def __init__(self, position_in_receptacle = False, position_on_receptacle = False):
+        super(FarOffObjectRule, self).__init__(position_in_receptacle, position_on_receptacle)
 
-    def choose_location(self, object_definition: Dict[str, Any], target_list: List[Dict[str, Any]], \
-            performer_start_position: Dict[str, float], bounding_rectangles: List[List[Dict[str, float]]]) -> \
-            Tuple[Dict[str, Any], List[List[Dict[str, float]]]]:
+    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
+            performer_start: Dict[str, Dict[str, float]]) -> bool:
 
-        while True:
-            # Copy the bounding_rectangles because we don't want to modify them if the distance not right.
-            object_location, bounding_rectangles_modified = super(FarOffObjectRule, self).choose_location(\
-                    object_definition, target_list, performer_start_position, bounding_rectangles.copy())
-            distance = geometry.position_distance(performer_start_position, object_location['position'])
-            # Cannot be positioned too close to the performer.
-            if distance >= geometry.MINIMUM_START_DIST_FROM_TARGET:
-                break
+        distance = geometry.position_distance(performer_start['position'], object_location['position'])
 
-        return object_location, bounding_rectangles_modified
+        # Cannot be positioned too close to the performer.
+        return distance >= geometry.MINIMUM_START_DIST_FROM_TARGET
 
 
 class DistractorObjectRule(ObjectRule):
-    def __init__(self, position_inside_receptacle=False):
-        super(DistractorObjectRule, self).__init__(position_inside_receptacle=position_inside_receptacle)
+    def __init__(self, target_list: List[Dict[str, Any]], position_in_receptacle = False, \
+            position_on_receptacle = False):
+        super(DistractorObjectRule, self).__init__(position_in_receptacle, position_on_receptacle)
+        self._target_list = target_list
 
-    def choose_definition(self, target_list: List[Dict[str, Any]]) -> Dict[str, Any]:
-        target_shape_list = [target['info'][-1] for target in target_list]
+    def choose_definition(self) -> Dict[str, Any]:
+        target_shape_list = [target['info'][-1] for target in self._target_list]
         while True:
-            distractor_definition = super(DistractorObjectRule, self).choose_definition(target_list)
+            distractor_definition = super(DistractorObjectRule, self).choose_definition()
             distractor_shape = distractor_definition['info'][-1]
             # Cannot have the same shape as a target object, so we don't unintentionally generate a confusor.
             if distractor_shape not in target_shape_list:
@@ -329,59 +309,185 @@ class DistractorObjectRule(ObjectRule):
         return distractor_definition
 
 
+class ConfusorObjectRule(ObjectRule):
+    def __init__(self, target_definition: Dict[str, Any]):
+        super(ConfusorObjectRule, self).__init__()
+        self._target_definition = target_definition
+
+    def choose_definition(self) -> Dict[str, Any]:
+        confusor_definition = util.get_similar_definition(self._target_definition)
+        if confusor_definition:
+            raise exceptions.SceneException('cannot create a confusor')
+        return util.finalize_object_definition(confusor_definition)
+
+
+class ObstructorObjectRule(ObjectRule):
+    def __init__(self, target_definition: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], \
+            obstruct_vision: bool = False):
+        super(ObstructorObjectRule, self).__init__()
+        self._target_definition = target_definition
+        self._obstruct_vision = obstruct_vision
+
+    def choose_definition(self) -> Dict[str, Any]:
+        for _ in range(util.MAX_TRIES):
+            if self._obstruct_vision:
+                obstructor_definition_list = geometry.get_wider_and_taller_defs(self._target_definition)
+            else:
+                # TODO MCS-262
+                pass
+            if obstructor_definition_list is not None:
+                break
+        if obstructor_definition_list is None:
+            raise exceptions.SceneException('cannot create an obstructor')
+        obstructor_definition, obstructor_angle = random.choice(obstructor_definition_list)
+        obstructor_definition = util.finalize_object_definition(obstructor_definition)
+        if not 'rotation' in obstructor_definition:
+            obstructor_definition['rotation'] = {
+                'x': 0,
+                'y': 0,
+                'z': 0
+            }
+        # Note that this rotation must be also modified with the final performer start Y.
+        obstructor_definition['rotation']['y'] = obstructor_definition['rotation']['y'] + obstructor_angle
+        return obstructor_definition
+
+
 class InteractionGoal(Goal, ABC):
     LAST_STEP = 600
+    # MAX_DISTRACTORS doesn't count the receptacles randomly generated to containerize other objects.
     MAX_DISTRACTORS = 10
-    OBJECT_RECEPTACLE_CHANCE = 0.25
+    OBJECT_RECEPTACLE_CHANCE = 0.333
+    WALL_CHOICES = [0, 1, 2, 3]
+    WALL_WEIGHTS = [40, 30, 20, 10]
 
-    def __init__(self, target_rule_list: List[ObjectRule], distractor_rule_list: List[ObjectRule] = None):
+    def __init__(self, target_rule_list: List[ObjectRule]):
         super(InteractionGoal, self).__init__()
-        self._bounding_rects = []
-        self._target_rule_list = target_rule_list;
-        if distractor_rule_list:
-            self._distractor_rule_list = distractor_rule_list;
-        else:
-            # Automatically generate a random number of distractors with random parameters.
-            self._distractor_rule_list = []
-            for _ in range(random.randint(0, InteractionGoal.MAX_DISTRACTORS) + 1):
-                self._distractor_rule_list.append(DistractorObjectRule(
-                    position_inside_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
-                ))
+        self._target_rule_list = target_rule_list
+        self._bounds_list = []
+        self._target_list = []
+        self._distractor_list = []
+        self._wall_list = None
+        self._is_distractor_list_done = False
 
-    def compute_objects(self, room_wall_material_name: str) -> \
-            Tuple[Dict[str, List[Dict[str, Any]]], List[List[Dict[str, float]]]]:
-
-        target_list = []
-        distractor_list = []
-
-        for target_rule in self._target_rule_list:
-            target_definition = target_rule.choose_definition(target_list)
-            target_location, bounding_rectangles = target_rule.choose_location(target_definition, target_list, \
-                    self._performer_start['position'], self._bounding_rects)
-            self._bounding_rects = bounding_rectangles
-            target = instantiate_object(target_definition, target_location)
-            target_list.append(target)
-            receptacle = target_rule.move_to_receptacle(target, self._performer_start['position'], \
-                    self._bounding_rects)
-            if receptacle:
-                distractor_list.append(receptacle)
-
-        for distractor_rule in self._distractor_rule_list:
-            distractor_definition = distractor_rule.choose_definition(target_list)
-            distractor_location, bounding_rectangles = distractor_rule.choose_location(distractor_definition, \
-                    target_list, self._performer_start['position'], self._bounding_rects)
-            self._bounding_rects = bounding_rectangles
-            distractor = instantiate_object(distractor_definition, distractor_location)
-            distractor_list.append(distractor)
-            receptacle = distractor_rule.move_to_receptacle(distractor, self._performer_start['position'], \
-                    self._bounding_rects)
-            if receptacle:
-                distractor_list.append(receptacle)
-
+    # override
+    def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
         return {
-            'target': target_list,
-            'distractor': distractor_list
-        }, self._bounding_rects
+            'target': self.generate_target_list(),
+            'distractor': self.generate_distractor_list(),
+            'wall': self.generate_wall_list(wall_material_name, wall_colors)
+        }
+
+    def generate_distractor_list(self) -> List[Dict[str, Any]]:
+        """Generates and returns the distractors in this goal."""
+        if not self._is_distractor_list_done:
+            # Automatically generate a random number of distractors with random parameters.
+            distractor_rule_list = []
+            for _ in range(random.randint(0, InteractionGoal.MAX_DISTRACTORS) + 1):
+                distractor_rule_list.append(self.get_distractor_rule(position_in_receptacle = \
+                        (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)))
+            self.__generate_object_list(self._distractor_list, distractor_rule_list, self._target_list, \
+                    self._distractor_list)
+            self._is_distractor_list_done = True
+        return self._distractor_list
+
+    def generate_target_list(self, end_index: int = None) -> List[Dict[str, Any]]:
+        """Generates and returns the targets in this goal (or up to the end_index, if given)."""
+        # Only generate each target up to the given end_index, or generate all targets if no end_index was given.
+        if len(self._target_list) < (end_index if end_index is not None else len(self._target_rule_list)):
+            # Keep all existing targets; only generate new targets that don't yet exist.
+            incomplete_target_rule_list = self._target_rule_list[len(self._target_list):]
+            self.__generate_object_list(self._target_list, incomplete_target_rule_list, self._target_list, \
+                    self._distractor_list)
+        return self._target_list
+
+    def generate_wall_list(self, wall_material_name: str, wall_colors: List[str]) -> List[Dict[str, Any]]:
+        """Generates and returns the walls (other than the room's starting walls) in this goal."""
+        if self._wall_list is None:
+            self._wall_list = []
+            for _ in range(random.choices(WALL_CHOICES, weights=WALL_WEIGHTS, k=1)[0]):
+                wall = generate_wall(wall_material_name, wall_colors, self._performer_start['position'], \
+                        self._bounds_list)
+                if wall:
+                    self._wall_list.append(wall)
+                    self._bounds_list.append(wall['shows'][0]['bounding_box'])
+                else:
+                    logging.warning('cannot generate wall object')
+        return self._wall_list
+
+    def get_bounds_list(self) -> List[List[Dict[str, float]]]:
+        """Returns the bounding rectangles of all objects in this goal."""
+        return self._bounds_list
+
+    def get_confusor_rule(self, target_definition: Dict[str, Any], position_in_receptacle: bool = False) -> ObjectRule:
+        """Returns the rule for any confusors compatible with this goal."""
+        return ConfusorObjectRule(target_definition = target_definition, \
+                position_in_receptacle = position_in_receptacle)
+
+    def get_distractor_list(self) -> List[Dict[str, Any]]:
+        """Returns the distractors in this goal."""
+        return self._distractor_list
+
+    def get_distractor_rule(self, target_list: List[Dict[str, Any]] = None, position_in_receptacle: bool = False) -> \
+            ObjectRule:
+        """Returns the rule for any distractors compatible with this goal."""
+        return DistractorObjectRule(target_list = (target_list if target_list is not None else self._target_list), \
+                position_in_receptacle = position_in_receptacle)
+
+    def get_obstructor_rule(self, target_definition: Dict[str, Any], obstruct_vision: bool = False) -> ObjectRule:
+        """Returns the rule for any obstructors compatible with this goal."""
+        return ObstructorObjectRule(target_definition = target_definition, obstruct_vision = obstruct_vision)
+
+    def get_target_list(self) -> List[Dict[str, Any]]:
+        """Returns the targets in this goal."""
+        return self._target_list
+
+    def get_target_rule_list(self) -> List[ObjectRule]:
+        """Returns the rules for the targets associated with this goal."""
+        return self._target_rule_list
+
+    def __generate_object_list(self, object_list: List[Dict[str, Any]], rule_list: List[ObjectRule], \
+            target_list: List[Dict[str, Any]], distractor_list: List[Dict[str, Any]]) -> None:
+        """Generates new objects using the given rule_list and saves them in the given object_list. Will modify the
+        given distractor_list and self._bounds_list"""
+
+        for rule in rule_list:
+            object_definition = rule.choose_definition(target_list)
+            for _ in range(util.MAX_TRIES):
+                object_location, bounds_list_modified = rule.choose_location(object_definition, \
+                        self._performer_start, self._bounds_list)
+                if rule.validate_location(object_location, target_list, self._performer_start):
+                    break
+            if not object_location:
+                raise exceptions.SceneException('cannot find a suitable object location')
+            self._bounds_list = bounds_list_modified
+            object_instance = instantiate_object(object_definition, object_location)
+            object_list.append(object_instance)
+            if rule.position_in_receptacle:
+                receptacle_instance = rule.__move_into_receptacle(object_instance, self._performer_start, \
+                        self._bounds_list)
+            if rule.position_on_receptacle:
+                receptacle_instance = rule.__move_onto_receptacle(object_instance, self._performer_start, \
+                        self._bounds_list)
+            if receptacle_instance:
+                distractor_list.append(receptacle_instance)
+
+    def __move_into_receptacle(self, object_instance: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], \
+            bounds_list: List[List[Dict[str, float]]]) -> Dict[str, Any]:
+        """Create and return a receptacle object, moving the given object into the new receptacle. Will modify
+        bounds_list."""
+        receptacle = None
+        # Only a pickupable object can be positioned inside a receptacle.
+        if object_instance.get('pickupable', False):
+            # Receptacles that can have objects positioned inside them are sometimes called "containers"
+            receptacle = move_to_container(object_instance, bounds_list, performer_start['position'])
+        return receptacle
+
+    def __move_onto_receptacle(self, object_instance: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], \
+            bounds_list: List[List[Dict[str, float]]]) -> Dict[str, Any]:
+        """Create and return a receptacle object, moving the given object onto the new receptacle. Will modify
+        bounds_list."""
+        # TODO MCS-146 Position objects on top of receptacles.
+        return None
 
 
 class RetrievalGoal(InteractionGoal):
@@ -398,13 +504,13 @@ class RetrievalGoal(InteractionGoal):
     def __init__(self):
         super(RetrievalGoal, self).__init__(target_rule_list = [
             PickupableObjectRule(
-                position_inside_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             )
         ])
 
     def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         if len(goal_objects) < 1:
-            raise ValueError('need at least 1 object for this goal')
+            raise exceptions.SceneException('need at least 1 object for this goal')
 
         target = goal_objects[0]
         target_image_obj = find_image_for_object(target)
@@ -423,7 +529,7 @@ class RetrievalGoal(InteractionGoal):
         goal['description'] = f'Find and pick up the {target["info_string"]}.'
         return goal
 
-    def find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
+    def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
             List[Dict[str, Any]]:
         # Goal should be a singleton... I hope
         actions, performer, heading = get_navigation_actions(self._performer_start, goal_objects[0], all_objects)
@@ -478,19 +584,19 @@ class TransferralGoal(InteractionGoal):
     def __init__(self):
         super(TransferralGoal, self).__init__(target_rule_list = [
             PickupableObjectRule(
-                position_inside_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             ),
             TransferToObjectRule()
         ])
 
     def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         if len(goal_objects) < 2:
-            raise ValueError(f'need at least 2 objects for this goal, was given {len(goal_objects)}')
+            raise exceptions.SceneException(f'need at least 2 objects for this goal, was given {len(goal_objects)}')
         target1, target2 = goal_objects[0:2]
         if not target1.get('pickupable', False):
-            raise ValueError(f'first object must be "pickupable": {target1}')
+            raise exceptions.SceneException(f'first object must be "pickupable": {target1}')
         if not target2.get('stackTarget', False):
-            raise ValueError(f'second object must be "stackTarget": {target2}')
+            raise exceptions.SceneException(f'second object must be "stackTarget": {target2}')
         relationship = random.choice(list(self.RelationshipType))
 
         target1_image_obj = find_image_for_object(target1)
@@ -521,7 +627,7 @@ class TransferralGoal(InteractionGoal):
             f'the {target2["info_string"]}.'
         return goal
 
-    def find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
+    def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
             List[Dict[str, Any]]:
         # Goal should be a singleton... I hope
         actions, performer, heading = get_navigation_actions(self._performer_start,
@@ -608,13 +714,13 @@ class TraversalGoal(InteractionGoal):
     def __init__(self):
         super(TraversalGoal, self).__init__(target_rule_list = [
             FarOffObjectRule(
-                position_inside_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             )
         ])
 
     def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         if len(goal_objects) < 1:
-            raise ValueError('need at least 1 object for this goal')
+            raise exceptions.SceneException('need at least 1 object for this goal')
 
         target = goal_objects[0]
         target_image_obj = find_image_for_object(target)
@@ -633,7 +739,7 @@ class TraversalGoal(InteractionGoal):
         goal['description'] = f'Find the {target["info_string"]} and move near it.'
         return goal
 
-    def find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
+    def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
             List[Dict[str, Any]]:
         # Goal should be a singleton... I hope
         # TODO: (maybe) look at actual object if it's inside a parent (future ticket)

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -318,9 +318,9 @@ class ConfusorObjectRule(ObjectRule):
     def choose_definition(self) -> Dict[str, Any]:
         if not self._target_definition:
             raise exceptions.SceneException('cannot create a confusor with no target definition')
-        confusor_definition = util.get_similar_definition(self._target_definition)
+        confusor_definition = util.get_similar_definition(self._target_definition, objects.get_all_object_defs())
         if not confusor_definition:
-            raise exceptions.SceneException('cannot find a confusor to create')
+            raise exceptions.SceneException(f'cannot find a confusor to create with target={self._target_definition}')
         return util.finalize_object_definition(confusor_definition)
 
 
@@ -343,7 +343,7 @@ class ObstructorObjectRule(ObjectRule):
             if not obstructor_definition_list:
                 break
         if not obstructor_definition_list:
-            raise exceptions.SceneException('cannot find an obstructor to create')
+            raise exceptions.SceneException(f'cannot find an obstructor to create with target={self._target_definition}')
         obstructor_definition, obstructor_angle = random.choice(obstructor_definition_list)
         obstructor_definition = util.finalize_object_definition(obstructor_definition)
         if not 'rotation' in obstructor_definition:
@@ -417,7 +417,7 @@ class InteractionGoal(Goal, ABC):
                     self._wall_list.append(wall)
                     self._bounds_list.append(wall['shows'][0]['bounding_box'])
                 else:
-                    logging.warning('cannot generate wall object')
+                    logging.warning('cannot generate a dynamic wall object')
         return self._wall_list
 
     def get_bounds_list(self) -> List[List[Dict[str, float]]]:

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -632,7 +632,7 @@ def test_add_RotateLook_to_action_list_before_Pickup_or_Put_Object():
 
     goal_obj = RetrievalGoal()
     goal_obj._performer_start = scene['performerStart']
-    path = goal_obj.find_optimal_path(scene['objects'], scene['objects'])
+    path = goal_obj._find_optimal_path(scene['objects'], scene['objects'])
     print(path)
     # TODO: uncomment when this is fixed
     assert path[-1]['action'] == 'RotateLook'

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -472,32 +472,18 @@ def test__generate_transferral_goal_with_nonstackable_goal():
 
 def test_TransferralGoal_ensure_pickup_action():
     """For MCS-270"""
-    goal_obj = TransferralGoal()
-    body: Dict[str, Any] = {
-        'name': '',
-        'ceilingMaterial': 'AI2-THOR/Materials/Walls/Drywall',
-        'floorMaterial': 'AI2-THOR/Materials/Fabrics/CarpetWhite 3',
-        'wallMaterial': 'AI2-THOR/Materials/Walls/DrywallBeige',
-        'wallColors': ['white'],
-        'performerStart': {
-            'position': {
-                'x': 0,
-                'z': 0
-            },
-            'rotation': {
-                'y': 0
-            }
-        },
-        'objects': [],
-        'goal': {},
-        'answer': {}
-    }
     for _ in range(MAX_TRIES):
-        try:
-            goal_obj.update_body(body, True)
+        goal_obj = TransferralGoal()
+        body: Dict[str, Any] = scene_generator.OUTPUT_TEMPLATE
+        for _ in range(MAX_TRIES):
+            try:
+                goal_obj.update_body(body, True)
+                break
+            except goal.GoalException:
+                pass
+        if 'actions' in body['answer']:
             break
-        except goal.GoalException:
-            pass
+
     # should have a PickupObject action
     assert any((action['action'] == 'PickupObject' for action in body['answer']['actions']))
     # last action one should be PutObject
@@ -506,27 +492,18 @@ def test_TransferralGoal_ensure_pickup_action():
 
 def test_TransferralGoal_navigate_near_objects():
     """For MCS-271"""
-    goal_obj = TransferralGoal()
-    body: Dict[str, Any] = {
-        'name': '',
-        'ceilingMaterial': 'AI2-THOR/Materials/Walls/Drywall',
-        'floorMaterial': 'AI2-THOR/Materials/Fabrics/CarpetWhite 3',
-        'wallMaterial': 'AI2-THOR/Materials/Walls/DrywallBeige',
-        'wallColors': ['white'],
-        'performerStart': {
-            'position': {
-                'x': 0,
-                'z': 0
-            },
-            'rotation': {
-                'y': 0
-            }
-        },
-        'objects': [],
-        'goal': {},
-        'answer': {}
-    }
-    goal_obj.update_body(body, True)
+    for _ in range(MAX_TRIES):
+        goal_obj = TransferralGoal()
+        body: Dict[str, Any] = scene_generator.OUTPUT_TEMPLATE
+        for _ in range(MAX_TRIES):
+            try:
+                goal_obj.update_body(body, True)
+                break
+            except goal.GoalException:
+                pass
+        if 'actions' in body['answer']:
+            break
+
     pickupable_id = body['goal']['metadata']['target_1']['id']
     container_id = body['goal']['metadata']['target_2']['id']
     pickupable_obj = next((obj for obj in body['objects'] if obj['id'] == pickupable_id))

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -14,7 +14,7 @@ import util
 from goal import Goal, GoalException
 from util import finalize_object_definition, instantiate_object
 
-MAX_SIZE_DIFFERENCE = 0.1
+
 MAX_WALL_WIDTH = 4
 MIN_WALL_WIDTH = 1
 WALL_Y_POS = 1.5

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -89,7 +89,7 @@ class IntPhysGoal(Goal, ABC):
         self._object_creator = None
         self._object_defs = objects.OBJECTS_INTPHYS
 
-    def compute_performer_start(self) -> Dict[str, Dict[str, float]]:
+    def _compute_performer_start(self) -> Dict[str, Dict[str, float]]:
         if self._performer_start is None:
             self._performer_start = {
                 'position': {
@@ -105,7 +105,7 @@ class IntPhysGoal(Goal, ABC):
 
     def update_body(self, body: Dict[str, Any], find_path: bool) -> Dict[str, Any]:
         body = super(IntPhysGoal, self).update_body(body, find_path)
-        for obj in self._targets:
+        for obj in self._tag_to_objects['target']:
             obj['torques'] = [IntPhysGoal.DEFAULT_TORQUE]
 
         body['observation'] = True
@@ -114,7 +114,7 @@ class IntPhysGoal(Goal, ABC):
         }
         return body
 
-    def find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
+    def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
             List[Dict[str, Any]]:
         return []
 
@@ -129,18 +129,11 @@ class IntPhysGoal(Goal, ABC):
                 goal['type_list'].append('fall down')
         return goal
 
-    def generate_walls(self, material: str, colors: List[str], performer_position: Dict[str, Any],
-                       bounding_rects: List[List[Dict[str, float]]]) -> List[Dict[str, Any]]:
-        """IntPhys goals have no walls."""
-        return None
-
-    def compute_objects(self, room_wall_material_name: str) -> \
-            Tuple[Dict[str, List[Dict[str, Any]]], List[List[Dict[str, float]]]]:
-
+    def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
         self._object_creator = random.choice([IntPhysGoal._get_objects_and_occluders_moving_across,
                                               IntPhysGoal._get_objects_falling_down])
         self._last_step = IntPhysGoal.LAST_STEP_FALL_DOWN
-        moving_objs, occluder_objs = self._object_creator(self, room_wall_material_name)
+        moving_objs, occluder_objs = self._object_creator(self, wall_material_name)
         background_objs = self._compute_scenery()
 
         return {
@@ -148,7 +141,7 @@ class IntPhysGoal(Goal, ABC):
             'distractor': moving_objs[1:],
             'background object': background_objs,
             'occluder': occluder_objs
-        }, []
+        }
 
     def _compute_scenery(self):
         MIN_VISIBLE_X = -6.5
@@ -561,10 +554,8 @@ class GravityGoal(IntPhysGoal):
             raise ValueError('cannot get left-to-right-ness before compute_objects is called')
         return self._left_to_right
 
-    def compute_objects(self, room_wall_material_name: str) -> \
-            Tuple[Dict[str, List[Dict[str, Any]]], List[List[Dict[str, float]]]]:
-
-        ramp_type, left_to_right, ramp_objs, moving_objs = self._get_ramp_and_objects(room_wall_material_name)
+    def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+        ramp_type, left_to_right, ramp_objs, moving_objs = self._get_ramp_and_objects(wall_material_name)
         self._ramp_type = ramp_type
         self._left_to_right = left_to_right
         background_objs = self._compute_scenery()
@@ -574,7 +565,7 @@ class GravityGoal(IntPhysGoal):
             'distractor': moving_objs[1:],
             'background object': background_objs,
             'ramp': ramp_objs
-        }, []
+        }
 
     def _create_random_ramp(self) -> Tuple[ramps.Ramp, bool, float, List[Dict[str, Any]]]:
         material_name = random.choice(materials.OCCLUDER_MATERIALS)[0]

--- a/scene_generator/intphys_goals_test.py
+++ b/scene_generator/intphys_goals_test.py
@@ -31,12 +31,11 @@ BODY_TEMPLATE = {
 
 def test_GravityGoal_compute_objects():
     goal = GravityGoal()
-    tag_to_objects, rects = goal.compute_objects('dummy wall material')
+    tag_to_objects = goal.compute_objects('dummy wall material', 'dummy wall color')
     assert len(tag_to_objects['target']) >= 1
     assert len(tag_to_objects['distractor']) >= 0
     assert len(tag_to_objects['background object']) >= 0
     assert len(tag_to_objects['ramp']) >= 1
-    assert len(rects) == 0
     assert goal._last_step > 0
 
 
@@ -61,12 +60,11 @@ def test_GravityGoal_update_body():
 
 def test_ObjectPermanenceGoal_compute_objects():
     goal = ObjectPermanenceGoal()
-    tag_to_objects, rects = goal.compute_objects('dummy wall material')
+    tag_to_objects = goal.compute_objects('dummy wall material', 'dummy wall color')
     assert len(tag_to_objects['target']) >= 1
     assert len(tag_to_objects['distractor']) >= 0
     assert len(tag_to_objects['background object']) >= 0
     assert len(tag_to_objects['occluder']) >= 1
-    assert len(rects) == 0
     assert (goal._object_creator == IntPhysGoal._get_objects_and_occluders_moving_across) or \
             (goal._object_creator == IntPhysGoal._get_objects_falling_down)
     assert goal._last_step > 0
@@ -90,12 +88,11 @@ def test_ObjectPermanenceGoal_update_body():
 
 def test_ShapeConstancyGoal_compute_objects():
     goal = ShapeConstancyGoal()
-    tag_to_objects, rects = goal.compute_objects('dummy wall material')
+    tag_to_objects = goal.compute_objects('dummy wall material', 'dummy wall color')
     assert len(tag_to_objects['target']) >= 1
     assert len(tag_to_objects['distractor']) >= 0
     assert len(tag_to_objects['background object']) >= 0
     assert len(tag_to_objects['occluder']) >= 1
-    assert len(rects) == 0
     assert (goal._object_creator == IntPhysGoal._get_objects_and_occluders_moving_across) or \
             (goal._object_creator == IntPhysGoal._get_objects_falling_down)
     assert goal._last_step > 0
@@ -119,12 +116,11 @@ def test_ShapeConstancyGoal_update_body():
 
 def test_SpatioTemporalContinuityGoal_compute_objects():
     goal = SpatioTemporalContinuityGoal()
-    tag_to_objects, rects = goal.compute_objects('dummy wall material')
+    tag_to_objects = goal.compute_objects('dummy wall material', 'dummy wall color')
     assert len(tag_to_objects['target']) >= 1
     assert len(tag_to_objects['distractor']) >= 0
     assert len(tag_to_objects['background object']) >= 0
     assert len(tag_to_objects['occluder']) >= 1
-    assert len(rects) == 0
     assert (goal._object_creator == IntPhysGoal._get_objects_and_occluders_moving_across) or \
             (goal._object_creator == IntPhysGoal._get_objects_falling_down)
     assert goal._last_step > 0

--- a/scene_generator/pairs.py
+++ b/scene_generator/pairs.py
@@ -2,25 +2,18 @@ import copy
 import logging
 import random
 from abc import ABC, abstractmethod
-from typing import Tuple, Dict, Any, Type, Optional
+from enum import Enum, auto
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import shapely
 
 import containers
 import exceptions
 import geometry
+import goals
+from interaction_goals import InteractionGoal, ObjectRule
 import objects
 import util
-from geometry import ROOM_DIMENSIONS, MIN_START_DISTANCE_AWAY
-
-
-MAX_EXTRA_OBJECTS = 10
-PERFORMER_BOUNDS = ((ROOM_DIMENSIONS[0][0] + MIN_START_DISTANCE_AWAY,
-                     ROOM_DIMENSIONS[0][1] - MIN_START_DISTANCE_AWAY),
-                    (ROOM_DIMENSIONS[1][0] + MIN_START_DISTANCE_AWAY,
-                     ROOM_DIMENSIONS[1][1] - MIN_START_DISTANCE_AWAY))
-"""(minX, maxX), (minZ, maxZ) for the performer (leaving space to put
-an object in front of it)"""
 
 
 def move_to_location(obj_def: Dict[str, Any], obj: Dict[str, Any],
@@ -37,93 +30,539 @@ def move_to_location(obj_def: Dict[str, Any], obj: Dict[str, Any],
         obj['shows'][0]['bounding_box'] = new_location['bounding_box']
 
 
-def instantiate_away_from(obj_def: Dict[str, Any],
-                          performer_position: Dict[str, float],
-                          old_obj: Dict[str, Any]) \
-                          -> Optional[Dict[str, Any]]:
-    """Instantiate obj_def in a location so that old_obj and the returned
-    object are not adjacent. Returns None if it cannot find any such
-    location for the new object.
-    """
-    for _ in range(util.MAX_TRIES):
-        location = geometry.calc_obj_pos(performer_position, [], obj_def)
-        new_obj = util.instantiate_object(obj_def, location)
-        if not geometry.are_adjacent(old_obj, new_obj):
-            return new_obj
-    return None
+class BoolPairOption(Enum):
+    YES_YES = auto()
+    YES_NO = auto()
+    NO_NO = auto()
+    NO_YES = auto()
 
 
-def add_objects(target: Dict[str, Any], performer_position: Dict[str, float], scene: Dict[str, Any]):
-    """Add 0 to MAX_EXTRA_OBJECTS to the scene with none between the
-    performer and the target.
-    """
-    all_obj_defs = objects.get_all_object_defs()
-    target_x = target['shows'][0]['position']['x']
-    target_z = target['shows'][0]['position']['z']
-    target_coords = geometry.calc_obj_coords(target_x, target_z,
-                                             target['dimensions']['x'] / 2.0,
-                                             target['dimensions']['z'] / 2.0,
-                                             0, 0, target['shows'][0]['rotation']['y'])
-    # init with the rect for the target
-    rects = [target_coords]
-    num_extra_objects = random.randint(0, MAX_EXTRA_OBJECTS)
-    for _ in range(num_extra_objects):
-        found_location = False
-        for dummy in range(util.MAX_TRIES):
-            obj_def = util.finalize_object_definition(random.choice(all_obj_defs))
-            location = geometry.calc_obj_pos(performer_position, rects, obj_def)
-            rect = rects[-1]
-            rect_as_poly = shapely.geometry.Polygon([(point['x'], point['z']) for point in rect])
-            # check intersection of rect_coords with line between target and performer
-            visible_segment = shapely.geometry.LineString([(performer_position['x'],
-                                                           performer_position['z']),
-                                                           (target_x, target_z)])
-            if rect_as_poly.intersects(visible_segment):
-                # reject it
-                rects.pop()
-            else:
-                found_location = True
-                break
-        if found_location:
-            new_obj = util.instantiate_object(obj_def, location)
-            scene['objects'].append(new_obj)
+class ConfusorLocationPairOption(Enum):
+    # Either in back of or in front of the performer
+    BACK_FRONT = auto()
+    # Very close to the target object
+    CLOSE_CLOSE = auto()
+    # Either very close to or far away from the target object
+    CLOSE_FAR = auto()
+    # Either doesn't exist or very close to the target object
+    NONE_CLOSE = auto()
+    # Either doesn't exist or far away from the target object
+    NONE_FAR = auto()
 
 
-class InteractionPair(ABC):
-    """Abstract base class for interaction pairs. This is analogous to the
-    intphys quartets, but for interaction scenarios. See MCS-235.
-    """
+class TargetLocationPairOption(Enum):
+    # Either in back of or in from of the performer
+    FRONT_BACK = auto()
+    # The same position in front of the performer
+    FRONT_FRONT = auto()
+    # The same random position
+    RANDOM = auto()
 
-    def __init__(self, template: Dict[str, Any], find_path: bool):
-        self._template = template
-        self._find_path = find_path
-        self._compute_performer_start()
 
-    @abstractmethod
+class SceneOptions():
+    def __init__(self, target_containerize: BoolPairOption = BoolPairOption.NO_NO, \
+            target_location: TargetLocationPairOption = TargetLocationPairOption.RANDOM, \
+            confusor: BoolPairOption = BoolPairOption.NO_NO, \
+            confusor_containerize: BoolPairOption = BoolPairOption.NO_NO, \
+            confusor_location: ConfusorLocationPairOption = ConfusorLocationPairOption.CLOSE_CLOSE, \
+            obstructor: BoolPairOption = BoolPairOption.NO_NO):
+        self.target_containerize = target_containerize
+        self.target_location = target_location
+        # The confusor is always for the target object, but we may want to change that in the future.
+        self.confusor = confusor
+        self.confusor_containerize = confusor_containerize
+        self.confusor_location = confusor_location
+        # The obstructor is always for the target object, but we may want to change that in the future.
+        self.obstructor = obstructor
+
+
+class InteractionPair():
+    """A pair of interactive scenes that each have the same goals, targets, distractors, walls, materials, and
+    performer starts, except for specifically configured scene options."""
+
+    def __init__(self, template: Dict[str, Any], find_path: bool, options: SceneOptions):
+        self._scene_1 = copy.deepcopy(template)
+        self._scene_2 = copy.deepcopy(template)
+        self._options = options
+        self._goal_1 = goals.choose_goal('interaction')
+        self._initialize_each_goal()
+        self._goal_1.update_body(self._scene_1, find_path)
+        self._goal_2.update_body(self._scene_2, find_path)
+
     def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        pass
+        return self._scene_1, self._scene_2
 
-    def _compute_performer_start(self) -> None:
-        """Set the starting location (position & rotation) for the performer
-        (_performer_start). This default implementation chooses a
-        random location.
+    def _initialize_each_goal(self) -> None:
         """
-        if getattr(self, '_performer_start', None) is None:
-            self._performer_start = {
-                'position': {
-                    'x': round(random.uniform(PERFORMER_BOUNDS[0][0], PERFORMER_BOUNDS[0][1]), geometry.POSITION_DIGITS),
-                    'y': 0,
-                    'z': round(random.uniform(PERFORMER_BOUNDS[1][0], PERFORMER_BOUNDS[1][1]), geometry.POSITION_DIGITS)
-                },
-                'rotation': {
-                    'y': geometry.random_rotation()
-                }
-            }
+        Initialize the goals for the two scenes in this pair and all their objects:
+        - Create the objects specific to this pair (target, confusor, obstructor).
+        - Containerize this pair's objects if needed by this pair's setup or if randomly chosen.
+        - Move this pair's objects into locations specific to each scene.
+        - Create the rest of the objects (targets, distractors, walls) in the goal for the first scene.
+        - Copy the first scene's goal to make the second scene's goal and replace this pair's objects.
+        """
+        # Use the first goal for the pair now, and later copy it and modify the copy that will be the second goal.
+        goal_1_target_rule_list = self._goal_1.get_target_rule_list()
 
-    def _get_empty_scene(self) -> Dict[str, Any]:
-        scene = copy.deepcopy(self._template)
-        scene['performerStart'] = self._performer_start
-        return scene
+        # Randomly choose a target from the goal to use in both scenes.
+        target_choice = random.randint(0, len(goal_1_target_rule_list) - 1)
+
+        # Create all the targets in the goal that must come before the chosen one.
+        self._goal_1.generate_target_list(target_choice)
+
+        # Save each existing target and its bounding rectangles for later.
+        goal_1_target_list = self._goal_1.get_target_list()
+        shared_bounds_list = self._goal_1.get_bounds_list()
+
+        # Choose a definition for the chosen target to use in both scenes.
+        target_definition = goal_1_target_rule_list[target_choice].choose_definition()
+
+        # Create the target template now at a location, and later it'll move to its location for each scene.
+        target_template = util.instantiate_object(target_definition, geometry.ORIGIN_LOCATION)
+
+        confusor_template = None
+        obstructor_template = None
+        receptacle_definition = None
+        receptacle_template = None
+        area_index = None
+        orientation = None
+        target_rotation = None
+        confusor_rotation = None
+
+        # Create the confusor to use in either scene if needed.
+        if self._options.confusor != BoolPairOption.NO_NO:
+            confusor_definition = self._goal_1.get_confusor_rule(target_template).choose_definition()
+            # Create the confusor template now at a location, and later it'll move to its location for each scene.
+            confusor_template = util.instantiate_object(confusor_definition, geometry.ORIGIN_LOCATION)
+
+        is_receptacle_needed = (self._options.target_containerize != BoolPairOption.NO_NO or \
+                self._options.confusor_containerize != BoolPairOption.NO_NO)
+
+        is_confusor_close_in_goal_1 = (self._options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or \
+                self._options.confusor_location == ConfusorLocationPairOption.CLOSE_FAR)
+
+        is_confusor_close_in_goal_2 = (self._options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or \
+                self._options.confusor_location == ConfusorLocationPairOption.NONE_CLOSE)
+
+        # Create the receptacle to use in either scene that will containerize the target and/or confusor if needed.
+        if is_receptacle_needed:
+            # If the confusor will be close to the target in either scene, the receptacle must be able to hold both.
+            if confusor_template and (is_confusor_close_in_goal_1 or is_confusor_close_in_goal_2):
+                receptacle_data = self._create_receptacle_around_both(target_definition, confusor_definition)
+                if not receptacle_data:
+                    # TODO Recreate the target and/or confusor?
+                    raise exceptions.SceneException('cannot create enclosable receptacle around target AND confusor')
+                receptacle_definition, area_index, target_rotation, confusor_rotation, orientation = receptacle_data
+            else:
+                receptacle_data = self._create_receptacle_around_either(target_definition, confusor_definition)
+                if not receptacle_data:
+                    # TODO Recreate the target and/or confusor?
+                    raise exceptions.SceneException('cannot create enclosable receptacle around target OR confusor')
+                receptacle_definition, area_index, target_rotation, confusor_rotation = receptacle_data
+            # Create the receptacle template now at a location, and later it'll move to its location for each scene.
+            receptacle_template = util.instantiate_object(receptacle_definition, geometry.ORIGIN_LOCATION)
+
+        # Create the obstructor to use in either scene if needed.
+        if self._options.obstructor != BoolPairOption.NO_NO:
+            obstruct_vision = True # TODO MCS-262
+            obstructor_definition = self._goal_1.get_obstructor_rule(target_template, \
+                    obstruct_vision).choose_definition()
+            # Create the obstructor template now at a location, and later it'll move to its location for each scene.
+            obstructor_template = util.instantiate_object(obstructor_definition, geometry.ORIGIN_LOCATION)
+
+        # If an object is switched across the scenes (in the same position), use the larger object to generate the
+        # location to avoid any collisions (if positioned inside a receptacle, the receptacle must be larger).
+        larger_of_target_or_receptacle = receptacle_template if \
+                self._options.target_containerize != BoolPairOption.NO_NO else target_template
+        larger_of_confusor_or_receptacle = receptacle_template if \
+                self._options.confusor_containerize != BoolPairOption.NO_NO else confusor_template
+        larger_of_target_or_confusor = self._find_larger_object(larger_of_target_or_receptacle, \
+                larger_of_confusor_or_receptacle)
+        larger_of_target_or_obstructor = self._find_larger_object(larger_of_target_or_receptacle, \
+                obstructor_template)
+        larger_object = self._find_larger_object(larger_of_target_or_confusor, larger_of_target_or_obstructor)
+
+        target_location_1 = None
+        target_location_2 = None
+        confusor_location_1 = None
+        confusor_location_2 = None
+        obstructor_location_1 = None
+        obstructor_location_2 = None
+
+        is_target_relative_to_performer_start = \
+                (self._options.target_location == TargetLocationPairOption.FRONT_BACK or \
+                self._options.target_location == TargetLocationPairOption.FRONT_FRONT)
+        is_confusor_relative_to_performer_start = (confusor_template and self._options.confusor_location == \
+                ConfusorLocationPairOption.BACK_FRONT)
+
+        # If the target must be positioned relative to the performer_start, find locations both in front of and in back
+        # of the performer based on its position/rotation. Do this first because it may change the performer_start.
+        if is_target_relative_to_performer_start:
+            location_front, location_back = self._generate_front_and_back(goal, larger_object, \
+                    goal_1_target_rule_list[target_choice], True)
+            target_location_1 = location_front
+            target_location_2 = location_back if \
+                    self._options.target_location == TargetLocationPairOption.FRONT_BACK else location_front
+            if is_confusor_relative_to_performer_start:
+                confusor_location_1 = location_back
+                confusor_location_2 = location_front
+
+        else:
+            # If an object must be positioned relative to the performer_start, do it first.
+            if is_confusor_relative_to_performer_start:
+                location_front, location_back = self._generate_front_and_back(goal, larger_of_confusor_or_obstructor, \
+                        goal_1_target_rule_list[target_choice], True)
+                confusor_location_1 = location_back
+                confusor_location_2 = location_front
+
+            # If the target isn't positioned relative to the performer_start, it'll be positioned randomly.
+            target_location_1, target_location_2 = self._generate_random_location(goal, \
+                    larger_of_target_or_receptacle, goal_1_target_rule_list[target_choice], \
+                    goal_1_target_list, shared_bounds_list)
+
+            # Add more target location scene options here if needed in the future.
+
+        # The performer_start shouldn't be modified past here.
+        performer_start = self._goal_1.get_performer_start()
+
+        if obstructor_template:
+            # Must rotate obstructor relative to performer start rotation (save in definition to use later).
+            obstructor_definition['rotation']['y'] = obstructor_definition['rotation']['y'] + \
+                    performer_start['rotation']['y']
+            # Exchange the target with the obstructor, then position the target directly behind the obstructor.
+            target_location_1, obstructor_location_1 = self._generate_obstructor_location( \
+                    self._is_true_goal_1(self._options.obstructor), target_location_1, target_definition, \
+                    obstructor_template, performer_start)
+            target_location_2, obstructor_location_2 = self._generate_obstructor_location( \
+                    self._is_true_goal_2(self._options.obstructor), target_location_2, target_definition, \
+                    obstructor_template, performer_start)
+
+        # If the confusor isn't positioned relative to the performer_start, it's positioned relative to the target.
+        if confusor_template and not is_confusor_relative_to_performer_start:
+            is_target_location_same_in_both = \
+                    (self._options.target_location == TargetLocationPairOption.FRONT_FRONT or \
+                    self._options.target_location == TargetLocationPairOption.RANDOM)
+            confusor_location_1, confusor_location_2 = self._generate_confusor_location(confusor_definition, \
+                    target_definition, target_template, target_location_1, target_location_2, performer_start, \
+                    is_confusor_close_in_goal_1, is_confusor_close_in_goal_2, is_target_location_same_in_both)
+
+        # Finalize the position of the target and the confusor in both scenes (they may be inside a receptacle).
+        target_1, confusor_1, target_receptacle_1, confusor_receptacle_1 = self._finalize_target_confusor_position( \
+                target_definition, target_template, target_location_1, \
+                self._is_true_goal_1(self._options.target_containerize), confusor_definition, confusor_template, \
+                confusor_location_1, self._is_true_goal_1(self._options.confusor_containerize), \
+                receptacle_definition, receptacle_template, area_index, target_rotation, confusor_rotation, \
+                orientation, is_confusor_close_in_goal_1, shared_bounds_list)
+        target_2, confusor_2, target_receptacle_2, confusor_receptacle_2 = self._finalize_target_confusor_position( \
+                target_definition, target_template, target_location_2, \
+                self._is_true_goal_2(self._options.target_containerize), confusor_definition, confusor_template, \
+                confusor_location_2, self._is_true_goal_2(self._options.confusor_containerize), \
+                receptacle_definition, receptacle_template, area_index, target_rotation, confusor_rotation, \
+                orientation, is_confusor_close_in_goal_2, shared_bounds_list)
+
+        obstructor_1 = self._finalize_obstructor_position(obstructor_definition, obstructor_template, \
+                obstructor_location_1)
+        obstructor_2 = self._finalize_obstructor_position(obstructor_definition, obstructor_template, \
+                obstructor_location_2)
+
+        distractor_list_1 = [instance for instance in [target_receptacle_1, confusor_1, confusor_receptacle_1, \
+                obstructor_1] if instance]
+        distractor_list_2 = [instance for instance in [target_receptacle_2, confusor_2, confusor_receptacle_2, \
+                obstructor_2] if instance]
+
+        self._finalize_goal_1(target_1, distractor_list_1)
+        self._finalize_goal_2(target_choice, distractor_list_1, target_2, distractor_list_2)
+
+    def _create_receptacle_around_both(self, target_instance: Dict[str, Any], confusor_instance: Dict[str, Any]) -> \
+            Optional[Tuple[Dict[str, Any], int, float, float, containers.Orientation]]:
+        """Create and return a receptacle that encloses the target and confusor together. If impossible return None."""
+
+        # Find an enclosable receptacle that can hold both the target and the confusor together.
+        receptacle_definition_list = objects.get_enclosed_containers().copy()
+        random.shuffle(receptacle_definition_list)
+        for receptacle_definition in receptacle_definition_list:
+            valid_containment = containers.can_contain_both(receptacle_definition, target_instance, confusor_instance)
+            if valid_containment:
+                break
+        if valid_containment:
+            receptacle_definition, area_index, orientation, target_rotation, confusor_rotation = valid_containment
+            return receptacle_definition, area_index, target_rotation, confusor_rotation, orientation
+        return None
+
+    def _create_receptacle_around_either(self, target_instance: Dict[str, Any], confusor_instance: Dict[str, Any]) -> \
+            Optional[Tuple[Dict[str, Any], int, float, float]]:
+        """Create and return a receptacle that encloses the target or confusor alone. If impossible return None."""
+
+        # Find an enclosable receptacle that can hold either the target or the confusor individually.
+        valid_containment_list = containers.get_enclosable_containments((target_instance, confusor_instance))
+
+        if len(valid_containment_list) == 0:
+            return None
+
+        valid_containment = random.choice(valid_containment_list)
+        receptacle_definition, area_index, angles = valid_containment
+
+        # The angles list should have a length of 2 if the confusor_instance is not None
+        return receptacle_definition, area_index, angles[0], (angles[1] if len(angles) == 2 else None)
+
+    def _finalize_goal_1(self, target_1: Dict[str, Any], distractor_list: List[Dict[str, Any]]) -> None:
+        """Finalize the targets and other objects in the first goal."""
+
+        # Add the first version of each chosen object to the first goal.
+        goal_1_target_list = self._goal_1.get_target_list()
+        goal_1_target_list.append(target_1)
+        goal_1_distractor_list = self._goal_1.get_distractor_list()
+        for distractor in distractor_list_1:
+            goal_1_distractor_list.append(distractor)
+
+        # Generate the other random objects in the first goal, then copy them to the second goal.
+        self._goal_1.compute_objects(self._template['wallMaterial'], self._template['wallColors'])
+
+    def _finalize_goal_2(self, target_choice: int, distractor_list_1: List[Dict[str, Any]], target_2: Dict[str, Any], \
+            distractor_list_2: List[Dict[str, Any]]) -> None:
+        """Finalize the targets and other objects in the first goal."""
+
+        # Copy the random objects from the first goal to the second goal.
+        self._goal_2 = copy.deepcopy(self._goal_1)
+
+        # Exchange the first version of the target object with the second version to keep it at the same list index.
+        goal_2_target_list = self._goal_2.get_target_list()
+        goal_2_target_list[target_choice] = target_2
+
+        # Remove the first version of each distractor object from the copied list.
+        goal_2_distractor_list = self._goal_2.get_distractor_list()
+        for distractor in distractor_list_1:
+            goal_2_distractor_list.pop(0)
+
+        # Add the second version of each chosen object to the second goal.
+        for distractor in distractor_list_2:
+            goal_2_distractor_list.append(distractor)
+
+    def _finalize_target_confusor_position(self, target_definition: Dict[str, Any], target_template: Dict[str, Any], \
+            target_location: Dict[str, Any], containerize_target: bool, confusor_definition: Dict[str, Any], \
+            confusor_template: Dict[str, Any], confusor_location: Dict[str, Any], containerize_confusor: bool, \
+            receptacle_definition: Dict[str, Any], receptacle_template: Dict[str, Any], area_index: int, \
+            target_rotation: float, confusor_rotation: bool, orientation: containers.Orientation, \
+            is_confusor_close: bool, bounds_list: List[List[Dict[str, float]]]) -> \
+            Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+        """Finalize the position of the target and confusor, and return the target, confusor (if any), target
+        receptacle (if any), and confusor receptacle (if any). Will modify the given bounds_list."""
+
+        target_instance = copy.deepcopy(target_template)
+        confusor_instance = copy.deepcopy(confusor_template) if confusor_template else None
+        target_receptacle_instance = None
+        confusor_receptacle_instance = None
+
+        # If needed, position both the target and confusor together inside a receptacle.
+        if containerize_target and containerize_confusor and is_confusor_close:
+            target_receptacle_instance = copy.deepcopy(receptacle_template)
+            move_to_location(receptacle_definition, target_receptacle_instance, target_location)
+            containers.put_objects_in_container(target_instance, confusor_instance, \
+                    target_receptacle_instance, receptacle_definition, area_index, orientation, \
+                    target_rotation, confusor_rotation)
+            bounds_list.append(target_receptacle_instance['shows'][0]['bounding_box'])
+
+        else:
+            if containerize_target:
+                # Use the target location for its receptacle, then position the target inside its receptacle.
+                target_receptacle_instance = copy.deepcopy(receptacle_template)
+                move_to_location(receptacle_definition, receptacle_instance, target_location)
+                containers.put_object_in_container(target_instance, target_receptacle_instance, \
+                        receptacle_definition, area_index, target_rotation)
+                bounds_list.append(target_receptacle_instance['shows'][0]['bounding_box'])
+            else:
+                move_to_location(target_definition, target_instance, target_location)
+                bounds_list.append(target_instance['shows'][0]['bounding_box'])
+            if confuser_instance:
+                if containerize_confusor:
+                    # Use the confusor location for its receptacle, then position the confusor inside its receptacle.
+                    confusor_receptacle_instance = copy.deepcopy(receptacle_template)
+                    move_to_location(receptacle_definition, receptacle_instance, confusor_location)
+                    containers.put_object_in_container(confusor_instance, confusor_receptacle_instance, \
+                            receptacle_definition, area_index, confusor_rotation)
+                    bounds_list.append(confusor_receptacle_instance['shows'][0]['bounding_box'])
+                else:
+                    move_to_location(confusor_definition, confusor_instance, confusor_location)
+                    bounds_list.append(confusor_instance['shows'][0]['bounding_box'])
+
+        return target_instance, confusor_instance, target_receptacle_instance, confusor_receptacle_instance
+
+    def _finalize_obstructor_position(self, obstructor_definition: Dict[str, Any], \
+            obstructor_template: Dict[str, Any], obstructor_location: Dict[str, Any]) -> Dict[str, Any]:
+        """Finalize the position and rotation of the obstructor and return the obstructor (if any)."""
+
+        # Note from Chris Long: Rotate obstructor to "face" the performer. There's a chance that this rotation could
+        # cause the obstructor to intersect with the wall of the room, because it's different from the rotation
+        # returned by get_location_in_front_of_performer (which does check for that case). But it seems unlikely.
+        obstructor_instance = copy.deepcopy(obstructor_template) if obstructor_template else None
+        if obstructor_location:
+            # The obstructor must have a very specific Y rotation that isn't random.
+            obstructor_location['rotation']['y'] = obstructor_definition['rotation']['y']
+            move_to_location(obstructor_definition, obstructor_instance, obstructor_location)
+        return obstructor_instance
+
+    def _find_larger_object(self, object_one: Dict[str, Any], object_two: Dict[str, Any]) -> Dict[str, Any]:
+        """Return the larger of the two given objects."""
+        if not object_one and not object_two:
+            return None
+        if not object_one:
+            return object_two
+        if not object_two:
+            return object_one
+        # TODO Handle case if one object has larger X and other object has larger Z
+        return object_one if (object_one['dimensions']['x'] > object_two['dimensions']['x'] or \
+                object_one['dimensions']['z'] > object_two['dimensions']['z']) else object_two
+
+    def _generate_confusor_location(self, confusor_definition: Dict[str, Any], target_definition: Dict[str, Any], \
+            target_template: Dict[str, Any], target_location_1: Dict[str, float], 
+            target_location_2: Dict[str, float], performer_start: Dict[str, Dict[str, float]], \
+            is_confusor_close_in_goal_1: bool, is_confusor_close_in_goal_2: bool, \
+            is_target_location_same_in_both: bool) -> Tuple[Dict[str, float], Dict[str, float]]:
+        """Generate and return the location for the confusor in both scenes positioned relative to the target."""
+
+        # Copy the target_template to create temporary instances of the target in both its probable locations.
+        target_instance_1 = copy.deepcopy(target_template)
+        target_instance_2 = copy.deepcopy(target_template)
+        move_to_location(target_definition, target_instance_1, target_location_1)
+        move_to_location(target_definition, target_instance_2, target_location_2)
+
+        # If the target location is the same in both scenes, just generate the confusor location once.
+        if is_confusor_close_in_goal_1 and is_confusor_close_in_goal_2 and is_target_location_same_in_both:
+            confusor_location = self._generate_location_close_to_object(confusor_definition, target_instance_1, \
+                    performer_start)
+            return confusor_location, confusor_location
+
+        confusor_location_1 = None
+        confusor_location_2 = None
+
+        if is_confusor_close_in_goal_1:
+            confusor_location_1 = self._generate_location_close_to_object(confusor_definition, target_instance_1, \
+                    performer_start)
+        else:
+            confusor_location_1 = self._generate_location_far_from_object(confusor_definition, target_location_1, \
+                    performer_start)
+
+        if is_confusor_close_in_goal_2:
+            confusor_location_2 = self._generate_location_close_to_object(confusor_definition, target_instance_2, \
+                    performer_start)
+        else:
+            confusor_location_2 = self._generate_location_far_from_object(confusor_definition, target_location_2, \
+                    performer_start)
+
+        # Add more confusor location scene options here if needed in the future.
+
+        return confusor_location_1, confusor_location_2
+
+    def _generate_front_and_back(self, goal: InteractionGoal, object_definition: Dict[str, Any], \
+            object_rule: ObjectRule, generate_back: bool) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Generate a location both in front of and in back of the performer_start. Will modify the performer_start
+        in the given goal if needed to generate the two locations. Return the front and back locations."""
+
+        performer_start = goal.get_performer_start()
+        location_front = None
+        location_back = None
+
+        for _ in range(util.MAX_TRIES):
+            # TODO Use existing target bounds?
+            location_front = self._identify_front(object_definition, object_rule, performer_start)
+            if generate_back:
+                location_back = self._identify_back(object_definition, object_rule, performer_start)
+                if location_front and location_back:
+                    break
+            elif location_front:
+                break
+            performer_start = goal.reset_performer_start()
+
+        if not generate_back and not location_front:
+            raise exceptions.SceneException('cannot position performer and objects in pair (front)')
+
+        if generate_back and (not location_front or not location_back):
+            raise exceptions.SceneException('cannot position performer and objects in pair (front and back)')
+
+        return location_front, location_back
+
+    def _generate_location_close_to_object(self, object_definition: Dict[str, Any], target_instance: Dict[str, Any], \
+            performer_start: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+        """Generate and return a new location close to the given target_instance."""
+        # TODO Use existing target bounds?
+        location_close = geometry.get_adjacent_location(object_definition, target_instance, \
+                performer_start['position'])
+        if not location_close:
+            # TODO Reposition the target?
+            raise exceptions.SceneException('cannot position object close to target')
+        return location_close
+
+    def _generate_location_far_from_object(self, object_definition: Dict[str, Any], target_location: Dict[str, float], \
+            performer_start: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+        """Generate and return a new location far away the given target location."""
+        for _ in range(util.MAX_TRIES):
+            # TODO Use existing target bounds?
+            location_far = geometry.calc_obj_pos(performer_start['position'], [], object_definition)
+            if not geometry.are_adjacent(base_location, location_far):
+                break
+        if not location_far:
+            # TODO Reposition the target?
+            raise exceptions.SceneException('cannot position object far from target')
+        return location_far
+
+    def _generate_obstructor_location(self, show_obstructor: bool, original_target_location: Dict[str, float], \
+            target_definition: Dict[str, Any], obstructor_template: Dict[str, Any], \
+            performer_start: Dict[str, Dict[str, float]]) -> Tuple[Dict[str, float], Dict[str, float]]:
+        """If needed, move the obstructor's position to the target's position, then move the target directly behind the
+        obstructor. Return the target and obstructor locations."""
+
+        if show_obstructor:
+            obstructor_location = original_target_location
+            target_location = geometry.get_adjacent_location_on_side(target_definition, obstructor_template, \
+                    performer_start['position'], geometry.Side.BACK)
+            if not target_location:
+                # TODO Reposition the obstructor?
+                raise exceptions.SceneException('cannot position target directly behind obstructor')
+            return target_location, obstructor_location
+
+        return original_target_location, None
+
+    def _generate_random_location(self, goal: InteractionGoal, object_definition: Dict[str, Any], \
+            object_rule: ObjectRule, target_list: List[Dict[str, Any]], \
+            bounds_list: List[List[Dict[str, float]]]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Generate a random location and return it twice."""
+
+        for _ in range(util.MAX_TRIES):
+            object_location, bounds = object_rule.choose_location(object_definition, goal.get_performer_start(), \
+                    bounds_list)
+            if object_rule.validate_location(object_location, target_list, goal.get_performer_start()):
+                break
+        if not object_location:
+            raise exceptions.SceneException('cannot position objects in pair (random)')
+        return object_location, object_location
+
+    def _identify_front(self, object_definition: Dict[str, Any], object_rule: ObjectRule, \
+            performer_start: Dict[str, float]) -> Dict[str, Any]:
+        """Find and return a location in front of the given performer_start."""
+
+        for _ in range(util.MAX_TRIES):
+            location_front = geometry.get_location_in_front_of_performer(performer_start, object_definition)
+            if location_front and object_rule.validate_location(object_location, []):
+                break
+        return location_front
+
+    def _identify_back(self, object_definition: Dict[str, Any], object_rule: ObjectRule, \
+            performer_start: Dict[str, float]) -> Dict[str, Any]:
+        """Find and return a location in back of the given performer_start."""
+
+        for _ in range(util.MAX_TRIES):
+            location_back = geometry.get_location_in_back_of_performer(performer_start, object_definition)
+            if location_back and object_rule.validate_location(object_location, []):
+                break
+        return location_back
+
+    def _is_true_goal_1(self, bool_pair: BoolPairOption):
+        """Return if the given scene options bool_pair is true in the first goal."""
+        return bool_pair == BoolPairOption.YES_NO or bool_pair == BoolPairOption.YES_YES
+
+    def _is_true_goal_2(self, bool_pair: BoolPairOption):
+        """Return if the given scene options bool_pair is true in the second goal."""
+        return bool_pair == BoolPairOption.NO_YES or bool_pair == BoolPairOption.YES_YES
 
 
 class ImmediatelyVisiblePair(InteractionPair):
@@ -134,55 +573,10 @@ class ImmediatelyVisiblePair(InteractionPair):
     """
 
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(ImmediatelyVisiblePair, self).__init__(template, find_path)
-        logging.debug(f'performerStart={self._performer_start}')
-
-    def _get_locations(self, target_def: Dict[str, Any]) -> \
-            Optional[Tuple[Dict[str, Any], Dict[str, Any]]]:
-        # place target object in scene 1 right in front of the performer
-        for _ in range(util.MAX_TRIES):
-            in_front_location = geometry.\
-                get_location_in_front_of_performer(self._performer_start, target_def)
-            if in_front_location is not None:
-                break
-        if in_front_location is None:
-            return None
-
-        # place target object in scene 2 behind the performer
-        for _ in range(util.MAX_TRIES):
-            behind_location = geometry.\
-                get_location_behind_performer(self._performer_start, target_def)
-            if behind_location is not None:
-                break
-        if behind_location is None:
-            return None
-
-        return in_front_location, behind_location
-
-    def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        # choose target object
-        target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-        for _ in range(util.MAX_TRIES):
-            locations = self._get_locations(target_def)
-            if locations is not None:
-                break
-            self._performer_start = None
-            self._compute_performer_start()
-        if locations is None:
-            raise exceptions.SceneException('could not place performer with objects in front and behind')
-        in_front_location, behind_location = locations
-
-        scene1 = self._get_empty_scene()
-        target = util.instantiate_object(target_def, in_front_location)
-        scene1['objects'] = [target]
-        add_objects(target, self._performer_start['position'], scene1)
-
-        scene2 = self._get_empty_scene()
-        target2 = copy.deepcopy(target)
-        move_to_location(target_def, target2, behind_location)
-        scene2['objects'] = [target2]
-        add_objects(target, self._performer_start['position'], scene2)
-        return scene1, scene2
+        containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
+                BoolPairOption.NO_NO
+        super(ImmediatelyVisiblePair, self).__init__(template, find_path, options = SceneOptions( \
+                target_containerize = containerize, target_location = TargetLocationPairOption.FRONT_BACK))
 
 
 class ImmediatelyVisibleSimilarPair(InteractionPair):
@@ -196,94 +590,12 @@ class ImmediatelyVisibleSimilarPair(InteractionPair):
     """
 
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(ImmediatelyVisibleSimilarPair, self).__init__(template, find_path)
-        logging.debug(f'performerStart={self._performer_start}')
-
-    def _contained_in_front_and_back(self, container_def: Dict[str, Any],
-                                     front_obj: Dict[str, Any],
-                                     back_obj: Dict[str, Any]) -> \
-                                     Optional[Tuple[Dict[str, Any], Dict[str, Any]]]:
-        in_front_location = geometry. \
-            get_location_in_front_of_performer(self._performer_start, container_def)
-        behind_location = geometry. \
-            get_location_behind_performer(self._performer_start, container_def)
-        front_obj_container = util.instantiate_object(container_def, in_front_location)
-        index, angles = containers.how_can_contain(container_def, front_obj)
-        if index is None:
-            return None
-        containers.put_object_in_container(front_obj, front_obj_container, container_def, index, angles[0])
-        back_obj_container = util.instantiate_object(container_def, behind_location)
-        index, angles = containers.how_can_contain(container_def, back_obj)
-        if index is None:
-            return None
-        containers.put_object_in_container(back_obj, back_obj_container, container_def, index, angles[0])
-
-        return front_obj_container, back_obj_container
-
-    def _move_in_front_and_back(self, front_obj_def: Dict[str, Any],
-                                front_obj: Dict[str, Any],
-                                back_obj_def: Dict[str, Any],
-                                back_obj: Dict[str, Any]) -> bool:
-        in_front_location = geometry. \
-            get_location_in_front_of_performer(self._performer_start, front_obj_def)
-        behind_location = geometry. \
-            get_location_behind_performer(self._performer_start, back_obj_def)
-        if in_front_location is None or behind_location is None:
-            return False
-        move_to_location(front_obj_def, front_obj, in_front_location)
-        move_to_location(back_obj_def, back_obj, behind_location)
-        return True
-
-    def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        scene1 = self._get_empty_scene()
-        scene2 = self._get_empty_scene()
-        is_contained = random.random() <= util.TARGET_CONTAINED_CHANCE
-        done = False
-        for _ in range(util.MAX_TRIES):
-            target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-            similar_def = util.finalize_object_definition(util.get_similar_definition(target_def))
-            if is_contained:
-                target = util.instantiate_object(target_def, geometry.ORIGIN_LOCATION)
-                similar = util.instantiate_object(similar_def, geometry.ORIGIN_LOCATION)
-                container_defs = containers.get_enclosable_container_defs((target, similar))
-                if len(container_defs) == 0:
-                    is_contained = False
-                else:
-                    container_def = util.finalize_object_definition(random.choice(container_defs))
-                    maybe_containers = self._contained_in_front_and_back(container_def,
-                                                                         target, similar)
-                    if maybe_containers is None:
-                        continue
-                    target_container, similar_container = maybe_containers
-                    scene1['objects'] = [target, similar, target_container, similar_container]
-
-                    target2 = copy.deepcopy(target)
-                    similar2 = copy.deepcopy(similar)
-                    maybe_containers2 = self._contained_in_front_and_back(container_def,
-                                                                          similar2, target2)
-                    if maybe_containers2 is None:
-                        continue
-                    similar_container2, target_container2 = maybe_containers2
-                    scene2['objects'] = [target2, similar2, target_container2, similar_container2]
-                    done = True
-                    break
-            # not contained
-            target = util.instantiate_object(target_def, geometry.ORIGIN_LOCATION)
-            similar = util.instantiate_object(similar_def, geometry.ORIGIN_LOCATION)
-            if not self._move_in_front_and_back(target_def, target, similar_def, similar):
-                continue
-            scene1['objects'] = [target, similar]
-
-            target2 = copy.deepcopy(target)
-            similar2 = copy.deepcopy(similar)
-            if not self._move_in_front_and_back(similar_def, similar2, target_def, target2):
-                continue
-            scene2['objects'] = [target2, similar2]
-            done = True
-            break
-        if not done:
-            raise exceptions.SceneException('could not place target in front and similar behind')
-        return scene1, scene2
+        containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
+                BoolPairOption.NO_NO
+        super(ImmediatelyVisibleSimilarPair, self).__init__(template, find_path, options = SceneOptions( \
+                target_containerize = containerize, target_location = TargetLocationPairOption.FRONT_BACK, \
+                confusor = BoolPairOption.YES_YES, confusor_containerize = containerize, \
+                confusor_location = ConfusorLocationPairOption.BACK_FRONT))
 
 
 class HiddenBehindPair(InteractionPair):
@@ -294,60 +606,12 @@ class HiddenBehindPair(InteractionPair):
     """
 
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(HiddenBehindPair, self).__init__(template, find_path)
+        containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
+                BoolPairOption.NO_NO
+        super(HiddenBehindPair, self).__init__(template, find_path, options = SceneOptions( \
+                target_containerize = containerize, target_location = TargetLocationPairOption.FRONT_FRONT, \
+                obstructor = BoolPairOption.NO_YES))
 
-    def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        for _ in range(util.MAX_TRIES):
-            target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-            blocker_defs = geometry.get_wider_and_taller_defs(target_def)
-            if blocker_defs is not None:
-                break
-        if blocker_defs is None:
-            raise exceptions.SceneException('could not get a target and blocker')
-        blocker_def, blocker_angle = random.choice(blocker_defs)
-        blocker_def = util.finalize_object_definition(blocker_def)
-
-        scene1 = self._get_empty_scene()
-        # place target object in scene 1 right in front of the performer
-        for _ in range(util.MAX_TRIES):
-            in_front_location = geometry.get_location_in_front_of_performer(self._performer_start, target_def)
-            if in_front_location is not None:
-                break
-        if in_front_location is None:
-            raise exceptions.SceneException('could not place target in front of performer')
-        target = util.instantiate_object(target_def, in_front_location)
-        scene1['objects'] = [target]
-
-        # place blocker right in front of performer in scene 2
-        for _ in range(util.MAX_TRIES):
-            in_front_location = geometry.get_location_in_front_of_performer(self._performer_start, blocker_def,
-                                                                            lambda: blocker_angle)
-            if in_front_location is not None:
-                break
-        if in_front_location is None:
-            raise exceptions.SceneException('could not place blocker in front of performer')
-        # Rotate blocker to be "facing" the performer (accounting for
-        # blocker_angle). There is a chance that this rotation could
-        # cause the blocker to intersect the wall of the room, because
-        # it's different from the rotation returned by
-        # get_location_in_front_of_performer (which does check for
-        # that). But it seems pretty unlikely.
-        angle = self._performer_start['rotation']['y']
-        in_front_location['rotation']['y'] = angle + blocker_angle
-        blocker = util.instantiate_object(blocker_def, in_front_location)
-        occluded_location = geometry.get_adjacent_location_on_side(target_def,
-                                                                   blocker,
-                                                                   self._performer_start['position'],
-                                                                   geometry.Side.BACK)
-        if occluded_location is None:
-            raise exceptions.SceneException('could not place target behind blocker')
-        target2 = copy.deepcopy(target)
-        move_to_location(target_def, target2, occluded_location)
-        scene2 = self._get_empty_scene()
-        scene2['objects'] = [target2, blocker]
-
-        return scene1, scene2
-    
 
 class OneEnclosedPair(InteractionPair):
     """(7) Like pair (6), but, for each pair, randomly choose either the
@@ -356,73 +620,12 @@ class OneEnclosedPair(InteractionPair):
     container for neither scene. See MCS-234.
     """
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(OneEnclosedPair, self).__init__(template, find_path)
-
-    def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        scene1 = self._get_empty_scene()
-        scene2 = self._get_empty_scene()
-        for _ in range(util.MAX_TRIES):
-            target_enclosed = random.choice((True, False))
-            target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-            target_location = geometry.\
-                get_location_in_front_of_performer(self._performer_start, target_def)
-            if target_location is None:
-                continue
-            target = util.instantiate_object(target_def, target_location)
-            similar_def = util.get_similar_definition(target)
-            if similar_def is None:
-                continue
-            similar_def = util.finalize_object_definition(similar_def)
-            similar_location = geometry.\
-                get_location_behind_performer(self._performer_start, similar_def)
-            if similar_location is None:
-                continue
-            similar = util.instantiate_object(similar_def, similar_location)
-            if target_enclosed:
-                container_defs = containers.get_enclosable_container_defs((target,))
-                if len(container_defs) == 0:
-                    continue
-                container_def = util.finalize_object_definition(random.choice(container_defs))
-                container_location = geometry.\
-                    get_location_in_front_of_performer(self._performer_start, container_def)
-                containee = target
-            else:
-                container_defs = containers.get_enclosable_container_defs((similar,))
-                if len(container_defs) == 0:
-                    continue
-                container_def = util.finalize_object_definition(random.choice(container_defs))
-                container_location = geometry.\
-                    get_location_behind_performer(self._performer_start, container_def)
-                containee = similar
-            container = util.instantiate_object(container_def, container_location)
-            area_index, rotations = containers.how_can_contain(container_def, containee)
-            containers.put_object_in_container(containee, container, container_def, area_index, rotations[0])
-            scene1['objects'] = [target, similar, container]
-
-            target2 = copy.deepcopy(target)
-            similar2 = copy.deepcopy(similar)
-            target2_location = geometry.\
-                get_location_behind_performer(self._performer_start, target_def)
-            similar2_location = geometry.\
-                get_location_in_front_of_performer(self._performer_start, target_def)
-            if target2_location is None or similar2_location is None:
-                continue
-            if target_enclosed:
-                container_location2 = geometry.\
-                    get_location_behind_performer(self._performer_start, container_def)
-                containee2 = target2
-                move_to_location(similar_def, similar2, similar2_location)
-            else:
-                container_location2 = geometry.\
-                    get_location_in_front_of_performer(self._performer_start, container_def)
-                containee2 = similar2
-                move_to_location(similar_def, target2, target2_location)
-            container2 = util.instantiate_object(container_def, container_location2)
-            area_index2, rotations2 = containers.how_can_contain(container_def, containee2)
-            containers.put_object_in_container(containee2, container2, container_def, area_index2, rotations2[0])
-            scene2['objects'] = [target2, similar2, container2]
-            break
-        return scene1, scene2
+        containerize_confusor = BoolPairOption.YES_YES if containerize_target == BoolPairOption.NO_NO else \
+                BoolPairOption.NO_NO
+        super(OneEnclosedPair, self).__init__(template, find_path, options = SceneOptions( \
+                target_containerize = containerize_target, target_location = TargetLocationPairOption.FRONT_BACK, \
+                confusor = BoolPairOption.YES_YES, confusor_containerize = (not containerize_target), \
+                confusor_location = ConfusorLocationPairOption.BACK_FRONT))
 
 
 class SimilarAdjacentPair(InteractionPair):
@@ -435,90 +638,26 @@ class SimilarAdjacentPair(InteractionPair):
     """
 
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(SimilarAdjacentPair, self).__init__(template, find_path)
-
-    def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-        target_location = geometry.calc_obj_pos(self._performer_start['position'], [], target_def)
-        target = util.instantiate_object(target_def, target_location)
-        similar_def = util.finalize_object_definition(util.get_similar_definition(target))
-        container = None
-        if random.random() <= util.TARGET_CONTAINED_CHANCE:
-            container_defs = objects.get_enclosed_containers().copy()
-            random.shuffle(container_defs)
-            for container_def in container_defs:
-                placement = containers.can_contain_both(container_def, target_def, similar_def)
-                if placement is not None:
-                    break
-            if placement is not None:
-                container_def, index, orientation, rot_a, rot_b = placement
-                container_def = util.finalize_object_definition(container_def)
-                container_location = geometry. \
-                    calc_obj_pos(self._performer_start['position'], [], container_def)
-                container = util.instantiate_object(container_def, container_location)
-                containers.put_object_in_container(target, container, container_def, index, rot_a)
-        scene1 = self._get_empty_scene()
-        scene1['objects'] = [target] if container is None else [target, container]
-
-        similar_location = geometry. \
-            get_adjacent_location(similar_def, target,
-                                  self._performer_start['position'])
-        if similar_location is None:
-            raise exceptions.SceneException('could not place similar object adjacent to target')
-        similar = util.instantiate_object(similar_def, similar_location)
-        scene2 = self._get_empty_scene()
-        if container is None:
-            scene2['objects'] = [target, similar]
-        else:
-            target2 = copy.deepcopy(target)
-            containers.put_objects_in_container(target2, similar, container,
-                                                container_def, index, orientation,
-                                                rot_a, rot_b)
-            scene2['objects'] = [target2, similar, container]
-
-        return scene1, scene2
+        containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
+                BoolPairOption.NO_NO
+        super(SimilarAdjacentPair, self).__init__(template, find_path, options = SceneOptions( \
+                target_containerize = containerize, confusor = BoolPairOption.NO_YES, \
+                confusor_containerize = containerize, confusor_location = ConfusorLocationPairOption.NONE_CLOSE))
 
 
 class SimilarFarPair(InteractionPair):
-    def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(SimilarFarPair, self).__init__(template, find_path)
+    """(4A) The Target Object is positioned normally, without a Similar Object
+    in the scene, OR (4B) with a Similar Object in the scene, but far away
+    from it.  For each pair, the objects may or may not be inside identical
+    containers, but only if the container is big enough to hold both
+    individually; otherwise, no container will be used in that pair."""
 
-    def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-        target = util.instantiate_object(target_def, geometry.ORIGIN_LOCATION)
-        similar_def = util.finalize_object_definition(util.get_similar_definition(target))
-        scene1 = self._get_empty_scene()
-        scene2 = self._get_empty_scene()
-        container = None
-        performer_position = self._performer_start['position']
-        if random.random() <= util.TARGET_CONTAINED_CHANCE:
-            container_defs = containers.get_enclosable_container_defs((target_def, similar_def))
-            if len(container_defs) > 0:
-                container_def = util.finalize_object_definition(random.choice(container_defs))
-                container_location = geometry. \
-                    calc_obj_pos(performer_position, [], container_def)
-                container = util.instantiate_object(container_def, container_location)
-                containers.put_object_in_container(target, container, container_def, 0)
-                scene1['objects'] = [target, container]
-                similar = util.instantiate_object(similar_def, geometry.ORIGIN_LOCATION)
-                container2 = instantiate_away_from(container_def, performer_position, container)
-                # Should be impossible for this to fail with normal
-                # objects in our room, but just in case...
-                if container2 is None:
-                    raise exceptions.SceneException('could not place second container away from first')
-                containers.put_object_in_container(similar, container2, container_def, 0)
-                scene2['objects'] = [target, similar, container, container2]
-        if container is None:
-            target_location = geometry.calc_obj_pos(performer_position, [], target_def)
-            move_to_location(target_def, target, target_location)
-            similar = instantiate_away_from(similar_def, performer_position, target)
-            # Should be impossible for this to fail with normal
-            # objects in our room, but just in case...
-            if similar is None:
-                raise exceptions.SceneException('could not place similar object away from target')
-            scene1['objects'] = [target]
-            scene2['objects'] = [target, similar]
-        return scene1, scene2
+    def __init__(self, template: Dict[str, Any], find_path: bool):
+        containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
+                BoolPairOption.NO_NO
+        super(SimilarFarPair, self).__init__(template, find_path, options = SceneOptions( \
+                target_containerize = containerize, confusor = BoolPairOption.NO_YES, \
+                confusor_containerize = containerize, confusor_location = ConfusorLocationPairOption.NONE_FAR))
 
 
 class SimilarAdjacentFarPair(InteractionPair):
@@ -530,60 +669,11 @@ class SimilarAdjacentFarPair(InteractionPair):
     """
 
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(SimilarAdjacentFarPair, self).__init__(template, find_path)
-
-    def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-        target = util.instantiate_object(target_def, geometry.ORIGIN_LOCATION)
-        similar_def = util.finalize_object_definition(util.get_similar_definition(target))
-        scene1 = self._get_empty_scene()
-        scene2 = self._get_empty_scene()
-        placement = None
-        performer_position = self._performer_start['position']
-        if random.random() <= util.TARGET_CONTAINED_CHANCE:
-            container_defs = objects.get_enclosed_containers().copy()
-            random.shuffle(container_defs)
-            for container_def in container_defs:
-                container_def = util.finalize_object_definition(container_def)
-                placement = containers.can_contain_both(container_def, target_def, similar_def)
-                if placement is not None:
-                    break
-            if placement is not None:
-                container_def, index, orientation, rot_a, rot_b = placement
-                similar = util.instantiate_object(similar_def, geometry.ORIGIN_LOCATION)
-                container_location = geometry. \
-                    calc_obj_pos(performer_position, [], container_def)
-                container = util.instantiate_object(container_def, container_location)
-                containers.put_objects_in_container(target, similar, container,
-                                                    container_def, index, orientation,
-                                                    rot_a, rot_b)
-                scene1['objects'] = [target, similar, container]
-
-                # scene 2
-                target_container_loc = geometry.calc_obj_pos(performer_position, [], container_def)
-                target_container = util.instantiate_object(container_def, target_container_loc)
-                target2 = util.instantiate_object(target_def, geometry.ORIGIN_LOCATION)
-                containers.put_object_in_container(target2, target_container, container_def, index, rot_a)
-
-                similar_container = instantiate_away_from(container_def, performer_position, target_container)
-                similar2 = util.instantiate_object(target_def, geometry.ORIGIN_LOCATION)
-                containers.put_object_in_container(similar2, similar_container, container_def, index, rot_b)
-                scene2['objects'] = [target2, similar2, target_container, similar_container]
-        if placement is None:
-            # Decided not to use a container or couldn't find one that
-            # could hold the target & similar objects.
-            similar_location = geometry.get_adjacent_location(similar_def, target,
-                                                              performer_position)
-            similar = util.instantiate_object(similar_def, similar_location)
-            scene1['objects'] = [target, similar]
-
-            # scene 2
-            target2_location = geometry.calc_obj_pos(performer_position, [], target_def)
-            target2 = util.instantiate_object(target_def, target2_location)
-            similar2 = instantiate_away_from(similar_def, performer_position, target2)
-            scene2['objects'] = [target2, similar2]
-
-        return scene1, scene2
+        containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
+                BoolPairOption.NO_NO
+        super(SimilarAdjacentFarPair, self).__init__(template, find_path, options = SceneOptions( \
+                target_containerize = containerize, confusor = BoolPairOption.YES_YES, \
+                confusor_containerize = containerize, confusor_location = ConfusorLocationPairOption.CLOSE_FAR))
 
 
 class SimilarAdjacentContainedPair(InteractionPair):
@@ -594,50 +684,10 @@ class SimilarAdjacentContainedPair(InteractionPair):
     """
 
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(SimilarAdjacentContainedPair, self).__init__(template, find_path)
-
-    def get_scenes(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        for _ in range(util.MAX_TRIES):
-            target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-            target_location = geometry.calc_obj_pos(self._performer_start['position'], [], target_def)
-            target = util.instantiate_object(target_def, target_location)
-            similar_def = util.get_similar_definition(target)
-            if similar_def is None:
-                continue
-            similar_def = util.finalize_object_definition(similar_def)
-            similar = util.instantiate_object(similar_def, geometry.ORIGIN_LOCATION)
-            # find a container big enough for both of them
-            valid_containments = containers.get_enclosable_containments((target, similar))
-            if len(valid_containments) > 0:
-                break
-        if len(valid_containments) == 0:
-            raise exceptions.SceneException(f'failed to find target and/or similar object that will fit in something')
-        containment = random.choice(valid_containments)
-        container_def, area_index, angles = containment
-        container_def = util.finalize_object_definition(container_def)
-        container_location = geometry.get_adjacent_location(container_def,
-                                                            target,
-                                                            self._performer_start['position'])
-        container = util.instantiate_object(container_def, container_location)
-
-        containers.put_object_in_container(similar, container, container_def, area_index, angles[1])
-
-        scene1 = self._get_empty_scene()
-        scene1['objects'] = [target, similar, container]
-
-        target2 = copy.deepcopy(target)
-        container2 = copy.deepcopy(container)
-        containers.put_object_in_container(target2, container2, container_def, area_index, angles[0])
-        similar2 = copy.deepcopy(similar)
-        del similar2['locationParent']
-        similar2_location = geometry.get_adjacent_location(similar_def,
-                                                           container2,
-                                                           self._performer_start['position'])
-        move_to_location(similar_def, similar2, similar2_location)
-        scene2 = self._get_empty_scene()
-        scene2['objects'] = [target2, similar2, container2]
-
-        return scene1, scene2
+        super(SimilarAdjacentContainedPair, self).__init__(template, find_path, options = SceneOptions( \
+                target_containerize = BoolPairOption.NO_YES, confusor = BoolPairOption.YES_YES, \
+                confusor_containerize = BoolPairOption.YES_NO, \
+                confusor_location = ConfusorLocationPairOption.CLOSE_CLOSE))
 
 
 _INTERACTION_PAIR_CLASSES = [

--- a/scene_generator/pairs.py
+++ b/scene_generator/pairs.py
@@ -85,10 +85,15 @@ class InteractionPair():
         self._scene_1 = copy.deepcopy(template)
         self._scene_2 = copy.deepcopy(template)
         self._options = options
-        self._goal_1 = goals.choose_goal('interaction')
-        self._initialize_each_goal()
-        self._goal_1.update_body(self._scene_1, find_path)
-        self._goal_2.update_body(self._scene_2, find_path)
+        while True:
+            try:
+                self._goal_1 = goals.choose_goal('interaction')
+                self._initialize_each_goal()
+                self._goal_1.update_body(self._scene_1, find_path)
+                self._goal_2.update_body(self._scene_2, find_path)
+                break
+            except exceptions.SceneException as e:
+                logging.error(e)
 
     def get_name(self) -> str:
         """Return the name of this pair."""
@@ -314,16 +319,16 @@ class InteractionPair():
         obstructor_2 = self._finalize_obstructor_position(self._is_true_goal_2(self._options.obstructor), \
                 obstructor_definition, obstructor_template, obstructor_location_2)
 
-        print('target_1 ' + target_1['id'] + ' ' + target_1['type'])
-        print('target_2 ' + target_2['id'] + ' ' + target_2['type'])
-        print('target_receptacle_1 ' + ((target_receptacle_1['id'] + ' ' + target_receptacle_1['type']) if target_receptacle_1 else 'None'))
-        print('target_receptacle_2 ' + ((target_receptacle_2['id'] + ' ' + target_receptacle_2['type']) if target_receptacle_2 else 'None'))
-        print('confusor_1 ' + ((confusor_1['id'] + ' ' + confusor_1['type']) if confusor_1 else 'None'))
-        print('confusor_2 ' + ((confusor_2['id'] + ' ' + confusor_2['type']) if confusor_2 else 'None'))
-        print('confusor_receptacle_1 ' + ((confusor_receptacle_1['id'] + ' ' + confusor_receptacle_1['type']) if confusor_receptacle_1 else 'None'))
-        print('confusor_receptacle_2 ' + ((confusor_receptacle_2['id'] + ' ' + confusor_receptacle_2['type']) if confusor_receptacle_2 else 'None'))
-        print('obstructor_1 ' + ((obstructor_1['id'] + ' ' + obstructor_1['type']) if obstructor_1 else 'None'))
-        print('obstructor_2 ' + ((obstructor_2['id'] + ' ' + obstructor_2['type']) if obstructor_2 else 'None'))
+        logging.debug('target_1 ' + target_1['id'] + ' ' + target_1['type'])
+        logging.debug('target_2 ' + target_2['id'] + ' ' + target_2['type'])
+        logging.debug('target_receptacle_1 ' + ((target_receptacle_1['id'] + ' ' + target_receptacle_1['type']) if target_receptacle_1 else 'None'))
+        logging.debug('target_receptacle_2 ' + ((target_receptacle_2['id'] + ' ' + target_receptacle_2['type']) if target_receptacle_2 else 'None'))
+        logging.debug('confusor_1 ' + ((confusor_1['id'] + ' ' + confusor_1['type']) if confusor_1 else 'None'))
+        logging.debug('confusor_2 ' + ((confusor_2['id'] + ' ' + confusor_2['type']) if confusor_2 else 'None'))
+        logging.debug('confusor_receptacle_1 ' + ((confusor_receptacle_1['id'] + ' ' + confusor_receptacle_1['type']) if confusor_receptacle_1 else 'None'))
+        logging.debug('confusor_receptacle_2 ' + ((confusor_receptacle_2['id'] + ' ' + confusor_receptacle_2['type']) if confusor_receptacle_2 else 'None'))
+        logging.debug('obstructor_1 ' + ((obstructor_1['id'] + ' ' + obstructor_1['type']) if obstructor_1 else 'None'))
+        logging.debug('obstructor_2 ' + ((obstructor_2['id'] + ' ' + obstructor_2['type']) if obstructor_2 else 'None'))
 
         distractor_list_1 = [instance for instance in [confusor_1, target_receptacle_1, confusor_receptacle_1, \
                 obstructor_1] if instance]

--- a/scene_generator/pairs_test.py
+++ b/scene_generator/pairs_test.py
@@ -38,9 +38,9 @@ def test_SimilarAdjacentPair_get_scenes():
     assert scene2 is not None
     assert len(scene1['objects']) >= 1
     assert len(scene2['objects']) >= 2
-    target1 = scene1['objects'][0]
+    target1 = pair._goal_1.get_target_list()[0]
     in_container = 'locationParent' in target1
-    target2 = scene2['objects'][0]
+    target2 = pair._goal_2.get_target_list()[0]
     similar = pair._goal_2.get_distractor_list()[0]
     assert ('locationParent' in target2) == in_container
     assert ('locationParent' in similar) == in_container
@@ -57,9 +57,9 @@ def test_SimilarFarPair_get_scenes():
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
-    target = scene1['objects'][0]
+    target = pair._goal_1.get_target_list()[0]
     in_container = 'locationParent' in target
-    target2 = scene2['objects'][0]
+    target2 = pair._goal_2.get_target_list()[0]
     similar = pair._goal_2.get_distractor_list()[0]
     assert target2 == target
     assert ('locationParent' in similar) == in_container
@@ -81,7 +81,8 @@ def test_SimilarAdjacentFarPair_get_scene():
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
-    target, similar = scene1['objects'][0:2]
+    target = pair._goal_1.get_target_list()[0]
+    similar = pair._goal_1.get_distractor_list()[0]
     is_contained = 'locationParent' in target
     assert is_contained == ('locationParent' in similar)
     if is_contained:
@@ -89,7 +90,7 @@ def test_SimilarAdjacentFarPair_get_scene():
     else:
         assert are_adjacent(target, similar)
     
-    target2 = scene2['objects'][0]
+    target2 = pair._goal_2.get_target_list()[0]
     similar2 = pair._goal_2.get_distractor_list()[0]
     if is_contained:
         assert target2['locationParent'] != similar2['locationParent']
@@ -126,9 +127,10 @@ def test_ImmediatelyVisibleSimilar_get_scenes():
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
-    target1, similar1 = scene1['objects'][0:2]
+    target1 = pair._goal_1.get_target_list()[0]
+    similar1 = pair._goal_1.get_distractor_list()[0]
     assert is_contained(target1) == is_contained(similar1)
-    target2 = scene2['objects'][0]
+    target2 = pair._goal_2.get_target_list()[0]
     similar2 = pair._goal_2.get_distractor_list()[0]
     assert is_contained(target2) == is_contained(similar2)
 
@@ -139,7 +141,7 @@ def test_HiddenBehindPair_get_scenes():
     assert scene1 is not None
     assert scene2 is not None
     # ensure the obstructor is between the target and the performer
-    target = scene2['objects'][0]
+    target = pair._goal_2.get_target_list()[0]
     obstructor = pair._goal_2.get_distractor_list()[0]
     assert (target['dimensions']['x'] <= obstructor['dimensions']['x'] or \
             target['dimensions']['z'] <= obstructor['dimensions']['z'])
@@ -158,9 +160,10 @@ def test_OneEnclosedPair_get_scenes():
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
-    target, similar = scene1['objects'][0:2]
+    target = pair._goal_1.get_target_list()[0]
+    similar = pair._goal_1.get_distractor_list()[0]
     assert ('locationParent' in target) != ('locationParent' in similar)
-    target2 = scene2['objects'][0]
+    target2 = pair._goal_2.get_target_list()[0]
     similar2 = pair._goal_2.get_distractor_list()[0]
     assert ('locationParent' in target2) != ('locationParent' in similar2)
     assert ('locationParent' in target) == ('locationParent' in target2)

--- a/scene_generator/pairs_test.py
+++ b/scene_generator/pairs_test.py
@@ -8,13 +8,31 @@ from geometry_test import are_adjacent
 from pairs import ImmediatelyVisibleSimilarPair, SimilarAdjacentPair, SimilarFarPair, SimilarAdjacentFarPair, ImmediatelyVisiblePair, HiddenBehindPair, OneEnclosedPair
 
 
+BODY_TEMPLATE = {
+    'wallMaterial': 'test_wall_material',
+    'wallColors': ['test_wall_color'],
+    'performerStart': {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': 0
+        },
+        "rotation": {
+            'x': 0,
+            'y': 0,
+            'z': 0
+        }
+    }
+}
+
+
 def test_SimilarAdjacentPair():
-    pair = SimilarAdjacentPair({}, False)
+    pair = SimilarAdjacentPair(BODY_TEMPLATE, False)
     assert pair is not None
 
 
 def test_SimilarAdjacentPair_get_scenes():
-    pair = SimilarAdjacentPair({}, False)
+    pair = SimilarAdjacentPair(BODY_TEMPLATE, False)
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
@@ -29,12 +47,12 @@ def test_SimilarAdjacentPair_get_scenes():
 
 
 def test_SimilarFarPair():
-    pair = SimilarFarPair({}, False)
+    pair = SimilarFarPair(BODY_TEMPLATE, False)
     assert pair is not None
 
 
 def test_SimilarFarPair_get_scenes():
-    pair = SimilarFarPair({}, False)
+    pair = SimilarFarPair(BODY_TEMPLATE, False)
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
@@ -51,12 +69,12 @@ def test_SimilarFarPair_get_scenes():
 
 
 def test_SimilarAdjacentFarPair():
-    pair = SimilarAdjacentFarPair({}, False)
+    pair = SimilarAdjacentFarPair(BODY_TEMPLATE, False)
     assert pair is not None
 
 
 def test_SimilarAdjacentFarPair_get_scene():
-    pair = SimilarAdjacentFarPair({}, False)
+    pair = SimilarAdjacentFarPair(BODY_TEMPLATE, False)
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
@@ -79,19 +97,19 @@ def test_SimilarAdjacentFarPair_get_scene():
 
 
 def test_ImmediatelyVisiblePair():
-    pair = ImmediatelyVisiblePair({}, False)
+    pair = ImmediatelyVisiblePair(BODY_TEMPLATE, False)
     assert pair is not None
 
 
 def test_ImmediatelyVisiblePair_get_scenes():
-    pair = ImmediatelyVisiblePair({}, False)
+    pair = ImmediatelyVisiblePair(BODY_TEMPLATE, False)
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
 
 
 def test_ImmediatelyVisibleSimilar():
-    pair = ImmediatelyVisibleSimilarPair({}, False)
+    pair = ImmediatelyVisibleSimilarPair(BODY_TEMPLATE, False)
     assert pair is not None
 
 
@@ -100,7 +118,7 @@ def is_contained(obj: Dict[str, Any]) -> bool:
 
 
 def test_ImmediatelyVisibleSimilar_get_scenes():
-    pair = ImmediatelyVisibleSimilarPair({}, False)
+    pair = ImmediatelyVisibleSimilarPair(BODY_TEMPLATE, False)
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
@@ -111,7 +129,7 @@ def test_ImmediatelyVisibleSimilar_get_scenes():
 
 
 def test_HiddenBehindPair_get_scenes():
-    pair = HiddenBehindPair({}, False)
+    pair = HiddenBehindPair(BODY_TEMPLATE, False)
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
@@ -130,7 +148,7 @@ def test_HiddenBehindPair_get_scenes():
 
 
 def test_OneEnclosedPair_get_scenes():
-    pair = OneEnclosedPair({}, False)
+    pair = OneEnclosedPair(BODY_TEMPLATE, False)
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None

--- a/scene_generator/pairs_test.py
+++ b/scene_generator/pairs_test.py
@@ -40,7 +40,8 @@ def test_SimilarAdjacentPair_get_scenes():
     assert len(scene2['objects']) >= 2
     target1 = scene1['objects'][0]
     in_container = 'locationParent' in target1
-    target2, similar = scene2['objects'][0:2]
+    target2 = scene2['objects'][0]
+    similar = pair._goal_2.get_distractor_list()[0]
     assert ('locationParent' in target2) == in_container
     assert ('locationParent' in similar) == in_container
     assert are_adjacent(target2, similar)
@@ -58,11 +59,12 @@ def test_SimilarFarPair_get_scenes():
     assert scene2 is not None
     target = scene1['objects'][0]
     in_container = 'locationParent' in target
-    target2, similar = scene2['objects'][0:2]
+    target2 = scene2['objects'][0]
+    similar = pair._goal_2.get_distractor_list()[0]
     assert target2 == target
     assert ('locationParent' in similar) == in_container
     if in_container:
-        container1, container2 = scene2['objects'][2:4]
+        container1, container2 = scene2['objects'][1:2]
         assert not are_adjacent(container1, container2)
     else:
         assert not are_adjacent(target2, similar)
@@ -86,7 +88,8 @@ def test_SimilarAdjacentFarPair_get_scene():
     else:
         assert are_adjacent(target, similar)
     
-    target2, similar2 = scene2['objects'][0:2]
+    target2 = scene2['objects'][0]
+    similar2 = pair._goal_2.get_distractor_list()[0]
     if is_contained:
         assert target2['locationParent'] != similar2['locationParent']
         target2Parent = containers.get_parent(target2, scene2['objects'])
@@ -124,7 +127,8 @@ def test_ImmediatelyVisibleSimilar_get_scenes():
     assert scene2 is not None
     target1, similar1 = scene1['objects'][0:2]
     assert is_contained(target1) == is_contained(similar1)
-    target2, similar2 = scene2['objects'][0:2]
+    target2 = scene2['objects'][0]
+    similar2 = pair._goal_2.get_distractor_list()[0]
     assert is_contained(target2) == is_contained(similar2)
 
 
@@ -133,18 +137,26 @@ def test_HiddenBehindPair_get_scenes():
     scene1, scene2 = pair.get_scenes()
     assert scene1 is not None
     assert scene2 is not None
-    # ensure the occluder is between the target and the performer
-    target, occluder = scene2['objects'][0:2]
-    assert target['dimensions']['x'] <= occluder['dimensions']['x']
-    assert target['dimensions']['y'] <= occluder['dimensions']['y']
+    # ensure the obstructor is between the target and the performer
+    target = scene2['objects'][0]
+    obstructor = pair._goal_2.get_distractor_list()[0]
+    assert (target['dimensions']['x'] <= obstructor['dimensions']['x'] or \
+            target['dimensions']['z'] <= obstructor['dimensions']['z'])
+    assert target['dimensions']['y'] <= obstructor['dimensions']['y']
     target_position = target['shows'][0]['position']
     target_coords = (target_position['x'], target_position['z'])
     performer_position = scene2['performerStart']['position']
     performer_coords = (performer_position['x'], performer_position['z'])
     line_to_target = shapely.geometry.LineString([performer_coords, target_coords])
 
-    occluder_poly = geometry.get_bounding_polygon(occluder)
-    assert occluder_poly.intersects(line_to_target)
+    print('performerStart')
+    print(scene2['performerStart'])
+    print('target')
+    print(target)
+    print('obstructor')
+    print(obstructor)
+    obstructor_poly = geometry.get_bounding_polygon(obstructor)
+    assert obstructor_poly.intersects(line_to_target)
 
 
 def test_OneEnclosedPair_get_scenes():
@@ -154,6 +166,8 @@ def test_OneEnclosedPair_get_scenes():
     assert scene2 is not None
     target, similar = scene1['objects'][0:2]
     assert ('locationParent' in target) != ('locationParent' in similar)
-    target2, similar2 = scene2['objects'][0:2]
+    target2 = scene2['objects'][0]
+    similar2 = pair._goal_2.get_distractor_list()[0]
     assert ('locationParent' in target2) != ('locationParent' in similar2)
     assert ('locationParent' in target) == ('locationParent' in target2)
+

--- a/scene_generator/pairs_test.py
+++ b/scene_generator/pairs_test.py
@@ -17,7 +17,7 @@ BODY_TEMPLATE = {
             'y': 0,
             'z': 0
         },
-        "rotation": {
+        'rotation': {
             'x': 0,
             'y': 0,
             'z': 0
@@ -64,7 +64,8 @@ def test_SimilarFarPair_get_scenes():
     assert target2 == target
     assert ('locationParent' in similar) == in_container
     if in_container:
-        container1, container2 = scene2['objects'][1:2]
+        container1 = containers.get_parent(target2, scene2['objects'])
+        container2 = containers.get_parent(similar, scene2['objects'])
         assert not are_adjacent(container1, container2)
     else:
         assert not are_adjacent(target2, similar)
@@ -148,13 +149,6 @@ def test_HiddenBehindPair_get_scenes():
     performer_position = scene2['performerStart']['position']
     performer_coords = (performer_position['x'], performer_position['z'])
     line_to_target = shapely.geometry.LineString([performer_coords, target_coords])
-
-    print('performerStart')
-    print(scene2['performerStart'])
-    print('target')
-    print(target)
-    print('obstructor')
-    print(obstructor)
     obstructor_poly = geometry.get_bounding_polygon(obstructor)
     assert obstructor_poly.intersects(line_to_target)
 

--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -24,7 +24,7 @@ def find_targets(scene: Dict[str, Any], goal: goal.Goal, num_targets: Optional[i
     have them, but they do have objects that may behave plausibly or
     implausibly.)
     """
-    target_ids = [target['id'] for target in goal._targets[:num_targets]]
+    target_ids = [target['id'] for target in goal._tag_to_objects['target'][:num_targets]]
     # This isn't the most efficient way to do this, but since there
     # will only be 2-3 'target' objects and maybe a dozen total
     # objects, that's ok.
@@ -121,7 +121,7 @@ class ObjectPermanenceQuartet(Quartet):
         elif q == 4:
             # target not in the scene (plausible)
             scene['goal']['type_list'].append('object permanence hide object')
-            target_id = self._goal._targets[0]['id']
+            target_id = self._goal._tag_to_objects['target'][0]['id']
             for i in range(len(scene['objects'])):
                 obj = scene['objects'][i]
                 if obj['id'] == target_id:

--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -370,8 +370,8 @@ class ShapeConstancyQuartet(Quartet):
         for obj_def in self._goal._object_defs:
             if obj_def['type'] != a['type']:
                 possible_b_size = obj_def['dimensions']['x']
-                if possible_b_size < (a_size + intphys_goals.MAX_SIZE_DIFFERENCE) and possible_b_size > \
-                        (a_size - intphys_goals.MAX_SIZE_DIFFERENCE):
+                if possible_b_size < (a_size + util.MAX_SIZE_DIFFERENCE) and possible_b_size > \
+                        (a_size - util.MAX_SIZE_DIFFERENCE):
                     possible_defs.append(obj_def)
         if len(possible_defs) == 0:
             raise goal.GoalException(f'no valid choices for "b" object. a = {a}')

--- a/scene_generator/quartets_test.py
+++ b/scene_generator/quartets_test.py
@@ -3,6 +3,7 @@ import objects
 import pytest
 from quartets import GravityQuartet, ShapeConstancyQuartet, ObjectPermanenceQuartet, SpatioTemporalContinuityQuartet, \
         find_targets, get_position_step
+import util
 
 
 TEMPLATE = {'wallMaterial': 'dummy', 'wallColors': ['color']}
@@ -108,7 +109,7 @@ def test_ShapeConstancyQuartet():
     a = quartet._scene_template['objects'][0]
     assert a['type'] != quartet._b['type']
     assert a['id'] == quartet._b['id']
-    assert a['dimensions']['x'] == pytest.approx(quartet._b['dimensions']['x'], abs=intphys_goals.MAX_SIZE_DIFFERENCE)
+    assert a['dimensions']['x'] == pytest.approx(quartet._b['dimensions']['x'], abs=util.MAX_SIZE_DIFFERENCE)
     assert a['materials'] == quartet._b['materials']
 
 

--- a/scene_generator/scene_generator.py
+++ b/scene_generator/scene_generator.py
@@ -76,6 +76,7 @@ def clean_object(obj: Dict[str, Any]) -> None:
     obj.pop('novel_combination', None)
     obj.pop('novel_shape', None)
     obj.pop('shape', None)
+    obj.pop('similarityScale', None)
     if 'shows' in obj:
         obj['shows'][0].pop('bounding_box', None)
 

--- a/scene_generator/scene_generator.py
+++ b/scene_generator/scene_generator.py
@@ -78,7 +78,6 @@ def clean_object(obj: Dict[str, Any]) -> None:
     obj.pop('novel_combination', None)
     obj.pop('novel_shape', None)
     obj.pop('shape', None)
-    obj.pop('similarityScale', None)
     if 'shows' in obj:
         obj['shows'][0].pop('bounding_box', None)
 
@@ -215,13 +214,12 @@ def generate_pair(prefix: str, count: int, find_path: bool, stop_on_error: bool)
     pair_class = pairs.get_pair_class()
     pair = pair_class(template, find_path)
     pair_id = str(uuid.uuid4())
-    pair_name = pair.__class__.__name__.replace('Pair', '').lower()
     logging.debug(f'generating scene pair #{count}')
     while True:
         try:
             scenes = pair.get_scenes()
-            scenes[0]['goal']['series_id'] = 'pair_' + pair_name + '_' + pair_id
-            scenes[1]['goal']['series_id'] = 'pair_' + pair_name + '_' + pair_id
+            scenes[0]['goal']['series_id'] = 'pair_' + pair.get_name() + '_' + pair_id
+            scenes[1]['goal']['series_id'] = 'pair_' + pair.get_name() + '_' + pair_id
             write_scene_of_pair(scenes[0], generate_name(prefix, count, 1))
             write_scene_of_pair(scenes[1], generate_name(prefix, count, 2))
             break

--- a/scene_generator/scene_generator.py
+++ b/scene_generator/scene_generator.py
@@ -32,11 +32,13 @@ OUTPUT_TEMPLATE_JSON = """
   "performerStart": {
     "position": {
       "x": 0,
+      "y": 0,
       "z": 0
     },
     "rotation": {
       "x": 0,
-      "y": 0
+      "y": 0,
+      "z": 0
     }
   },
   "objects": [],

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -206,7 +206,7 @@ def check_same_and_different(a: Dict[str, Any], b: Dict[str, Any],
                     b[prop]['z'] >= (a[prop]['z'] - MAX_SIZE_DIFFERENCE):
                 diff_ok = False
                 break
-        elif prop in a and prop in b and a[prop] == b[prop]:
+        elif (prop in a and prop in b and a[prop] == b[prop]) or (not prop in a and not prop in b):
             diff_ok = False
             break
     return diff_ok

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -8,14 +8,11 @@ import exceptions
 import materials
 import objects
 
+
 MAX_TRIES = 200
 MIN_RANDOM_INTERVAL = 0.05
 PERFORMER_WIDTH = 0.1
 PERFORMER_HALF_WIDTH = PERFORMER_WIDTH / 2.0
-
-# TODO MCS-306 DELETE
-TARGET_CONTAINED_CHANCE = 0.5
-"""Chance that the target will be in a container"""
 
 
 def random_real(a: float, b: float, step: float = MIN_RANDOM_INTERVAL) -> float:
@@ -64,7 +61,9 @@ def instantiate_object(object_def: Dict[str, Any],
         'info': object_def['info'].copy(),
         'novel_color': object_def['novel_color'] if 'novel_color' in object_def else False,
         'novel_combination': object_def['novel_combination'] if 'novel_combination' in object_def else False,
-        'novel_shape': object_def['novel_shape'] if 'novel_shape' in object_def else False
+        'novel_shape': object_def['novel_shape'] if 'novel_shape' in object_def else False,
+        # TODO MCS-261 Each object definition should have a similarityScale
+        'similarityScale': object_def['similarityScale'] if 'similarityScale' in object_def else 1
     }
     if 'dimensions' in object_def:
         new_object['dimensions'] = object_def['dimensions']
@@ -81,8 +80,16 @@ def instantiate_object(object_def: Dict[str, Any],
         object_location['position']['x'] -= object_def['offset']['x']
         object_location['position']['z'] -= object_def['offset']['z']
 
-    if 'rotation' in object_def:
-        object_location['rotation'] = copy.deepcopy(object_def['rotation'])
+    if not 'rotation' in object_def:
+        object_def['rotation'] = {
+            'x': 0,
+            'y': 0,
+            'z': 0
+        }
+
+    object_location['rotation']['x'] = object_location['rotation']['x'] + object_def['rotation']['x']
+    object_location['rotation']['y'] = object_location['rotation']['y'] + object_def['rotation']['y']
+    object_location['rotation']['z'] = object_location['rotation']['z'] + object_def['rotation']['z']
 
     shows = [object_location]
     new_object['shows'] = shows

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -9,6 +9,7 @@ import materials
 import objects
 
 
+MAX_SIZE_DIFFERENCE = 0.1
 MAX_TRIES = 200
 MIN_RANDOM_INTERVAL = 0.05
 PERFORMER_WIDTH = 0.1
@@ -61,14 +62,12 @@ def instantiate_object(object_def: Dict[str, Any],
         'info': object_def['info'].copy(),
         'novel_color': object_def['novel_color'] if 'novel_color' in object_def else False,
         'novel_combination': object_def['novel_combination'] if 'novel_combination' in object_def else False,
-        'novel_shape': object_def['novel_shape'] if 'novel_shape' in object_def else False,
-        # TODO MCS-261 Each object definition should have a similarityScale
-        'similarityScale': object_def['similarityScale'] if 'similarityScale' in object_def else 1
+        'novel_shape': object_def['novel_shape'] if 'novel_shape' in object_def else False
     }
     if 'dimensions' in object_def:
         new_object['dimensions'] = object_def['dimensions']
     else:
-        logging.warning(f'object type "{object_def["type"]}" has no dimensions')
+        exceptions.SceneException(f'object definition of type "{object_def["type"]}" doesn\'t have any dimensions')
 
     for attribute in object_def['attributes']:
         new_object[attribute] = True
@@ -158,7 +157,7 @@ def instantiate_object(object_def: Dict[str, Any],
     return new_object
 
 
-def get_similar_definition(obj: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def get_similar_definition(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """Get an object definition similar to obj but different in one of
     type, material, or scale. It is possible but unlikely that no such
     definition can be found, in which case it returns None.
@@ -167,11 +166,11 @@ def get_similar_definition(obj: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     random.shuffle(choices)
     for choice in choices:
         if choice == 1:
-            new_obj = get_def_with_new_type(obj)
+            new_obj = get_def_with_new_type(obj, all_defs)
         elif choice == 2:
-            new_obj = get_def_with_new_material(obj)
+            new_obj = get_def_with_new_material(obj, all_defs)
         else:
-            new_obj = get_def_with_new_scale(obj)
+            new_obj = get_def_with_new_scale(obj, all_defs)
         if new_obj is not None:
             return new_obj
     return None
@@ -185,46 +184,60 @@ def check_same_and_different(a: Dict[str, Any], b: Dict[str, Any],
     """
     same_ok = True
     for prop in same:
-        if prop in a:
-            if prop not in b or a[prop] != b[prop]:
+        if prop == 'dimensions':
+            if b[prop]['x'] > (a[prop]['x'] + MAX_SIZE_DIFFERENCE) or \
+                    b[prop]['x'] < (a[prop]['x'] - MAX_SIZE_DIFFERENCE) or \
+                    b[prop]['z'] > (a[prop]['z'] + MAX_SIZE_DIFFERENCE) or \
+                    b[prop]['z'] < (a[prop]['z'] - MAX_SIZE_DIFFERENCE):
                 same_ok = False
                 break
+        elif (prop in a and prop not in b) or (prop not in a and prop in b) or \
+                (prop in a and prop in b and a[prop] != b[prop]):
+            same_ok = False
+            break
     if not same_ok:
         return False
     diff_ok = True
     for prop in different:
-        if prop in a:
-            if prop not in b or a[prop] == b[prop]:
+        if prop == 'dimensions':
+            if b[prop]['x'] <= (a[prop]['x'] + MAX_SIZE_DIFFERENCE) and \
+                    b[prop]['x'] >= (a[prop]['x'] - MAX_SIZE_DIFFERENCE) and \
+                    b[prop]['z'] <= (a[prop]['z'] + MAX_SIZE_DIFFERENCE) and \
+                    b[prop]['z'] >= (a[prop]['z'] - MAX_SIZE_DIFFERENCE):
                 diff_ok = False
                 break
+        elif prop in a and prop in b and a[prop] == b[prop]:
+            diff_ok = False
+            break
     return diff_ok
 
     
-def get_similar_defs(obj: Dict[str, Any], same: Iterable[str],
+def get_similar_defs(obj: Dict[str, Any], all_defs: List[Dict[str, Any]], same: Iterable[str],
                      different: Iterable[str]) -> List[Dict[str, Any]]:
     """Return object definitions similar to obj: where properties from
     same are identical and from different are different.
     """
     valid_defs = []
-    for obj_def in objects.get_all_object_defs():
-        if check_same_and_different(obj_def, obj, same, different):
-            # now test the choose part if it's there
-            if 'choose' in obj_def:
-                valid_choices = [choice for choice in obj_def['choose']
-                                 if check_same_and_different(choice, obj, same, different)]
-                if len(valid_choices) != 0:
-                    new_def = copy.deepcopy(obj_def)
-                    new_def['choose'] = valid_choices
-                    valid_defs.append(new_def)
-            else:
+    for obj_def in all_defs:
+        if 'choose' in obj_def:
+            valid_choices = []
+            for choice in obj_def['choose']:
+                possible_obj_def = finalize_object_definition(copy.deepcopy(obj_def), choice)
+                if check_same_and_different(possible_obj_def, obj, same, different):
+                    valid_choices.append(choice)
+            if len(valid_choices) > 0:
+                new_def = copy.deepcopy(obj_def)
+                new_def['choose'] = valid_choices
+                valid_defs.append(new_def)
+        else:
+            possible_obj_def = finalize_object_definition(copy.deepcopy(obj_def))
+            if check_same_and_different(possible_obj_def, obj, same, different):
                 valid_defs.append(obj_def)
     return valid_defs
 
 
-def get_def_with_new_type(obj: Dict[str, Any]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, ('materialCategory',
-                                        'similarityScale'),
-                                  ('type',))
+def get_def_with_new_type(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(obj, all_defs, ('materialCategory', 'dimensions'), ('type',))
     if len(valid_defs) > 0:
         obj_def = random.choice(valid_defs)
     else:
@@ -232,10 +245,8 @@ def get_def_with_new_type(obj: Dict[str, Any]) -> Dict[str, Any]:
     return obj_def
 
 
-def get_def_with_new_material(obj: Dict[str, Any]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, ('type',
-                                        'similarityScale'),
-                                  ('materialCategory',))
+def get_def_with_new_material(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(obj, all_defs, ('type', 'dimensions'), ('materialCategory',))
     if len(valid_defs) > 0:
         obj_def = random.choice(valid_defs)
     else:
@@ -243,10 +254,8 @@ def get_def_with_new_material(obj: Dict[str, Any]) -> Dict[str, Any]:
     return obj_def
 
 
-def get_def_with_new_scale(obj: Dict[str, Any]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, ('type',
-                                        'materialCategory'),
-                                  ('similarityScale',))
+def get_def_with_new_scale(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(obj, all_defs, ('type', 'materialCategory'), ('dimensions',))
     if len(valid_defs) > 0:
         obj_def = random.choice(valid_defs)
     else:

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -85,9 +85,9 @@ def instantiate_object(object_def: Dict[str, Any],
     if not 'rotation' in object_location:
         object_location['rotation'] = {'x': 0, 'y': 0, 'z': 0}
 
-    object_location['rotation']['x'] = object_location['rotation']['x'] + object_def['rotation']['x']
-    object_location['rotation']['y'] = object_location['rotation']['y'] + object_def['rotation']['y']
-    object_location['rotation']['z'] = object_location['rotation']['z'] + object_def['rotation']['z']
+    object_location['rotation']['x'] += object_def['rotation']['x']
+    object_location['rotation']['y'] += object_def['rotation']['y']
+    object_location['rotation']['z'] += object_def['rotation']['z']
 
     shows = [object_location]
     new_object['shows'] = shows
@@ -261,3 +261,4 @@ def get_def_with_new_scale(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) 
     else:
         obj_def = None
     return obj_def
+

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -81,11 +81,10 @@ def instantiate_object(object_def: Dict[str, Any],
         object_location['position']['z'] -= object_def['offset']['z']
 
     if not 'rotation' in object_def:
-        object_def['rotation'] = {
-            'x': 0,
-            'y': 0,
-            'z': 0
-        }
+        object_def['rotation'] = {'x': 0, 'y': 0, 'z': 0}
+
+    if not 'rotation' in object_location:
+        object_location['rotation'] = {'x': 0, 'y': 0, 'z': 0}
 
     object_location['rotation']['x'] = object_location['rotation']['x'] + object_def['rotation']['x']
     object_location['rotation']['y'] = object_location['rotation']['y'] + object_def['rotation']['y']

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -7,6 +7,30 @@ from goals import *
 from util import finalize_object_definition, instantiate_object, check_same_and_different, get_similar_defs, random_real
 
 
+PACIFIER = {
+    "type": "pacifier",
+    "info": ["tiny", "blue", "pacifier"],
+    "mass": 0.125,
+    "salientMaterials": ["plastic"],
+    "attributes": ["moveable", "pickupable"],
+    "dimensions": {
+        "x": 0.07,
+        "y": 0.04,
+        "z": 0.05
+    },
+    "offset": {
+        "x": 0,
+        "y": 0.02,
+        "z": 0
+    },
+    "position_y": 0.01,
+    "scale": {
+        "x": 1,
+        "y": 1,
+        "z": 1
+    }
+}
+
 def test_random_real():
     n = random_real(0, 1, 0.1)
     assert 0 <= n <= 1
@@ -296,6 +320,12 @@ def test_check_same_and_different():
     assert check_same_and_different(a, b, ('type', 'size'), ('color',)) is True
     assert check_same_and_different(a, b, ('type', 'color'), ('size',)) is False
     assert check_same_and_different(a, b, ('color', 'size'), ('type',)) is False
+
+
+def test_check_same_and_different_pacifier():
+    assert check_same_and_different(PACIFIER, PACIFIER, ('type', 'dimensions'), ('materialCategory',)) is False
+    assert check_same_and_different(PACIFIER, PACIFIER, ('type', 'materialCategory'), ('dimensions',)) is False
+    assert check_same_and_different(PACIFIER, PACIFIER, ('dimensions', 'materialCategory'), ('type',)) is False
 
 
 def test_get_similar_defs():

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -301,9 +301,10 @@ def test_check_same_and_different():
 def test_get_similar_defs():
     original_def = objects.OBJECTS_PICKUPABLE_BALLS[0]
     obj = instantiate_object(original_def, geometry.ORIGIN)
-    similar_defs = get_similar_defs(obj, ('type', 'materialCategory'), ('mass',))
+    similar_defs = get_similar_defs(obj, objects.get_all_object_defs(), ('type', 'materialCategory'), ('mass',))
     for obj_def in similar_defs:
-        assert check_same_and_different(obj_def, obj, ('type', 'materialCategory'), ('mass',))
+        obj_2 = instantiate_object(obj_def, geometry.ORIGIN)
+        assert check_same_and_different(obj_2, obj, ('type', 'materialCategory'), ('mass',))
 
 
 def test_instantiate_object_novel_color():


### PR DESCRIPTION
This ticket still needs more testing but I wanted to open the PR so you all could start reviewing the changes and giving me feedback.

Task: MCS-306 (Each Interactive Pair should have an Interactive Goal)

Accomplishments:
- Reorganized the InteractionPair class and subclasses to generate an InteractionGoal and then use that Goal to generate the Pair's two scenes. Most of the behavior moved away from the subclasses into the InteractionPair class. The Pair will consider the Goal's requirements while generating its Target objects. The new structure should make it easier to add new Pairs in the future.
- Fixed some minor bugs with the existing Pairs. Some examples: if the Target and the Confuser were meant to switch being "immediately visible" in one scene and "not immediately visible" in another, they were incorrectly given new positions rather than just switching their positions; Pairs that should have a chance to containerize their Targets were never doing so.
- Each InteractionGoal subclass can customize its own Rules for generating Targets, Distractors, Confusors, and Obstructors. For example, in a TransferralGoal, the 1st Target must be pickupable, and the 2nd Target must have stackTarget.
- Minor cleanup in some functions relevant to the recent changes.

Outstanding Issues:
- Obstructors in the HiddenBehindPair aren't being positioned properly.

Solved Issues:
- Pair generation is still failing more often than it should.
- Some pair unit tests are broken because they rely on accessing specific objects at specific list indices and that behavior needs to be updated.
- The "cannot create enclosable receptacle" exceptions occur frequently due to the lack of similarityScale in object definitions (TODO MCS-261)
- Other misc. bug fixes.