### PR TITLE
MCS-303 Refactor Tags

### DIFF
--- a/python_api/API.md
+++ b/python_api/API.md
@@ -7,7 +7,7 @@
 - [Python Class: MCS_Step_Output](#mcs_step_output)
 - [Actions](#actions)
 - [Future Actions (Not Yet Supported)](#future-actions)
-- [Goal Descriptions](#goal-description)
+- [Goal Descriptions](#goal-descriptions)
 - [Goal Metadata](#goal-metadata)
 - [Config File](#config-file)
 
@@ -92,9 +92,17 @@ The MCS scene output data object from after the action and the physics simulatio
 
 The list of actions that are available for the scene at each step (outer list index).  Each inner list item is a list of action strings. For example, ['MoveAhead','RotateLook,rotation=180'] restricts the actions to either 'MoveAhead' or 'RotateLook' with the 'rotation' parameter set to 180. An action_list of None means that all actions are always available. An empty inner list means that all actions are available for that specific step.
 
+### category : string
+
+The category that describes this goal and the properties in its `metadata`. Please see [Goal Metadata](#Goal-Metadata).
+
 ### description : string
 
 A human-readable sentence describing this goal and containing the target task(s) and object(s). Please see [Goal Descriptions](#Goal-Descriptions).
+
+### domain_list : list of strings
+
+The list of MCS "core domains" associated with this goal (for the visualization interface).
 
 ### info_list : list of strings
 
@@ -108,13 +116,9 @@ The last step of the Preview Phase in this scene, if any. Each step of a Preview
 
 The last step of this scene. This scene will automatically end following this step.
 
-### task_list : list of strings
-
-The list of tasks associated with this goal (for the visualization interface), secondary to its types.
-
 ### type_list : list of strings
 
-The list of types associated with this goal (for the visualization interface), including the relevant MCS core domains.
+The list of types associated with this goal (for the visualization interface).
 
 ### metadata : dict
 
@@ -807,7 +811,7 @@ Materials:
 
 ## Goal Metadata
 
-A goal's `metadata` property is a dict with a string `category` property and one or more other properties depending on the `category`.
+A goal's `metadata` property is a dict with one or more properties depending on the goal's `category` property.
 
 Categories:
 

--- a/python_api/machine_common_sense/mcs_controller_ai2thor.py
+++ b/python_api/machine_common_sense/mcs_controller_ai2thor.py
@@ -467,15 +467,18 @@ class MCS_Controller_AI2THOR(MCS_Controller):
     def retrieve_goal(self, scene_configuration):
         goal_config = scene_configuration['goal'] if 'goal' in scene_configuration else {}
         if 'category' in goal_config:
+            # Backwards compatibility
             goal_config['metadata']['category'] = goal_config['category']
 
         return self.restrict_goal_output_metadata(MCS_Goal(
             action_list=(goal_config['action_list'] if 'action_list' in goal_config else None),
+            category=(goal_config['category'] if 'category' in goal_config else ''),
+            description=(goal_config['description'] if 'description' in goal_config else ''),
+            domain_list=(goal_config['domain_list'] if 'domain_list' in goal_config else []),
             info_list=(goal_config['info_list'] if 'type_list' in goal_config else []),
             last_preview_phase_step=(goal_config['last_preview_phase_step'] if 'last_preview_phase_step' \
                     in goal_config else 0),
             last_step=(goal_config['last_step'] if 'last_step' in goal_config else None),
-            task_list=(goal_config['task_list'] if 'type_list' in goal_config else []),
             type_list=(goal_config['type_list'] if 'type_list' in goal_config else []),
             metadata=(goal_config['metadata'] if 'metadata' in goal_config else {})
         ))

--- a/python_api/machine_common_sense/mcs_goal.py
+++ b/python_api/machine_common_sense/mcs_goal.py
@@ -11,16 +11,20 @@ class MCS_Goal:
         a list of action strings. For example, ['MoveAhead','RotateLook,rotation=180'] restricts the actions to either
         'MoveAhead' or 'RotateLook' with the 'rotation' parameter set to 180. An action_list of None means that all
         actions are always available. An empty inner list means that all actions are available for that specific step.
+    category : string
+        The category that describes this goal and the properties in its metadata.
+    description : string
+        A human-readable sentence describing this goal and containing the target task(s) and object(s).
+    domain_list : list of strings
+        The list of MCS "core domains" associated with this goal (for the visualization interface).
     info_list : list
         The list of information for the visualization interface associated with this goal.
     last_preview_phase_step : integer
         The last step of the preview phase of this scene (scripted in its configuration), if any. Default: 0
     last_step : integer
         The last step of this scene. This scene will automatically end following this step.
-    task_list : list of strings
-        The list of tasks for the visualization interface associated with this goal (secondary to its types).
     type_list : list of strings
-        The list of types for the visualization interface associated with this goal, including relevant core domains.
+        The list of types associated with this goal (for the visualization interface).
     metadata : dict
         The metadata specific to this goal.
     """
@@ -28,6 +32,9 @@ class MCS_Goal:
     def __init__(
         self,
         action_list=None,
+        category='',
+        description='',
+        domain_list=None,
         info_list=None,
         last_preview_phase_step=0,
         last_step=None,
@@ -35,11 +42,14 @@ class MCS_Goal:
         type_list=None,
         metadata=None
     ):
+        # The action_list must be None by default
         self.action_list = action_list
+        self.category = category
+        self.description = description
+        self.domain_list = [] if domain_list is None else domain_list
         self.info_list = [] if info_list is None else info_list
         self.last_preview_phase_step = last_preview_phase_step
         self.last_step = last_step
-        self.task_list = [] if task_list is None else task_list
         self.type_list = [] if type_list is None else type_list
         self.metadata = {} if metadata is None else metadata
 

--- a/python_api/test/test_mcs_controller_ai2thor.py
+++ b/python_api/test/test_mcs_controller_ai2thor.py
@@ -601,9 +601,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
     def test_retrieve_goal(self):
         goal_1 = self.controller.retrieve_goal({})
         self.assertEqual(goal_1.action_list, None)
+        self.assertEqual(goal_1.category, '')
+        self.assertEqual(goal_1.description, '')
+        self.assertEqual(goal_1.domain_list, [])
         self.assertEqual(goal_1.info_list, [])
         self.assertEqual(goal_1.last_step, None)
-        self.assertEqual(goal_1.task_list, [])
         self.assertEqual(goal_1.type_list, [])
         self.assertEqual(goal_1.metadata, {})
 
@@ -612,18 +614,22 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             }
         })
         self.assertEqual(goal_2.action_list, None)
+        self.assertEqual(goal_2.category, '')
+        self.assertEqual(goal_2.description, '')
+        self.assertEqual(goal_2.domain_list, [])
         self.assertEqual(goal_2.info_list, [])
         self.assertEqual(goal_2.last_step, None)
-        self.assertEqual(goal_2.task_list, [])
         self.assertEqual(goal_2.type_list, [])
         self.assertEqual(goal_2.metadata, {})
 
         goal_3 = self.controller.retrieve_goal({
             "goal": {
                 "action_list": [["action1"], [], ["action2", "action3", "action4"]],
+                "category": "test category",
+                "description": "test description",
+                "domain_list": ["domain1", "domain2"],
                 "info_list": ["info1", "info2", 12.34],
                 "last_step": 10,
-                "task_list": ["task1", "task2"],
                 "type_list": ["type1", "type2"],
                 "metadata": {
                     "key": "value"
@@ -631,11 +637,14 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             }
         })
         self.assertEqual(goal_3.action_list, [["action1"], [], ["action2", "action3", "action4"]])
+        self.assertEqual(goal_3.category, "test category")
+        self.assertEqual(goal_3.description, "test description")
+        self.assertEqual(goal_3.domain_list, ["domain1", "domain2"])
         self.assertEqual(goal_3.info_list, ["info1", "info2", 12.34])
         self.assertEqual(goal_3.last_step, 10)
-        self.assertEqual(goal_3.task_list, ["task1", "task2"])
         self.assertEqual(goal_3.type_list, ["type1", "type2"])
         self.assertEqual(goal_3.metadata, {
+            "category": "test category",
             "key": "value"
         })
 

--- a/python_api/test/test_mcs_goal.py
+++ b/python_api/test/test_mcs_goal.py
@@ -8,10 +8,12 @@ class Test_Default_MCS_Goal(unittest.TestCase):
 
     str_output = '''    {
         "action_list": null,
+        "category": "",
+        "description": "",
+        "domain_list": [],
         "info_list": [],
         "last_preview_phase_step": 0,
         "last_step": null,
-        "task_list": [],
         "type_list": [],
         "metadata": {}
     }'''
@@ -27,6 +29,16 @@ class Test_Default_MCS_Goal(unittest.TestCase):
     def test_action_list(self):
         self.assertIsNone(self.goal.action_list)
 
+    def test_category(self):
+        self.assertEqual(self.goal.category, '')
+
+    def test_description(self):
+        self.assertEqual(self.goal.description, '')
+
+    def test_domain_list(self):
+        self.assertEqual(len(self.goal.domain_list), 0)
+        self.assertIsInstance(self.goal.domain_list, list)
+
     def test_info_list(self):
         self.assertEqual(len(self.goal.info_list), 0)
         self.assertIsInstance(self.goal.info_list, list)
@@ -38,10 +50,6 @@ class Test_Default_MCS_Goal(unittest.TestCase):
     def test_last_step(self):
         self.assertIsNone(self.goal.last_step)
         
-    def test_task_list(self):
-        self.assertEqual(len(self.goal.task_list), 0)
-        self.assertIsInstance(self.goal.task_list, list)
-
     def test_type_list(self):
         self.assertEqual(len(self.goal.type_list), 0)
         self.assertIsInstance(self.goal.type_list, list)

--- a/python_api/test/test_mcs_step_output.py
+++ b/python_api/test/test_mcs_step_output.py
@@ -24,10 +24,12 @@ class Test_Default_MCS_Step_Output(unittest.TestCase):
         "depth_mask_list": [],
         "goal": {
             "action_list": null,
+            "category": "",
+            "description": "",
+            "domain_list": [],
             "info_list": [],
             "last_preview_phase_step": 0,
             "last_step": null,
-            "task_list": [],
             "type_list": [],
             "metadata": {}
         },

--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -161,8 +161,10 @@ class Goal(ABC):
     def get_config(self, tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
         """Create and return the goal configuration."""
         goal_config = self._get_subclass_config(tag_to_objects['target'])
-        goal_config['type_list'] = tags.append_object_tags(goal_config['type_list'], tag_to_objects)
+        goal_config['category'] = goal_config.get('category', '')
+        goal_config['type_list'] = tags.append_object_tags(goal_config.get('type_list', []), tag_to_objects)
         goal_config['info_list'] = self.update_goal_info_list(goal_config.get('info_list', []), tag_to_objects)
+        goal_config['metadata'] = goal_config.get('metadata', {})
         return goal_config
 
     def get_name(self) -> str:

--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -3,11 +3,13 @@ import random
 import shapely
 import uuid
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Dict, Any, Tuple, List, Optional
 
 import geometry
 import objects
 import separating_axis_theorem
+import tags
 import util
 
 MAX_WALL_WIDTH = 4
@@ -82,6 +84,14 @@ def generate_wall(wall_material: str, wall_colors: List[str], performer_position
     return None
 
 
+class GoalCategory(Enum):
+    """String for the goal's JSON config "category" property. Should all be listed in the API documentation."""
+    INTPHYS = 'intphys'
+    RETRIEVAL = 'retrieval'
+    TRANSFERRAL = 'transferral'
+    TRAVERSAL = 'traversal'
+
+
 class Goal(ABC):
     """An abstract Goal. Subclasses must implement compute_objects and
     get_config. Users of a goal object should normally only need to call 
@@ -91,7 +101,7 @@ class Goal(ABC):
         self._name = name
         self._performer_start = None
         self._compute_performer_start()
-        self._tag_to_objects = []
+        self._tag_to_objects = {}
 
     def update_body(self, body: Dict[str, Any], find_path: bool) -> Dict[str, Any]:
         """Helper method that calls other Goal methods to set performerStart, objects, and goal. Returns the goal body
@@ -137,51 +147,22 @@ class Goal(ABC):
         (dict that maps tag strings to object lists, bounding rectangles)"""
         pass
 
-    def _update_goal_info_list(self, goal: Dict[str, Any], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> None:
-        info_set = set(goal.get('info_list', []))
-
+    def update_goal_info_list(self, info_list: List[str], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> List[str]:
+        """Update and return the given info_list with the info from all objects in this goal."""
+        info_set = set(info_list)
         for key, value in tag_to_objects.items():
             for obj in value:
                 info_list = obj.get('info', []).copy()
                 if 'info_string' in obj:
                     info_list.append(obj['info_string'])
                 info_set |= set([(key + ' ' + info) for info in info_list])
-
-        goal['info_list'] = list(info_set)
-
-    def _update_goal_tags(self, goal: Dict[str, Any], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> None:
-        self._update_goal_tags_of_type(goal, tag_to_objects['target'], 'target')
-        if 'confusor' in tag_to_objects:
-            self._update_goal_tags_of_type(goal, tag_to_objects['confusor'], 'confusor')
-        if 'distractor' in tag_to_objects:
-            self._update_goal_tags_of_type(goal, tag_to_objects['distractor'], 'distractor')
-        if 'obstructor' in tag_to_objects:
-            self._update_goal_tags_of_type(goal, tag_to_objects['obstructor'], 'obstructor')
-        for item in ['background object', 'confusor', 'distractor', 'obstructor', 'occluder', 'target', 'wall']:
-            if item in tag_to_objects:
-                number = len(tag_to_objects[item])
-                if item == 'occluder':
-                    number = (int)(number / 2)
-                goal['type_list'].append(item + 's ' + str(number))
-        self._update_goal_info_list(goal, tag_to_objects)
-
-    def _update_goal_tags_of_type(self, goal: Dict[str, Any], objs: List[Dict[str, Any]], name: str) -> None:
-        for obj in objs:
-            enclosed_tag = (name + ' not enclosed') if obj.get('locationParent', None) is None else (name + ' enclosed')
-            novel_color_tag = (name + ' novel color') if 'novel_color' in obj and obj['novel_color'] else \
-                    (name + ' not novel color')
-            novel_combination_tag = (name + ' novel combination') if 'novel_combination' in obj and \
-                    obj['novel_combination'] else (name + ' not novel combination')
-            novel_shape_tag = (name + ' novel shape') if 'novel_shape' in obj and obj['novel_shape'] else \
-                    (name + ' not novel shape')
-            for new_tag in [enclosed_tag, novel_color_tag, novel_combination_tag, novel_shape_tag]:
-                if new_tag not in goal['type_list']:
-                    goal['type_list'].append(new_tag)
+        return list(info_set)
 
     def get_config(self, tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
         """Create and return the goal configuration."""
         goal_config = self._get_subclass_config(tag_to_objects['target'])
-        self._update_goal_tags(goal_config, tag_to_objects)
+        goal_config['type_list'] = tags.append_object_tags(goal_config['type_list'], tag_to_objects)
+        goal_config['info_list'] = self.update_goal_info_list(goal_config.get('info_list', []), tag_to_objects)
         return goal_config
 
     def get_name(self) -> str:

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -12,9 +12,10 @@ import containers
 import exceptions
 import geometry
 import objects
+import tags
 import util
 from geometry import POSITION_DIGITS
-from goal import Goal, generate_wall
+from goal import Goal, GoalCategory, generate_wall
 from machine_common_sense.mcs_controller_ai2thor import MAX_MOVE_DISTANCE, MAX_REACH_DISTANCE, PERFORMER_CAMERA_Y
 from optimal_path import generatepath
 from util import finalize_object_definition, instantiate_object
@@ -527,10 +528,19 @@ class RetrievalGoal(InteractionGoal):
     """Going to a specified object and picking it up."""
 
     TEMPLATE = {
-        'category': 'retrieval',
-        'domain_list': ['objects', 'places', 'object_solidity', 'navigation', 'localization'],
-        'type_list': ['interactive', 'action_full', 'retrieval'],
-        'task_list': ['navigate', 'localize', 'identify', 'retrieve'],
+        'category': GoalCategory.RETRIEVAL.value,
+        'domain_list': [
+            tags.DOMAIN_OBJECTS,
+            tags.DOMAIN_OBJECTS_SOLIDITY,
+            tags.DOMAIN_PLACES,
+            tags.DOMAIN_PLACES_LOCALIZATION,
+            tags.DOMAIN_PLACES_NAVIGATION
+        ],
+        'type_list': [
+            tags.INTERACTIVE,
+            tags.ACTION_FULL,
+            GoalCategory.RETRIEVAL.value
+        ],
         'last_step': InteractionGoal.LAST_STEP
     }
 
@@ -607,10 +617,19 @@ class TransferralGoal(InteractionGoal):
         ON_TOP_OF = 'on top of'
 
     TEMPLATE = {
-        'category': 'transferral',
-        'domain_list': ['objects', 'places', 'object_solidity', 'navigation', 'localization'],
-        'type_list': ['interactive', 'action_full', 'transferral'],
-        'task_list': ['navigate', 'localize', 'identify', 'retrieve', 'transfer'],
+        'category': GoalCategory.TRANSFERRAL.value,
+        'domain_list': [
+            tags.DOMAIN_OBJECTS,
+            tags.DOMAIN_OBJECTS_SOLIDITY,
+            tags.DOMAIN_PLACES,
+            tags.DOMAIN_PLACES_LOCALIZATION,
+            tags.DOMAIN_PLACES_NAVIGATION
+        ],
+        'type_list': [
+            tags.INTERACTIVE,
+            tags.ACTION_FULL,
+            GoalCategory.TRANSFERRAL.value
+        ],
         'last_step': InteractionGoal.LAST_STEP
     }
 
@@ -745,10 +764,19 @@ class TraversalGoal(InteractionGoal):
     """Locating and navigating to a specified object."""
 
     TEMPLATE = {
-        'category': 'traversal',
-        'domain_list': ['objects', 'places', 'object_solidity', 'navigation', 'localization'],
-        'type_list': ['interactive', 'action_full', 'traversal'],
-        'task_list': ['navigate', 'localize', 'identify'],
+        'category': GoalCategory.TRAVERSAL.value,
+        'domain_list': [
+            tags.DOMAIN_OBJECTS,
+            tags.DOMAIN_OBJECTS_SOLIDITY,
+            tags.DOMAIN_PLACES,
+            tags.DOMAIN_PLACES_LOCALIZATION,
+            tags.DOMAIN_PLACES_NAVIGATION
+        ],
+        'type_list': [
+            tags.INTERACTIVE,
+            tags.ACTION_FULL,
+            GoalCategory.TRAVERSAL.value
+        ],
         'last_step': InteractionGoal.LAST_STEP
     }
 

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -11,8 +11,9 @@ import materials
 import math
 import objects
 import ramps
+import tags
 import util
-from goal import Goal
+from goal import Goal, GoalCategory
 from util import finalize_object_definition, instantiate_object
 
 
@@ -25,6 +26,9 @@ WALL_DEPTH = 0.1
 
 class IntPhysGoal(Goal, ABC):
     """Base class for Intuitive Physics goals. Subclasses must set TEMPLATE variable (for use in get_config)."""
+
+    PLAUSIBLE = 'plausible'
+    IMPLAUSIBLE = 'implausible'
 
     # The 3.55 or 4.2 is the position at which the object will leave the camera's viewport, and is dependent on the
     # object's Z position (either 1.6 or 2.7). The * 1.2 is to account for the camera's perspective.
@@ -111,7 +115,7 @@ class IntPhysGoal(Goal, ABC):
 
         body['observation'] = True
         body['answer'] = {
-            'choice': 'plausible'
+            'choice': IntPhysGoal.PLAUSIBLE
         }
         return body
 
@@ -125,9 +129,9 @@ class IntPhysGoal(Goal, ABC):
         goal['action_list'] = [['Pass']] * goal['last_step']
         if self._object_creator:
             if self._object_creator == IntPhysGoal._get_objects_and_occluders_moving_across:
-                goal['type_list'].append('move across')
+                goal['type_list'].append(tags.INTPHYS_MOVE_ACROSS)
             elif self._object_creator == IntPhysGoal._get_objects_falling_down:
-                goal['type_list'].append('fall down')
+                goal['type_list'].append(tags.INTPHYS_FALL_DOWN)
         return goal
 
     def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
@@ -518,13 +522,22 @@ class IntPhysGoal(Goal, ABC):
 
 class GravityGoal(IntPhysGoal):
     TEMPLATE = {
-        'category': 'intphys',
-        'domain_list': ['objects', 'object solidity', 'object motion', 'gravity'],
-        'type_list': ['passive', 'action none', 'intphys', 'gravity'],
-        'task_list': ['choose'],
+        'category': GoalCategory.INTPHYS.value,
+        'domain_list': [
+            tags.DOMAIN_OBJECTS,
+            tags.DOMAIN_OBJECTS_GRAVITY,
+            tags.DOMAIN_OBJECTS_MOTION,
+            tags.DOMAIN_OBJECTS_SOLIDITY
+        ],
+        'type_list': [
+            tags.PASSIVE,
+            tags.ACTION_NONE,
+            GoalCategory.INTPHYS.value,
+            tags.INTPHYS_GRAVITY
+        ],
         'description': '',
         'metadata': {
-            'choose': ['plausible', 'implausible']
+            'choose': [IntPhysGoal.PLAUSIBLE, IntPhysGoal.IMPLAUSIBLE]
         }
     }
 
@@ -641,18 +654,29 @@ class GravityGoal(IntPhysGoal):
 
     def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         goal = super(GravityGoal, self)._get_subclass_config(goal_objects)
-        goal['type_list'].append('ramp ' + self._ramp_type.value)
+        goal['type_list'].append(tags.get_ramp_tag(self._ramp_type.value))
         return goal
 
 
 class ObjectPermanenceGoal(IntPhysGoal):
     TEMPLATE = {
-        'category': 'intphys',
-        'domain_list': ['objects', 'object solidity', 'object motion', 'object permanence'],
-        'type_list': ['passive', 'action none', 'intphys', 'object permanence'],
-        'task_list': ['choose'],
+        'category': GoalCategory.INTPHYS.value,
+        'domain_list': [
+            tags.DOMAIN_OBJECTS,
+            tags.DOMAIN_OBJECTS_MOTION,
+            tags.DOMAIN_OBJECTS_PERMANENCE,
+            tags.DOMAIN_OBJECTS_SOLIDITY
+        ],
+        'type_list': [
+            tags.PASSIVE,
+            tags.ACTION_NONE,
+            GoalCategory.INTPHYS.value,
+            tags.INTPHYS_OBJECT_PERMANENCE
+        ],
         'description': '',
-        'metadata': {}
+        'metadata': {
+            'choose': [IntPhysGoal.PLAUSIBLE, IntPhysGoal.IMPLAUSIBLE]
+        }
     }
 
     def __init__(self):
@@ -661,12 +685,23 @@ class ObjectPermanenceGoal(IntPhysGoal):
 
 class ShapeConstancyGoal(IntPhysGoal):
     TEMPLATE = {
-        'category': 'intphys',
-        'domain_list': ['objects', 'object solidity', 'object motion', 'object permanence'],
-        'type_list': ['passive', 'action none', 'intphys', 'shape constancy'],
-        'task_list': ['choose'],
+        'category': GoalCategory.INTPHYS.value,
+        'domain_list': [
+            tags.DOMAIN_OBJECTS,
+            tags.DOMAIN_OBJECTS_MOTION,
+            tags.DOMAIN_OBJECTS_PERMANENCE,
+            tags.DOMAIN_OBJECTS_SOLIDITY
+        ],
+        'type_list': [
+            tags.PASSIVE,
+            tags.ACTION_NONE,
+            GoalCategory.INTPHYS.value,
+            tags.INTPHYS_SHAPE_CONSTANCY
+        ],
         'description': '',
-        'metadata': {}
+        'metadata': {
+            'choose': [IntPhysGoal.PLAUSIBLE, IntPhysGoal.IMPLAUSIBLE]
+        }
     }
 
     def __init__(self):
@@ -675,12 +710,23 @@ class ShapeConstancyGoal(IntPhysGoal):
 
 class SpatioTemporalContinuityGoal(IntPhysGoal):
     TEMPLATE = {
-        'category': 'intphys',
-        'domain_list': ['objects', 'object solidity', 'object motion', 'object permanence'],
-        'type_list': ['passive', 'action none', 'intphys', 'spatio temporal continuity'],
-        'task_list': ['choose'],
+        'category': GoalCategory.INTPHYS.value,
+        'domain_list': [
+            tags.DOMAIN_OBJECTS,
+            tags.DOMAIN_OBJECTS_MOTION,
+            tags.DOMAIN_OBJECTS_PERMANENCE,
+            tags.DOMAIN_OBJECTS_SOLIDITY
+        ],
+        'type_list': [
+            tags.PASSIVE,
+            tags.ACTION_NONE,
+            GoalCategory.INTPHYS.value,
+            tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY
+        ],
         'description': '',
-        'metadata': {}
+        'metadata': {
+            'choose': [IntPhysGoal.PLAUSIBLE, IntPhysGoal.IMPLAUSIBLE]
+        }
     }
 
     def __init__(self):

--- a/scene_generator/intphys_goals_test.py
+++ b/scene_generator/intphys_goals_test.py
@@ -45,7 +45,7 @@ def test_GravityGoal_update_body():
     assert body['goal']['last_step'] > 0
     assert body['goal']['action_list'] == [['Pass']] * body['goal']['last_step']
     assert body['goal']['category'] == 'intphys'
-    assert body['goal']['domain_list'] == ['objects', 'object solidity', 'object motion', 'gravity']
+    assert set(body['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'gravity'])
     assert 'passive' in body['goal']['type_list']
     assert 'action none' in body['goal']['type_list']
     assert 'intphys' in body['goal']['type_list']
@@ -76,7 +76,7 @@ def test_ObjectPermanenceGoal_update_body():
     assert body['goal']['last_step'] > 0
     assert body['goal']['action_list'] == [['Pass']] * body['goal']['last_step']
     assert body['goal']['category'] == 'intphys'
-    assert body['goal']['domain_list'] == ['objects', 'object solidity', 'object motion', 'object permanence']
+    assert set(body['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'object permanence'])
     assert 'passive' in body['goal']['type_list']
     assert 'action none' in body['goal']['type_list']
     assert 'intphys' in body['goal']['type_list']
@@ -104,7 +104,7 @@ def test_ShapeConstancyGoal_update_body():
     assert body['goal']['last_step'] > 0
     assert body['goal']['action_list'] == [['Pass']] * body['goal']['last_step']
     assert body['goal']['category'] == 'intphys'
-    assert body['goal']['domain_list'] == ['objects', 'object solidity', 'object motion', 'object permanence']
+    assert set(body['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'object permanence'])
     assert 'passive' in body['goal']['type_list']
     assert 'action none' in body['goal']['type_list']
     assert 'intphys' in body['goal']['type_list']
@@ -132,7 +132,7 @@ def test_SpatioTemporalContinuityGoal_update_body():
     assert body['goal']['last_step'] > 0
     assert body['goal']['action_list'] == [['Pass']] * body['goal']['last_step']
     assert body['goal']['category'] == 'intphys'
-    assert body['goal']['domain_list'] == ['objects', 'object solidity', 'object motion', 'object permanence']
+    assert set(body['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'object permanence'])
     assert 'passive' in body['goal']['type_list']
     assert 'action none' in body['goal']['type_list']
     assert 'intphys' in body['goal']['type_list']

--- a/scene_generator/pairs.py
+++ b/scene_generator/pairs.py
@@ -14,6 +14,7 @@ import geometry
 import goals
 from interaction_goals import DistractorObjectRule, InteractionGoal, ObjectRule
 import objects
+import tags
 import util
 
 
@@ -114,80 +115,72 @@ class InteractionPair():
         """Return both scenes of this pair."""
         return self._scene_1, self._scene_2
 
-    def _get_both_goal_type_list(self, options: SceneOptions, number: int, \
+    def _get_both_goal_type_list(self, options: SceneOptions, prefix: str, \
             is_true_func: Callable[[BoolPairOption], bool]) -> List[str]:
         """Return the type list for a goal using the given scene options."""
 
         type_list = [self.get_name()]
-
-        if is_true_func(options.target_containerize):
-            type_list.append(f'pair scene {number} target is hidden inside receptacle')
-        else:
-            type_list.append(f'pair scene {number} target isn\'t hidden inside receptacle')
+        type_list.append(f'{prefix} target {tags.get_containerize_tag(is_true_func(options.target_containerize))}')
+        type_list.append(f'{prefix} confusor {tags.get_exists_tag(is_true_func(options.confusor))}')
 
         if is_true_func(options.confusor):
-            type_list.append(f'pair scene {number} confusor does exist')
-            if is_true_func(options.confusor_containerize):
-                type_list.append(f'pair scene {number} confusor is hidden inside receptacle')
-            else:
-                type_list.append(f'pair scene {number} confusor isn\'t hidden inside receptacle')
-        else:
-            type_list.append(f'pair scene {number} confusor doesn\'t exist')
+            type_list.append( \
+                    f'{prefix} confusor {tags.get_containerize_tag(is_true_func(options.confusor_containerize))}')
 
         return type_list
 
     def _get_goal_type_list_1(self, options: SceneOptions) -> List[str]:
         """Return the type list for goal 1 using the given scene options."""
 
-        type_list = self._get_both_goal_type_list(options, 1, self._is_true_goal_1)
+        prefix = 'pair scene 1'
+        type_list = self._get_both_goal_type_list(options, prefix, self._is_true_goal_1)
 
         if options.target_location == TargetLocationPairOption.FRONT_BACK or \
                 options.target_location == TargetLocationPairOption.FRONT_FRONT:
-            type_list.append('pair scene 1 target location in front of performer start')
+            type_list.append(f'{prefix} target {tags.OBJECT_LOCATION_FRONT}')
         else:
-            type_list.append('pair scene 1 target location random')
+            type_list.append(f'{prefix} target {tags.OBJECT_LOCATION_RANDOM}')
 
         if self._is_true_goal_1(options.confusor):
             if options.confusor_location == ConfusorLocationPairOption.BACK_FRONT:
-                type_list.append('pair scene 1 confusor location in back of performer start')
+                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_BACK}')
             elif options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or \
                     options.confusor_location == ConfusorLocationPairOption.CLOSE_FAR:
-                type_list.append('pair scene 1 confusor location very close to target')
+                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_CLOSE}')
 
-        type_list.append(f'pair scene 1 obstructor doesn\'t exist')
+        type_list.append(f'{prefix} obstructor {tags.get_exists_tag(False)}')
 
         return type_list
 
     def _get_goal_type_list_2(self, options: SceneOptions) -> List[str]:
         """Return the type list for goal 2 using the given scene options."""
 
-        type_list = self._get_both_goal_type_list(options, 2, self._is_true_goal_2)
+        prefix = 'pair scene 2'
+        type_list = self._get_both_goal_type_list(options, prefix, self._is_true_goal_2)
 
         if options.target_location == TargetLocationPairOption.FRONT_BACK:
-            type_list.append('pair scene 2 target location in back of performer start')
+            type_list.append(f'{prefix} target {tags.OBJECT_LOCATION_BACK}')
         elif options.target_location == TargetLocationPairOption.FRONT_FRONT:
-            type_list.append('pair scene 2 target location in front of performer start')
+            type_list.append(f'{prefix} target {tags.OBJECT_LOCATION_FRONT}')
         else:
-            type_list.append('pair scene 2 target location random')
+            type_list.append(f'{prefix} target {tags.OBJECT_LOCATION_RANDOM}')
 
         if self._is_true_goal_2(options.confusor):
             if options.confusor_location == ConfusorLocationPairOption.BACK_FRONT:
-                type_list.append('pair scene 2 confusor location in front of performer start')
+                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_FRONT}')
             elif options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or \
                     options.confusor_location == ConfusorLocationPairOption.NONE_CLOSE:
-                type_list.append('pair scene 2 confusor location very close to target')
+                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_CLOSE}')
             elif options.confusor_location == ConfusorLocationPairOption.CLOSE_FAR or \
                     options.confusor_location == ConfusorLocationPairOption.NONE_FAR:
-                type_list.append('pair scene 2 confusor location far away from target')
+                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_FAR}')
 
-        if options.obstructor == ObstructorPairOption.NONE_NONE:
-            type_list.append(f'pair scene 2 obstructor doesn\'t exist')
-        else:
-            type_list.append(f'pair scene 2 obstructor does exist')
-            if options.obstructor == ObstructorPairOption.NONE_VISION:
-                type_list.append(f'pair scene 2 obstructor does obstruct vision')
-            else:
-                type_list.append(f'pair scene 2 obstructor doesn\'t obstruct vision')
+        type_list.append( \
+                f'{prefix} obstructor {tags.get_exists_tag(options.obstructor != ObstructorPairOption.NONE_NONE)}')
+
+        if options.obstructor != ObstructorPairOption.NONE_NONE:
+            obstruct_vision = (tags.get_obstruct_vision_tag(options.obstructor == ObstructorPairOption.NONE_VISION))
+            type_list.append(f'{prefix} obstructor {obstruct_vision}')
 
         return type_list
 

--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -9,6 +9,7 @@ import goal
 import intphys_goals
 import objects
 import ramps
+import tags
 import util
 
 
@@ -89,20 +90,20 @@ class ObjectPermanenceQuartet(Quartet):
             return self._scenes[q - 1]
         scene = copy.deepcopy(self._scene_template)
         if q == 1:
-            scene['goal']['type_list'].append('object permanence show object')
+            scene['goal']['type_list'].append(tags.INTPHYS_OBJECT_PERMANENCE_Q1)
         elif q == 2:
             # target moves behind occluder and disappears (implausible)
-            scene['answer']['choice'] = 'implausible'
-            scene['goal']['type_list'].append('object permanence show then hide object')
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
+            scene['goal']['type_list'].append(tags.INTPHYS_OBJECT_PERMANENCE_Q2)
             self._disappear_behind_occluder(scene)
         elif q == 3:
             # target first appears from behind occluder (implausible)
-            scene['answer']['choice'] = 'implausible'
-            scene['goal']['type_list'].append('object permanence hide then show object')
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
+            scene['goal']['type_list'].append(tags.INTPHYS_OBJECT_PERMANENCE_Q3)
             self._appear_behind_occluder(scene)
         elif q == 4:
             # target not in the scene (plausible)
-            scene['goal']['type_list'].append('object permanence hide object')
+            scene['goal']['type_list'].append(tags.INTPHYS_OBJECT_PERMANENCE_Q4)
             target_id = self._goal._tag_to_objects['target'][0]['id']
             for i in range(len(scene['objects'])):
                 obj = scene['objects'][i]
@@ -186,7 +187,7 @@ class SpatioTemporalContinuityQuartet(Quartet):
                     'stepBegin': target['shows'][0]['stepBegin'] + destination_index + 1,
                     'position': position
                 })
-                scene['goal']['type_list'].append('teleport_delayed')
+                scene['goal']['type_list'].append(tags.INTPHYS_TELEPORT_DELAYED)
             else:
                 # teleport the target
                 target['teleports'] = [{
@@ -194,7 +195,7 @@ class SpatioTemporalContinuityQuartet(Quartet):
                     'stepEnd': implausible_event_step,
                     'position': position
                 }]
-                scene['goal']['type_list'].append('teleport_instantaneous')
+                scene['goal']['type_list'].append(tags.INTPHYS_TELEPORT_INSTANTANEOUS)
 
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             # 8 is enough for it to fall to the ground
@@ -316,17 +317,17 @@ class SpatioTemporalContinuityQuartet(Quartet):
             return self._scenes[q - 1]
         scene = copy.deepcopy(self._scene_template)
         if q == 1:
-            scene['goal']['type_list'].append('spatio temporal continuity move earlier')
+            scene['goal']['type_list'].append(tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q1)
         elif q == 2:
-            scene['answer']['choice'] = 'implausible'
-            scene['goal']['type_list'].append('spatio temporal continuity teleport forward')
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
+            scene['goal']['type_list'].append(tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q2)
             self._teleport_forward(scene)
         elif q == 3:
-            scene['answer']['choice'] = 'implausible'
-            scene['goal']['type_list'].append('spatio temporal continuity teleport backward')
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
+            scene['goal']['type_list'].append(tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q3)
             self._teleport_backward(scene)
         elif q == 4:
-            scene['goal']['type_list'].append('spatio temporal continuity move later')
+            scene['goal']['type_list'].append(tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q4)
             self._move_later(scene)
         self._scenes[q - 1] = scene
         return scene
@@ -430,29 +431,30 @@ class ShapeConstancyQuartet(Quartet):
             return self._scenes[q - 1]
         scene = copy.deepcopy(self._scene_template)
         if q == 1:
-            scene['goal']['type_list'].append('shape constancy object one')
+            scene['goal']['type_list'].append(tags.INTPHYS_SHAPE_CONSTANCY_Q1)
         elif q == 2:
             # Object A moves behind an occluder, then object B emerges
             # from behind the occluder (implausible)
-            scene['answer']['choice'] = 'implausible'
-            scene['goal']['type_list'].append('shape constancy object one into two')
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
+            scene['goal']['type_list'].append(tags.INTPHYS_SHAPE_CONSTANCY_Q2)
             self._turn_a_into_b(scene)
         elif q == 3:
             # Object B moves behind an occluder (replacing object A's
             # movement), then object A emerges from behind the
             # occluder (implausible)
-            scene['answer']['choice'] = 'implausible'
-            scene['goal']['type_list'].append('shape constancy object two into one')
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
+            scene['goal']['type_list'].append(tags.INTPHYS_SHAPE_CONSTANCY_Q3)
             self._turn_b_into_a(scene)
         elif q == 4:
             # Object B moves normally (replacing object A's movement),
             # object A is never added to the scene (plausible)
-            scene['goal']['type_list'].append('shape constancy object two')
+            scene['goal']['type_list'].append(tags.INTPHYS_SHAPE_CONSTANCY_Q4)
             self._b_replaces_a(scene)
         # May have added and/or deleted an object, so regenerate
         # goal.info_list
         del scene['goal']['info_list']
-        self._goal._update_goal_info_list(scene['goal'], self._goal._tag_to_objects)
+        scene['info_list'] = self._goal.update_goal_info_list(scene['goal'].get('info_list', []), \
+                self._goal._tag_to_objects)
         self._scenes[q - 1] = scene
         logging.debug(f'get_scene: q={q}\thides? {scene["objects"][0].get("hides", None)}')
         return scene
@@ -504,7 +506,7 @@ class GravityQuartet(Quartet):
             # all the 'position_by_step' values for the slow speed to
             # get the top-of-ramp value.
         if q == 3 or q == 4:
-            scene['answer']['choice'] = 'implausible'
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
             _, top_offset = self._get_ramp_offsets()
             logging.debug(f'top_offset={top_offset}')
             implausible_x_start = target['intphys_option']['ramp_x_term'] + top_offset
@@ -520,29 +522,29 @@ class GravityQuartet(Quartet):
             target['forces'][0]['stepEnd'] = implausible_step - 1
 
         if q == 1:
-            scene['goal']['type_list'].append('gravity ramp fast further')
+            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_TRAJECTORY_Q1)
         elif q == 2:
-            scene['goal']['type_list'].append('gravity ramp slow shorter')
+            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_TRAJECTORY_Q2)
         elif q == 3:
-            scene['goal']['type_list'].append('gravity ramp fast shorter')
+            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_TRAJECTORY_Q3)
         elif q == 4:
-            scene['goal']['type_list'].append('gravity ramp slow further')
+            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_TRAJECTORY_Q4)
 
         return scene
 
     def _get_gentle_scene(self, scene: Dict[str, Any], q: int) -> Dict[str, Any]:
         if q == 1:
-            scene['goal']['type_list'].append('gravity ramp up slower')
+            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_ACCELERATION_Q1)
         elif q == 2:
-            scene['goal']['type_list'].append('gravity ramp down faster')
+            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_ACCELERATION_Q2)
             self._make_roll_down(scene)
         elif q == 3:
-            scene['answer']['choice'] = 'implausible'
-            scene['goal']['type_list'].append('gravity ramp up faster')
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
+            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_ACCELERATION_Q3)
             self._make_object_faster(scene)
         elif q == 4:
-            scene['answer']['choice'] = 'implausible'
-            scene['goal']['type_list'].append('gravity ramp down slower')
+            scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
+            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_ACCELERATION_Q4)
             self._make_roll_down(scene)
             self._make_object_slower(scene)
         return scene

--- a/scene_generator/quartets_test.py
+++ b/scene_generator/quartets_test.py
@@ -31,7 +31,8 @@ def test_STCQ_get_scene():
         assert scene['goal']['last_step'] == scene_1['goal']['last_step']
         assert scene['goal']['action_list'] == [['Pass']] * scene['goal']['last_step']
         assert scene['goal']['category'] == 'intphys'
-        assert scene['goal']['domain_list'] == ['objects', 'object solidity', 'object motion', 'object permanence']
+        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', \
+                'object permanence'])
         assert 'passive' in scene['goal']['type_list']
         assert 'action none' in scene['goal']['type_list']
         assert 'intphys' in scene['goal']['type_list']
@@ -126,7 +127,8 @@ def test_ShapeConstancyQuartet_get_scene():
         assert scene['goal']['last_step'] == scene_1['goal']['last_step']
         assert scene['goal']['action_list'] == [['Pass']] * scene['goal']['last_step']
         assert scene['goal']['category'] == 'intphys'
-        assert scene['goal']['domain_list'] == ['objects', 'object solidity', 'object motion', 'object permanence']
+        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', \
+                'object permanence'])
         assert 'passive' in scene['goal']['type_list']
         assert 'action none' in scene['goal']['type_list']
         assert 'intphys' in scene['goal']['type_list']
@@ -204,7 +206,8 @@ def test_ObjectPermanenceQuartet_get_scene():
         assert scene['goal']['last_step'] == scene_1['goal']['last_step']
         assert scene['goal']['action_list'] == [['Pass']] * scene['goal']['last_step']
         assert scene['goal']['category'] == 'intphys'
-        assert scene['goal']['domain_list'] == ['objects', 'object solidity', 'object motion', 'object permanence']
+        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', \
+                'object permanence'])
         assert 'passive' in scene['goal']['type_list']
         assert 'action none' in scene['goal']['type_list']
         assert 'intphys' in scene['goal']['type_list']
@@ -263,7 +266,7 @@ def test_GravityQuartet_get_scene():
         assert scene['goal']['last_step'] == scene_1['goal']['last_step']
         assert scene['goal']['action_list'] == [['Pass']] * scene['goal']['last_step']
         assert scene['goal']['category'] == 'intphys'
-        assert scene['goal']['domain_list'] == ['objects', 'object solidity', 'object motion', 'gravity']
+        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'gravity'])
         assert 'passive' in scene['goal']['type_list']
         assert 'action none' in scene['goal']['type_list']
         assert 'intphys' in scene['goal']['type_list']

--- a/scene_generator/tags.py
+++ b/scene_generator/tags.py
@@ -1,0 +1,115 @@
+from typing import Any, Dict, List
+
+# SHARED TAGS
+
+INTERACTIVE = 'interactive'
+PASSIVE = 'passive'
+
+ACTION_NONE = 'action none'
+ACTION_SOME = 'action some'
+ACTION_FULL = 'action full'
+
+# INTPHYS GOAL AND QUARTET TAGS
+
+INTPHYS_FALL_DOWN = 'fall down'
+INTPHYS_MOVE_ACROSS = 'move across'
+
+INTPHYS_TELEPORT_DELAYED = 'teleport delayed'
+INTPHYS_TELEPORT_INSTANTANEOUS = 'teleport instantaneous'
+
+INTPHYS_GRAVITY = 'gravity'
+INTPHYS_GRAVITY_ACCELERATION_Q1 = 'gravity ramp up slower'
+INTPHYS_GRAVITY_ACCELERATION_Q2 = 'gravity ramp down faster'
+INTPHYS_GRAVITY_ACCELERATION_Q3 = 'gravity ramp up faster'
+INTPHYS_GRAVITY_ACCELERATION_Q4 = 'gravity ramp down slower'
+INTPHYS_GRAVITY_TRAJECTORY_Q1 = 'gravity ramp fast further'
+INTPHYS_GRAVITY_TRAJECTORY_Q2 = 'gravity ramp slow shorter'
+INTPHYS_GRAVITY_TRAJECTORY_Q3 = 'gravity ramp fast shorter'
+INTPHYS_GRAVITY_TRAJECTORY_Q4 = 'gravity ramp slow further'
+
+INTPHYS_OBJECT_PERMANENCE = 'object permanence'
+INTPHYS_OBJECT_PERMANENCE_Q1 = 'object permanence show object'
+INTPHYS_OBJECT_PERMANENCE_Q2 = 'object permanence show then hide object'
+INTPHYS_OBJECT_PERMANENCE_Q3 = 'object permanence hide then show object'
+INTPHYS_OBJECT_PERMANENCE_Q4 = 'object permanence hide object'
+
+INTPHYS_SHAPE_CONSTANCY = 'shape constancy'
+INTPHYS_SHAPE_CONSTANCY_Q1 = 'shape constancy object one'
+INTPHYS_SHAPE_CONSTANCY_Q2 = 'shape constancy object one into two'
+INTPHYS_SHAPE_CONSTANCY_Q3 = 'shape constancy object two into one'
+INTPHYS_SHAPE_CONSTANCY_Q4 = 'shape constancy object two'
+
+INTPHYS_SPATIO_TEMPORAL_CONTINUITY = 'spatio temporal continuity'
+INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q1 = 'spatio temporal continuity move earlier'
+INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q2 = 'spatio temporal continuity teleport forward'
+INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q3 = 'spatio temporal continuity teleport backward'
+INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q4 = 'spatio temporal continuity move later'
+
+# MCS CORE DOMAIN TAGS
+
+DOMAIN_OBJECTS = 'objects'
+DOMAIN_OBJECTS_GRAVITY = 'gravity'
+DOMAIN_OBJECTS_MOTION = 'object motion'
+DOMAIN_OBJECTS_PERMANENCE = 'object permanence'
+DOMAIN_OBJECTS_SOLIDITY = 'object solidity'
+
+DOMAIN_PLACES = 'places'
+DOMAIN_PLACES_LOCALIZATION = 'localization'
+DOMAIN_PLACES_NAVIGATION = 'navigation'
+
+# OBJECT TAGS
+
+OBJECT_LOCATION_BACK = 'location in back of performer start'
+OBJECT_LOCATION_CLOSE = 'location very close to target'
+OBJECT_LOCATION_FAR = 'location far away from target'
+OBJECT_LOCATION_FRONT = 'location in front of performer start'
+OBJECT_LOCATION_RANDOM = 'location random'
+
+
+def append_object_tags(tags: List[str], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> List[str]:
+    append_object_tags_of_type(tags, tag_to_objects['target'], 'target')
+    if 'confusor' in tag_to_objects:
+        append_object_tags_of_type(tags, tag_to_objects['confusor'], 'confusor')
+    if 'distractor' in tag_to_objects:
+        append_object_tags_of_type(tags, tag_to_objects['distractor'], 'distractor')
+    if 'obstructor' in tag_to_objects:
+        append_object_tags_of_type(tags, tag_to_objects['obstructor'], 'obstructor')
+    for item in ['background object', 'confusor', 'distractor', 'obstructor', 'occluder', 'target', 'wall']:
+        if item in tag_to_objects:
+            number = len(tag_to_objects[item])
+            if item == 'occluder':
+                number = (int)(number / 2)
+            tags.append(item + 's ' + str(number))
+    return tags
+
+
+def append_object_tags_of_type(tags: List[str], objs: List[Dict[str, Any]], name: str) -> List[str]:
+    for obj in objs:
+        enclosed_tag = (name + ' not enclosed') if obj.get('locationParent', None) is None else (name + ' enclosed')
+        novel_color_tag = (name + ' novel color') if 'novel_color' in obj and obj['novel_color'] else \
+                (name + ' not novel color')
+        novel_combination_tag = (name + ' novel combination') if 'novel_combination' in obj and \
+                obj['novel_combination'] else (name + ' not novel combination')
+        novel_shape_tag = (name + ' novel shape') if 'novel_shape' in obj and obj['novel_shape'] else \
+                (name + ' not novel shape')
+        for new_tag in [enclosed_tag, novel_color_tag, novel_combination_tag, novel_shape_tag]:
+            if new_tag not in tags:
+                tags.append(new_tag)
+    return tags
+
+
+def get_containerize_tag(containerize: bool) -> str:
+    return ('is' if containerize else 'isn\'t') + ' hidden inside rececptacle'
+
+
+def get_exists_tag(exists: bool) -> str:
+    return ('does' if exists else 'doesn\'t') + ' exist'
+
+
+def get_obstruct_vision_tag(obstruct_vision: bool) -> str:
+    return ('does' if obstruct_vision else 'doesn\'t') + ' obstruct vision'
+
+
+def get_ramp_tag(ramp_type_string: str) -> str:
+    return 'ramp ' + ramp_type_string
+


### PR DESCRIPTION
- Moved scene generator tags from specific goals, pairs, and quartets into separate tags file.
- Added missing properties to Python MCS Goal class.
- Updated Python API documentation.
- Removed the task_list, because I don't think it's really that important.
- Minor cleanup.