### PR TITLE
MCS-315 Scene Generator Unit Tests: Pairs, Interactive Goals, Geometry/Util Functions

### DIFF
--- a/scene_generator/README.md
+++ b/scene_generator/README.md
@@ -38,6 +38,8 @@ python3 scene_generator.py --prefix my_scene -c 10 --goal Retrieval --find_path
 
 ## Testing
 
+Please note that the tests will take a few minutes to run!
+
 ```
 python3 -m pytest *_test.py
 ```

--- a/scene_generator/containers.py
+++ b/scene_generator/containers.py
@@ -47,6 +47,8 @@ def put_objects_in_container(obj_def_a: Dict[str, Any], obj_a: Dict[str, Any], o
     if rot_b not in (0, 90):
         raise ValueError('only 0 and 90 degree rotations supported for object b, not {rot_b}')
 
+    # TODO This function should probably verify that both objects can fit together inside the container...
+
     area = container_def['enclosed_areas'][area_index]
     obj_a['locationParent'] = container['id']
     obj_b['locationParent'] = container['id']
@@ -263,44 +265,7 @@ def can_contain_both(container_def: Dict[str, Any],
     return None
 
 
-def get_enclosable_container_defs(objs: Sequence[Dict[str, Any]],
-                                  container_defs: Sequence[Dict[str, Any]] = None) \
-                                  -> List[Dict[str, Any]]:
-    """Return a list of object definitions for containers that can enclose
-    all the passed objects objs. If container_defs is None, use
-    objects.get_enclosed_containers().
-    """
-    if container_defs is None:
-        container_defs = objects.get_enclosed_containers()
-    valid_container_defs = []
-    for container_def in container_defs:
-        containment = how_can_contain(container_def, *objs)
-        if containment is not None:
-            valid_container_defs.append(container_def)
-        elif 'choose' in container_def:
-            # try choose
-            valid_choices = []
-            for choice in container_def['choose']:
-                containment = how_can_contain(choice, *objs)
-                if containment is not None:
-                    valid_choices.append(choice)
-            if len(valid_choices) > 0:
-                if len(valid_choices) == len(container_def['choose']):
-                    valid_container_defs.append(container_def)
-                else:
-                    new_def = copy.deepcopy(container_def)
-                    new_def['choose'] = valid_choices
-                    valid_container_defs.append(new_def)
-    return valid_container_defs
-
-
-def get_parent(obj: Dict[str, Any], all_objects: Iterable[Dict[str, Any]]) \
-        -> Dict[str, Any]:
-    parent_id = obj['locationParent']
-    parent = next((o for o in all_objects if o['id'] == parent_id))
-    return parent
-
-
+# TODO Can we delete this function and just use get_enclosable_containments instead?
 def find_suitable_enclosable_list(obj: Dict[str, Any], container_defs: Sequence[Dict[str, Any]] = None) -> \
         List[Dict[str, Any]]:
     """Find and return the list of enclosable receptacle definitions into which the given object can fit."""

--- a/scene_generator/containers_test.py
+++ b/scene_generator/containers_test.py
@@ -1,44 +1,59 @@
+import pytest
 import random
 
 import geometry
 import objects
 import util
 from containers import put_object_in_container, put_objects_in_container, Orientation, can_enclose, \
-    can_contain_both, how_can_contain
+    can_contain_both, how_can_contain, get_enclosable_containments, find_suitable_enclosable_list
 from geometry_test import are_adjacent
 
 
 def test_put_object_in_container():
     obj_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-    obj_location = geometry.calc_obj_pos(geometry.ORIGIN, [], obj_def)
+    obj_location = geometry.calc_obj_pos({'x': 1, 'y': 0, 'z': 1}, [], obj_def)
     obj = util.instantiate_object(obj_def, obj_location)
+    obj_bounds = obj['shows'][0]['bounding_box']
     container_def = util.finalize_object_definition(random.choice(objects.get_enclosed_containers()))
-    container_location = geometry.calc_obj_pos(geometry.ORIGIN, [], container_def)
+    container_location = geometry.calc_obj_pos({'x': -1, 'y': 0, 'z': -1}, [], container_def)
     container = util.instantiate_object(container_def, container_location)
 
-    put_object_in_container(obj_def, obj, container, container_def, 0)
+    area_index = 0
+    put_object_in_container(obj_def, obj, container, container_def, area_index)
+
     assert obj['locationParent'] == container['id']
     assert obj['shows'][0]['position']['x'] == container_def['enclosed_areas'][0]['position']['x']
-    assert obj['shows'][0]['position']['y'] == container_def['enclosed_areas'][0]['position']['y'] - \
-            (container_def['enclosed_areas'][0]['dimensions']['y'] / 2.0) + obj_def.get('position_y', 0)
+    expected_position_y = container_def['enclosed_areas'][0]['position']['y'] - \
+            (container_def['enclosed_areas'][area_index]['dimensions']['y'] / 2.0) + obj_def.get('position_y', 0)
+    assert obj['shows'][0]['position']['y'] == pytest.approx(expected_position_y)
     assert obj['shows'][0]['position']['z'] == container_def['enclosed_areas'][0]['position']['z']
+    assert obj['shows'][0]['rotation']
+    assert obj['shows'][0]['bounding_box']
+    assert obj['shows'][0]['bounding_box'] != obj_bounds
 
 
 def test_put_objects_in_container():
     obj_a_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
     obj_a_location = geometry.calc_obj_pos(geometry.ORIGIN, [], obj_a_def)
     obj_a = util.instantiate_object(obj_a_def, obj_a_location)
+    obj_a_bounds = obj_a['shows'][0]['bounding_box']
     obj_b_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
     obj_b_location = geometry.calc_obj_pos(geometry.ORIGIN, [], obj_b_def)
     obj_b = util.instantiate_object(obj_b_def, obj_b_location)
+    obj_b_bounds = obj_b['shows'][0]['bounding_box']
     container_def = util.finalize_object_definition(random.choice(objects.get_enclosed_containers()))
     container_location = geometry.calc_obj_pos(geometry.ORIGIN, [], container_def)
     container = util.instantiate_object(container_def, container_location)
 
-    put_objects_in_container(obj_a_def, obj_a, obj_b_def, obj_b, container, container_def, 0,
+    area_index = 0
+    put_objects_in_container(obj_a_def, obj_a, obj_b_def, obj_b, container, container_def, area_index,
                              Orientation.SIDE_BY_SIDE, 0, 0)
     assert obj_a['locationParent'] == container['id']
     assert obj_b['locationParent'] == container['id']
+    assert obj_a['shows'][0]['bounding_box']
+    assert obj_b['shows'][0]['bounding_box']
+    assert obj_a['shows'][0]['bounding_box'] != obj_a_bounds
+    assert obj_b['shows'][0]['bounding_box'] != obj_b_bounds
     assert are_adjacent(obj_a, obj_b)
 
 
@@ -107,3 +122,47 @@ def test_can_contain_both():
     container_def = util.finalize_object_definition(objects.get_enclosed_containers()[0])
     assert can_contain_both(container_def, small1, small2) is not None
     assert can_contain_both(container_def, small1, big) is None
+
+
+def test_get_enclosable_containments():
+    # This test should work with ANY pickupable object
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    containments = get_enclosable_containments([target_definition])
+    assert len(containments) > 0
+    for containment in containments:
+        definition, index, angles = containment
+        assert definition
+        assert index >= 0
+        assert angles
+
+
+def test_get_enclosable_containments_multiple_object():
+    target_definition_1 = {
+        'dimensions': {
+            'x': 0.01,
+            'y': 0.01,
+            'z': 0.01
+        }
+    }
+    target_definition_2 = {
+        'dimensions': {
+            'x': 0.02,
+            'y': 0.02,
+            'z': 0.02
+        }
+    }
+    containments = get_enclosable_containments([target_definition_1, target_definition_2])
+    assert len(containments) > 0
+    for containment in containments:
+        definition, index, angles = containment
+        assert definition
+        assert index >= 0
+        assert angles
+
+
+def test_find_suitable_enclosable_list():
+    # This test should work with ANY pickupable object
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    definition_list = find_suitable_enclosable_list(target_definition)
+    assert len(definition_list) > 0
+

--- a/scene_generator/geometry_test.py
+++ b/scene_generator/geometry_test.py
@@ -405,73 +405,74 @@ def test_get_visible_segment():
 
 
 def test_get_position_in_front_of_performer():
-    # This test should work with ANY pickupable object
-    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
-    target_half_size_x = target_definition['dimensions']['x'] / 2.0
-    target_half_size_z = target_definition['dimensions']['z'] / 2.0
     performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
 
-    performer_start['rotation']['y'] = 0
-    positive_z = get_location_in_front_of_performer(performer_start, target_definition)
-    assert 0 <= positive_z['position']['z'] <= ROOM_Z_MAX
-    assert -target_half_size_x <= positive_z['position']['x'] <= target_half_size_x
+    for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
+        target_half_size_x = target_definition['dimensions']['x'] / 2.0
+        target_half_size_z = target_definition['dimensions']['z'] / 2.0
 
-    performer_start['rotation']['y'] = 90
-    positive_x = get_location_in_front_of_performer(performer_start, target_definition)
-    assert 0 <= positive_x['position']['x'] <= ROOM_X_MAX
-    assert -target_half_size_z <= positive_x['position']['z'] <= target_half_size_z
+        performer_start['rotation']['y'] = 0
+        positive_z = get_location_in_front_of_performer(performer_start, target_definition)
+        assert 0 <= positive_z['position']['z'] <= ROOM_Z_MAX
+        assert -target_half_size_x <= positive_z['position']['x'] <= target_half_size_x
 
-    performer_start['rotation']['y'] = 180
-    negative_z = get_location_in_front_of_performer(performer_start, target_definition)
-    assert ROOM_Z_MIN <= negative_z['position']['z'] <= 0
-    assert -target_half_size_x <= negative_z['position']['x'] <= target_half_size_x
+        performer_start['rotation']['y'] = 90
+        positive_x = get_location_in_front_of_performer(performer_start, target_definition)
+        assert 0 <= positive_x['position']['x'] <= ROOM_X_MAX
+        assert -target_half_size_z <= positive_x['position']['z'] <= target_half_size_z
 
-    performer_start['rotation']['y'] = 270
-    negative_x = get_location_in_front_of_performer(performer_start, target_definition)
-    assert ROOM_X_MIN <= negative_x['position']['x'] <= 0
-    assert -target_half_size_z <= negative_x['position']['z'] <= target_half_size_z
+        performer_start['rotation']['y'] = 180
+        negative_z = get_location_in_front_of_performer(performer_start, target_definition)
+        assert ROOM_Z_MIN <= negative_z['position']['z'] <= 0
+        assert -target_half_size_x <= negative_z['position']['x'] <= target_half_size_x
+
+        performer_start['rotation']['y'] = 270
+        negative_x = get_location_in_front_of_performer(performer_start, target_definition)
+        assert ROOM_X_MIN <= negative_x['position']['x'] <= 0
+        assert -target_half_size_z <= negative_x['position']['z'] <= target_half_size_z
 
 
 def test_get_position_in_front_of_performer_next_to_room_wall():
-    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
     performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
-    performer_start['position']['z'] = ROOM_Z_MAX
-    location = get_location_in_front_of_performer(performer_start, target_definition)
-    assert location is None
+
+    for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
+        performer_start['position']['z'] = ROOM_Z_MAX
+        location = get_location_in_front_of_performer(performer_start, target_definition)
+        assert location is None
 
 
 def test_get_position_in_back_of_performer():
-    # This test should work with ANY pickupable object
-    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
     performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
 
-    performer_start['rotation']['y'] = 0
-    negative_z = get_location_in_back_of_performer(performer_start, target_definition)
-    assert 0 >= negative_z['position']['z'] >= ROOM_Z_MIN
-    assert ROOM_X_MAX >= negative_z['position']['x'] >= ROOM_X_MIN
+    for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
+        performer_start['rotation']['y'] = 0
+        negative_z = get_location_in_back_of_performer(performer_start, target_definition)
+        assert 0 >= negative_z['position']['z'] >= ROOM_Z_MIN
+        assert ROOM_X_MAX >= negative_z['position']['x'] >= ROOM_X_MIN
 
-    performer_start['rotation']['y'] = 90
-    negative_x = get_location_in_back_of_performer(performer_start, target_definition)
-    assert 0 >= negative_x['position']['x'] >= ROOM_X_MIN
-    assert ROOM_Z_MAX >= negative_x['position']['z'] >= ROOM_Z_MIN
+        performer_start['rotation']['y'] = 90
+        negative_x = get_location_in_back_of_performer(performer_start, target_definition)
+        assert 0 >= negative_x['position']['x'] >= ROOM_X_MIN
+        assert ROOM_Z_MAX >= negative_x['position']['z'] >= ROOM_Z_MIN
 
-    performer_start['rotation']['y'] = 180
-    positive_z = get_location_in_back_of_performer(performer_start, target_definition)
-    assert ROOM_Z_MAX >= positive_z['position']['z'] >= 0
-    assert ROOM_X_MAX >= positive_z['position']['x'] >= ROOM_X_MIN
+        performer_start['rotation']['y'] = 180
+        positive_z = get_location_in_back_of_performer(performer_start, target_definition)
+        assert ROOM_Z_MAX >= positive_z['position']['z'] >= 0
+        assert ROOM_X_MAX >= positive_z['position']['x'] >= ROOM_X_MIN
 
-    performer_start['rotation']['y'] = 270
-    positive_x = get_location_in_back_of_performer(performer_start, target_definition)
-    assert ROOM_X_MAX >= positive_x['position']['x'] >= 0
-    assert ROOM_Z_MAX >= positive_x['position']['z'] >= ROOM_Z_MIN
+        performer_start['rotation']['y'] = 270
+        positive_x = get_location_in_back_of_performer(performer_start, target_definition)
+        assert ROOM_X_MAX >= positive_x['position']['x'] >= 0
+        assert ROOM_Z_MAX >= positive_x['position']['z'] >= ROOM_Z_MIN
 
 
 def test_get_position_in_back_of_performer_next_to_room_wall():
-    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
     performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
-    performer_start['position']['z'] = ROOM_Z_MIN
-    location = get_location_in_back_of_performer(performer_start, target_definition)
-    assert location is None
+
+    for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
+        performer_start['position']['z'] = ROOM_Z_MIN
+        location = get_location_in_back_of_performer(performer_start, target_definition)
+        assert location is None
 
 
 def test_are_adjacent():
@@ -618,43 +619,43 @@ def test_are_adjacent_with_offset():
 
 
 def test_get_adjacent_location():
-    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
-    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], \
-            (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
-            target_location['rotation'])
-    target_poly = get_bounding_polygon(target_location)
-    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-
     # Set the performer start out-of-the-way.
     performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
 
-    location = get_adjacent_location(object_definition, target_definition, target_location, performer_start)
-    assert location
-    object_poly = get_bounding_polygon(location)
-    assert object_poly.distance(target_poly) < 0.5
+    for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
+        target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], \
+                (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
+                target_location['rotation'])
+        target_poly = get_bounding_polygon(target_location)
+
+        for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
+            location = get_adjacent_location(object_definition, target_definition, target_location, performer_start)
+            assert location
+            object_poly = get_bounding_polygon(location)
+            assert object_poly.distance(target_poly) < 0.5
 
 
 def test_get_adjacent_location_with_obstruct():
-    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
-    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], \
-            (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
-            target_location['rotation'])
-    target_poly = get_bounding_polygon(target_location)
-
-    # Use the sofa here because it should obstruct any possible pickupable object.
-    sofa_list = [item for item in objects.get_all_object_defs() if 'type' in item and item['type'] == 'sofa_1']
-    object_definition = util.finalize_object_definition(sofa_list[0])
-
     # Set the performer start in the back of the room facing inward.
     performer_start = {'position': {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, 'rotation': {'y': 0}}
 
-    location = get_adjacent_location(object_definition, target_definition, target_location, performer_start, True)
-    assert location
-    object_poly = get_bounding_polygon(location)
-    assert object_poly.distance(target_poly) < 0.5
-    assert does_fully_obstruct_target(performer_start['position'], target_location, object_poly)
+    # Use the sofa in this test because it should obstruct any possible pickupable object.
+    sofa_list = [item for item in objects.get_all_object_defs() if 'type' in item and item['type'] == 'sofa_1']
+    object_definition = util.finalize_object_definition(sofa_list[0])
+
+    for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
+        target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], \
+                (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
+                target_location['rotation'])
+        target_poly = get_bounding_polygon(target_location)
+
+        location = get_adjacent_location(object_definition, target_definition, target_location, performer_start, True)
+        assert location
+        object_poly = get_bounding_polygon(location)
+        assert object_poly.distance(target_poly) < 0.5
+        assert does_fully_obstruct_target(performer_start['position'], target_location, object_poly)
 
 
 def get_min_and_max_in_bounds(bounds):
@@ -662,118 +663,119 @@ def get_min_and_max_in_bounds(bounds):
 
 
 def test_get_adjacent_location_on_side():
-    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
-    target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
-    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
-            target_location['position'], target_location['rotation'])
-    target_poly = get_bounding_polygon(target_location)
-
-    target_x_min, target_x_max, target_z_min, target_z_max = get_min_and_max_in_bounds(target_location['bounding_box'])
-
-    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-    object_offset = object_definition['offset'] if 'offset' in object_definition else {'x': 0, 'z': 0}
-
     # Set the performer start out-of-the-way.
     performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
 
-    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
-            Side.RIGHT, False)
-    assert location
-    x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
-    assert target_x_max <= x_min <= ROOM_X_MAX
-    assert target_x_max <= x_max <= ROOM_X_MAX
-    assert target_location['position']['z'] + target_offset['z'] == \
-            pytest.approx(location['position']['z'] + object_offset['z'])
-    object_poly = get_bounding_polygon(location)
-    assert object_poly.distance(target_poly) < 0.5
+    for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
+        target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
+        target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
+                target_location['position'], target_location['rotation'])
+        target_poly = get_bounding_polygon(target_location)
 
-    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
-            Side.LEFT, False)
-    assert location
-    x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
-    assert ROOM_X_MIN <= x_min <= target_x_min
-    assert ROOM_X_MIN <= x_max <= target_x_min
-    assert target_location['position']['z'] + target_offset['z'] == \
-            pytest.approx(location['position']['z'] + object_offset['z'])
-    object_poly = get_bounding_polygon(location)
-    assert object_poly.distance(target_poly) < 0.5
+        target_x_min, target_x_max, target_z_min, target_z_max = get_min_and_max_in_bounds( \
+                target_location['bounding_box'])
 
-    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
-            Side.FRONT, False)
-    assert location
-    x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
-    assert target_z_max <= z_min <= ROOM_Z_MAX
-    assert target_z_max <= z_max <= ROOM_Z_MAX
-    assert target_location['position']['x'] + target_offset['x'] == \
-            pytest.approx(location['position']['x'] + object_offset['x'])
-    object_poly = get_bounding_polygon(location)
-    assert object_poly.distance(target_poly) < 0.5
+        for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
+            object_offset = object_definition['offset'] if 'offset' in object_definition else {'x': 0, 'z': 0}
 
-    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
-            Side.BACK, False)
-    assert location
-    x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
-    assert ROOM_Z_MIN <= z_min <= target_z_min
-    assert ROOM_Z_MIN <= z_max <= target_z_min
-    assert target_location['position']['x'] + target_offset['x'] == \
-            pytest.approx(location['position']['x'] + object_offset['x'])
-    object_poly = get_bounding_polygon(location)
-    assert object_poly.distance(target_poly) < 0.5
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
+                    performer_start, Side.RIGHT, False)
+            assert location
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+            assert target_x_max <= x_min <= ROOM_X_MAX
+            assert target_x_max <= x_max <= ROOM_X_MAX
+            assert target_location['position']['z'] + target_offset['z'] == \
+                    pytest.approx(location['position']['z'] + object_offset['z'])
+            object_poly = get_bounding_polygon(location)
+            assert object_poly.distance(target_poly) < 0.5
+
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
+                    performer_start, Side.LEFT, False)
+            assert location
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+            assert ROOM_X_MIN <= x_min <= target_x_min
+            assert ROOM_X_MIN <= x_max <= target_x_min
+            assert target_location['position']['z'] + target_offset['z'] == \
+                    pytest.approx(location['position']['z'] + object_offset['z'])
+            object_poly = get_bounding_polygon(location)
+            assert object_poly.distance(target_poly) < 0.5
+
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
+                    performer_start, Side.FRONT, False)
+            assert location
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+            assert target_z_max <= z_min <= ROOM_Z_MAX
+            assert target_z_max <= z_max <= ROOM_Z_MAX
+            assert target_location['position']['x'] + target_offset['x'] == \
+                    pytest.approx(location['position']['x'] + object_offset['x'])
+            object_poly = get_bounding_polygon(location)
+            assert object_poly.distance(target_poly) < 0.5
+
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
+                    performer_start, Side.BACK, False)
+            assert location
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+            assert ROOM_Z_MIN <= z_min <= target_z_min
+            assert ROOM_Z_MIN <= z_max <= target_z_min
+            assert target_location['position']['x'] + target_offset['x'] == \
+                    pytest.approx(location['position']['x'] + object_offset['x'])
+            object_poly = get_bounding_polygon(location)
+            assert object_poly.distance(target_poly) < 0.5
 
 
 def test_get_adjacent_location_on_side_next_to_room_wall():
-    target_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-    target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
-    target_location = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
-            target_location['position'], target_location['rotation'])
-    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-
     # Set the performer start out-of-the-way.
     performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
 
-    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
-            Side.RIGHT, False)
-    assert not location
+    for target_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
+        target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
+        target_location = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
+                target_location['position'], target_location['rotation'])
+
+        for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
+                    performer_start, Side.RIGHT, False)
+            assert not location
 
 
 def test_get_wider_and_taller_defs():
-    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-    object_dimensions = object_definition['closed_dimensions'] if 'closed_dimensions' in object_definition else \
-            object_definition['dimensions']
-    bigger_definition_list = get_wider_and_taller_defs(object_definition, False)
-    for bigger_definition_result in bigger_definition_list:
-        bigger_definition, angle = bigger_definition_result
-        bigger_definition = util.finalize_object_definition(bigger_definition)
-        bigger_dimensions = bigger_definition['closed_dimensions'] if 'closed_dimensions' in bigger_definition else \
-                bigger_definition['dimensions']
-        assert bigger_definition['obstruct'] == 'navigation'
-        assert bigger_dimensions['y'] >= 0.2
-        if angle == 0:
-            assert bigger_dimensions['x'] >= object_dimensions['x']
-        else:
-            # We rotate the bigger object so compare its side to the original object's front.
-            assert bigger_dimensions['z'] >= object_dimensions['x']
+    for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
+        object_dimensions = object_definition['closed_dimensions'] if 'closed_dimensions' in object_definition else \
+                object_definition['dimensions']
+        bigger_definition_list = get_wider_and_taller_defs(object_definition, False)
+        for bigger_definition_result in bigger_definition_list:
+            bigger_definition, angle = bigger_definition_result
+            bigger_definition = util.finalize_object_definition(bigger_definition)
+            bigger_dimensions = bigger_definition['closed_dimensions'] if 'closed_dimensions' in bigger_definition \
+                    else bigger_definition['dimensions']
+            assert bigger_definition['obstruct'] == 'navigation'
+            assert bigger_dimensions['y'] >= 0.2
+            if angle == 0:
+                assert bigger_dimensions['x'] >= object_dimensions['x']
+            else:
+                # We rotate the bigger object so compare its side to the original object's front.
+                assert bigger_dimensions['z'] >= object_dimensions['x']
 
 
 def test_get_wider_and_taller_defs_obstruct_vision():
-    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-    object_dimensions = object_definition['closed_dimensions'] if 'closed_dimensions' in object_definition else \
-            object_definition['dimensions']
-    bigger_definition_list = get_wider_and_taller_defs(object_definition, True)
-    for bigger_definition_result in bigger_definition_list:
-        bigger_definition, angle = bigger_definition_result
-        bigger_definition = util.finalize_object_definition(bigger_definition)
-        bigger_dimensions = bigger_definition['closed_dimensions'] if 'closed_dimensions' in bigger_definition else \
-                bigger_definition['dimensions']
-        assert bigger_definition['obstruct'] == 'vision'
-        assert bigger_dimensions['y'] >= object_dimensions['y']
-        if angle == 0:
-            assert bigger_dimensions['x'] >= object_dimensions['x']
-        else:
-            # We rotate the bigger object so compare its side to the original object's front.
-            assert bigger_dimensions['z'] >= object_dimensions['x']
+    for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
+        object_dimensions = object_definition['closed_dimensions'] if 'closed_dimensions' in object_definition else \
+                object_definition['dimensions']
+        bigger_definition_list = get_wider_and_taller_defs(object_definition, True)
+        for bigger_definition_result in bigger_definition_list:
+            bigger_definition, angle = bigger_definition_result
+            bigger_definition = util.finalize_object_definition(bigger_definition)
+            bigger_dimensions = bigger_definition['closed_dimensions'] if 'closed_dimensions' in bigger_definition \
+                    else bigger_definition['dimensions']
+            assert bigger_definition['obstruct'] == 'vision'
+            assert bigger_dimensions['y'] >= object_dimensions['y']
+            if angle == 0:
+                assert bigger_dimensions['x'] >= object_dimensions['x']
+            else:
+                # We rotate the bigger object so compare its side to the original object's front.
+                assert bigger_dimensions['z'] >= object_dimensions['x']
 
 
 def test_get_bounding_poly():
@@ -799,56 +801,56 @@ def test_find_performer_rect():
 
 
 def test_set_location_rotation():
-    definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-    offset = definition['offset'] if 'offset' in definition else {'x': 0, 'z': 0}
+    for definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
+        offset = definition['offset'] if 'offset' in definition else {'x': 0, 'z': 0}
 
-    location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    location = set_location_rotation(definition, location, 0)
-    assert location['rotation']['y'] == 0
-    assert location['bounding_box'][0]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-    assert location['bounding_box'][0]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-    assert location['bounding_box'][1]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-    assert location['bounding_box'][1]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-    assert location['bounding_box'][2]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-    assert location['bounding_box'][2]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-    assert location['bounding_box'][3]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-    assert location['bounding_box'][3]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        location = set_location_rotation(definition, location, 0)
+        assert location['rotation']['y'] == 0
+        assert location['bounding_box'][0]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['bounding_box'][0]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['bounding_box'][1]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['bounding_box'][1]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['bounding_box'][2]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['bounding_box'][2]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['bounding_box'][3]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['bounding_box'][3]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
 
-    location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    location = set_location_rotation(definition, location, 90)
-    assert location['rotation']['y'] == 90
-    assert location['bounding_box'][0]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-    assert location['bounding_box'][0]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-    assert location['bounding_box'][1]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-    assert location['bounding_box'][1]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-    assert location['bounding_box'][2]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-    assert location['bounding_box'][2]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-    assert location['bounding_box'][3]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-    assert location['bounding_box'][3]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        location = set_location_rotation(definition, location, 90)
+        assert location['rotation']['y'] == 90
+        assert location['bounding_box'][0]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['bounding_box'][0]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['bounding_box'][1]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['bounding_box'][1]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['bounding_box'][2]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['bounding_box'][2]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['bounding_box'][3]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['bounding_box'][3]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
 
-    location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    location = set_location_rotation(definition, location, 180)
-    assert location['rotation']['y'] == 180
-    assert location['bounding_box'][0]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-    assert location['bounding_box'][0]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-    assert location['bounding_box'][1]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-    assert location['bounding_box'][1]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-    assert location['bounding_box'][2]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-    assert location['bounding_box'][2]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-    assert location['bounding_box'][3]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-    assert location['bounding_box'][3]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        location = set_location_rotation(definition, location, 180)
+        assert location['rotation']['y'] == 180
+        assert location['bounding_box'][0]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['bounding_box'][0]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['bounding_box'][1]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['bounding_box'][1]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['bounding_box'][2]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['bounding_box'][2]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['bounding_box'][3]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['bounding_box'][3]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
 
-    location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    location = set_location_rotation(definition, location, 270)
-    assert location['rotation']['y'] == 270
-    assert location['bounding_box'][0]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-    assert location['bounding_box'][0]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-    assert location['bounding_box'][1]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-    assert location['bounding_box'][1]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-    assert location['bounding_box'][2]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-    assert location['bounding_box'][2]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-    assert location['bounding_box'][3]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-    assert location['bounding_box'][3]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        location = set_location_rotation(definition, location, 270)
+        assert location['rotation']['y'] == 270
+        assert location['bounding_box'][0]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['bounding_box'][0]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['bounding_box'][1]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['bounding_box'][1]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['bounding_box'][2]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['bounding_box'][2]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['bounding_box'][3]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['bounding_box'][3]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
 
 
 def test_does_fully_obstruct_target():

--- a/scene_generator/geometry_test.py
+++ b/scene_generator/geometry_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+import exceptions
 import geometry
 from geometry import *
 from separating_axis_theorem import sat_entry
@@ -39,7 +40,7 @@ def test_rect_intersection():
 
 def test_point_within_room():
     outside1 = {
-        'x': ROOM_DIMENSIONS[0][0] - 1,
+        'x': ROOM_X_MIN - 1,
         'y': 0,
         'z': 0
     }
@@ -47,13 +48,13 @@ def test_point_within_room():
     outside2 = {
         'x': 0,
         'y': 0,
-        'z': ROOM_DIMENSIONS[1][1] + 1,
+        'z': ROOM_Z_MAX + 1,
     }
     assert point_within_room(outside2) is False
     inside = {
-        'x': (ROOM_DIMENSIONS[0][0] + ROOM_DIMENSIONS[0][1])/2.0,
+        'x': (ROOM_X_MIN + ROOM_X_MAX)/2.0,
         'y': 0,
-        'z': (ROOM_DIMENSIONS[1][0] + ROOM_DIMENSIONS[1][1])/2.0,
+        'z': (ROOM_Z_MIN + ROOM_Z_MAX)/2.0,
     }
     assert point_within_room(inside) is True
 
@@ -101,6 +102,12 @@ def test_calc_obj_coords_identity():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 0})
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
 
 def test_calc_obj_coords_rotate90():
 
@@ -120,6 +127,13 @@ def test_calc_obj_coords_rotate90():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 90})
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
+
 def test_calc_obj_coords_rotate180():
 
     c = {'x': 2, 'y': 0, 'z': 2}
@@ -133,6 +147,12 @@ def test_calc_obj_coords_rotate180():
                                                  offset_x=0,
                                                  offset_z=0,
                                                  rotation=180)
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 180})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -157,6 +177,12 @@ def test_calc_obj_coords_rotate270():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 270})
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
 
 def test_calc_obj_coords_nonorigin_identity():
 
@@ -171,6 +197,12 @@ def test_calc_obj_coords_nonorigin_identity():
                                                  offset_x=0,
                                                  offset_z=0,
                                                  rotation=0)
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 1, 'z': 1}, {'y': 0})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -195,6 +227,12 @@ def test_calc_obj_coords_nonorigin_rotate90():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 1, 'z': 1}, {'y': 90})
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
 
 def test_calc_obj_coords_identity_offset():
 
@@ -209,6 +247,12 @@ def test_calc_obj_coords_identity_offset():
                                                  offset_x=1,
                                                  offset_z=1,
                                                  rotation=0)
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 0}, {'y': 0})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -233,6 +277,12 @@ def test_calc_obj_coords_rotation90_offset():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 0}, {'y': 90})
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
 
 def test_calc_obj_coords_rotation90_offset_position_x():
 
@@ -247,6 +297,12 @@ def test_calc_obj_coords_rotation90_offset_position_x():
                                                  offset_x=1,
                                                  offset_z=1,
                                                  rotation=90)
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 0}, {'y': 90})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -271,6 +327,12 @@ def test_calc_obj_coords_rotation90_offset_position_z():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 7}, {'y': 90})
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
 
 def test_calc_obj_coords_rotation90_offset_position_xz():
 
@@ -285,6 +347,12 @@ def test_calc_obj_coords_rotation90_offset_position_xz():
                                                  offset_x=1,
                                                  offset_z=1,
                                                  rotation=90)
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 7}, {'y': 90})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -309,6 +377,12 @@ def test_calc_obj_coords_rotation45_offset_position_xz():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
+    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 7}, {'y': 45})
+    assert new_a == pytest.approx(a)
+    assert new_b == pytest.approx(b)
+    assert new_c == pytest.approx(c)
+    assert new_d == pytest.approx(d)
+
 
 def test__object_collision():
     r1 = geometry.calc_obj_coords(-1.97, 1.75, .55, .445, -.01, .445, 315)
@@ -326,83 +400,385 @@ def test_get_visible_segment():
         }
     }
     segment = get_visible_segment(start)
-    expected_segment = shapely.geometry.LineString([[0, 1], [0, ROOM_DIMENSIONS[0][1]]])
+    expected_segment = shapely.geometry.LineString([[0, 1], [0, ROOM_X_MAX]])
     assert segment == expected_segment
 
 
+def test_get_position_in_front_of_performer():
+    # This test should work with ANY pickupable object
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    target_half_size_x = target_definition['dimensions']['x'] / 2.0
+    target_half_size_z = target_definition['dimensions']['z'] / 2.0
+    performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
+
+    performer_start['rotation']['y'] = 0
+    positive_z = get_location_in_front_of_performer(performer_start, target_definition)
+    assert 0 <= positive_z['position']['z'] <= ROOM_Z_MAX
+    assert -target_half_size_x <= positive_z['position']['x'] <= target_half_size_x
+
+    performer_start['rotation']['y'] = 90
+    positive_x = get_location_in_front_of_performer(performer_start, target_definition)
+    assert 0 <= positive_x['position']['x'] <= ROOM_X_MAX
+    assert -target_half_size_z <= positive_x['position']['z'] <= target_half_size_z
+
+    performer_start['rotation']['y'] = 180
+    negative_z = get_location_in_front_of_performer(performer_start, target_definition)
+    assert ROOM_Z_MIN <= negative_z['position']['z'] <= 0
+    assert -target_half_size_x <= negative_z['position']['x'] <= target_half_size_x
+
+    performer_start['rotation']['y'] = 270
+    negative_x = get_location_in_front_of_performer(performer_start, target_definition)
+    assert ROOM_X_MIN <= negative_x['position']['x'] <= 0
+    assert -target_half_size_z <= negative_x['position']['z'] <= target_half_size_z
+
+
+def test_get_position_in_front_of_performer_next_to_room_wall():
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
+    performer_start['position']['z'] = ROOM_Z_MAX
+    location = get_location_in_front_of_performer(performer_start, target_definition)
+    assert location is None
+
+
 def test_get_position_in_back_of_performer():
-    target_def = objects.OBJECTS_PICKUPABLE_BALLS[0]
-    start = {
-        'position': ORIGIN,
-        'rotation': {
-            'y': 90
-        }
-    }
-    negative_x = get_location_in_back_of_performer(start, target_def)
-    assert 0 >= negative_x['position']['x'] >= ROOM_DIMENSIONS[0][0]
-    assert ROOM_DIMENSIONS[1][1] >= negative_x['position']['z'] >= ROOM_DIMENSIONS[1][0]
+    # This test should work with ANY pickupable object
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
 
-    start['rotation']['y'] = 0
-    negative_z = get_location_in_back_of_performer(start, target_def)
-    assert 0 >= negative_z['position']['z'] >= ROOM_DIMENSIONS[1][0]
-    assert ROOM_DIMENSIONS[0][1] >= negative_z['position']['z'] >= ROOM_DIMENSIONS[0][0]
+    performer_start['rotation']['y'] = 0
+    negative_z = get_location_in_back_of_performer(performer_start, target_definition)
+    assert 0 >= negative_z['position']['z'] >= ROOM_Z_MIN
+    assert ROOM_X_MAX >= negative_z['position']['x'] >= ROOM_X_MIN
+
+    performer_start['rotation']['y'] = 90
+    negative_x = get_location_in_back_of_performer(performer_start, target_definition)
+    assert 0 >= negative_x['position']['x'] >= ROOM_X_MIN
+    assert ROOM_Z_MAX >= negative_x['position']['z'] >= ROOM_Z_MIN
+
+    performer_start['rotation']['y'] = 180
+    positive_z = get_location_in_back_of_performer(performer_start, target_definition)
+    assert ROOM_Z_MAX >= positive_z['position']['z'] >= 0
+    assert ROOM_X_MAX >= positive_z['position']['x'] >= ROOM_X_MIN
+
+    performer_start['rotation']['y'] = 270
+    positive_x = get_location_in_back_of_performer(performer_start, target_definition)
+    assert ROOM_X_MAX >= positive_x['position']['x'] >= 0
+    assert ROOM_Z_MAX >= positive_x['position']['z'] >= ROOM_Z_MIN
 
 
-def are_adjacent(obj_a: Dict[str, Any], obj_b: Dict[str, Any]) -> bool:
-    poly_a = geometry.get_bounding_polygon(obj_a)
-    poly_b = geometry.get_bounding_polygon(obj_b)
-    distance = poly_a.distance(poly_b)
-    return distance <= MAX_ADJACENT_DISTANCE
+def test_get_position_in_back_of_performer_next_to_room_wall():
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
+    performer_start['position']['z'] = ROOM_Z_MIN
+    location = get_location_in_back_of_performer(performer_start, target_definition)
+    assert location is None
 
 
-MAX_ADJACENT_DISTANCE = 0.5
+def test_are_adjacent():
+    dimensions = {'x': 2, 'y': 2, 'z': 2}
+
+    center = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    center['bounding_box'] = generate_object_bounds(dimensions, None, center['position'], center['rotation'])
+
+    good_1 = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_1['bounding_box'] = generate_object_bounds(dimensions, None, good_1['position'], good_1['rotation'])
+    assert are_adjacent(center, good_1)
+
+    good_2 = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_2['bounding_box'] = generate_object_bounds(dimensions, None, good_2['position'], good_2['rotation'])
+    assert are_adjacent(center, good_2)
+
+    good_3 = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_3['bounding_box'] = generate_object_bounds(dimensions, None, good_3['position'], good_3['rotation'])
+    assert are_adjacent(center, good_3)
+
+    good_4 = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_4['bounding_box'] = generate_object_bounds(dimensions, None, good_4['position'], good_4['rotation'])
+    assert are_adjacent(center, good_4)
+
+    good_5 = {'position': {'x': 2, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_5['bounding_box'] = generate_object_bounds(dimensions, None, good_5['position'], good_5['rotation'])
+    assert are_adjacent(center, good_5)
+
+    good_6 = {'position': {'x': 2, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_6['bounding_box'] = generate_object_bounds(dimensions, None, good_6['position'], good_6['rotation'])
+    assert are_adjacent(center, good_6)
+
+    good_7 = {'position': {'x': -2, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_7['bounding_box'] = generate_object_bounds(dimensions, None, good_7['position'], good_7['rotation'])
+    assert are_adjacent(center, good_7)
+
+    good_8 = {'position': {'x': -2, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_8['bounding_box'] = generate_object_bounds(dimensions, None, good_8['position'], good_8['rotation'])
+    assert are_adjacent(center, good_8)
+
+    bad_1 = {'position': {'x': 3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_1['bounding_box'] = generate_object_bounds(dimensions, None, bad_1['position'], bad_1['rotation'])
+    assert not are_adjacent(center, bad_1)
+
+    bad_2 = {'position': {'x': -3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_2['bounding_box'] = generate_object_bounds(dimensions, None, bad_2['position'], bad_2['rotation'])
+    assert not are_adjacent(center, bad_2)
+
+    bad_3 = {'position': {'x': 0, 'y': 0, 'z': 3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_3['bounding_box'] = generate_object_bounds(dimensions, None, bad_3['position'], bad_3['rotation'])
+    assert not are_adjacent(center, bad_3)
+
+    bad_4 = {'position': {'x': 0, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_4['bounding_box'] = generate_object_bounds(dimensions, None, bad_4['position'], bad_4['rotation'])
+    assert not are_adjacent(center, bad_4)
+
+    bad_5 = {'position': {'x': 2.5, 'y': 0, 'z': 2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_5['bounding_box'] = generate_object_bounds(dimensions, None, bad_5['position'], bad_5['rotation'])
+    assert not are_adjacent(center, bad_5)
+
+    bad_6 = {'position': {'x': 2.5, 'y': 0, 'z': -2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_6['bounding_box'] = generate_object_bounds(dimensions, None, bad_6['position'], bad_6['rotation'])
+    assert not are_adjacent(center, bad_6)
+
+    bad_7 = {'position': {'x': -2.5, 'y': 0, 'z': 2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_7['bounding_box'] = generate_object_bounds(dimensions, None, bad_7['position'], bad_7['rotation'])
+    assert not are_adjacent(center, bad_7)
+
+    bad_8 = {'position': {'x': -2.5, 'y': 0, 'z': -2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_8['bounding_box'] = generate_object_bounds(dimensions, None, bad_8['position'], bad_8['rotation'])
+    assert not are_adjacent(center, bad_8)
+
+
+def test_are_adjacent_with_offset():
+    dimensions = {'x': 2, 'y': 2, 'z': 2}
+    offset = {'x': -1, 'y': 0, 'z': 1}
+
+    center = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    center['bounding_box'] = generate_object_bounds(dimensions, None, center['position'], center['rotation'])
+
+    good_1 = {'position': {'x': 3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_1['bounding_box'] = generate_object_bounds(dimensions, offset, good_1['position'], good_1['rotation'])
+    assert are_adjacent(center, good_1)
+
+    good_2 = {'position': {'x': -1, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_2['bounding_box'] = generate_object_bounds(dimensions, offset, good_2['position'], good_2['rotation'])
+    assert are_adjacent(center, good_2)
+
+    good_3 = {'position': {'x': 0, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_3['bounding_box'] = generate_object_bounds(dimensions, offset, good_3['position'], good_3['rotation'])
+    assert are_adjacent(center, good_3)
+
+    good_4 = {'position': {'x': 0, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_4['bounding_box'] = generate_object_bounds(dimensions, offset, good_4['position'], good_4['rotation'])
+    assert are_adjacent(center, good_4)
+
+    good_5 = {'position': {'x': 3, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_5['bounding_box'] = generate_object_bounds(dimensions, offset, good_5['position'], good_5['rotation'])
+    assert are_adjacent(center, good_5)
+
+    good_6 = {'position': {'x': 3, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_6['bounding_box'] = generate_object_bounds(dimensions, offset, good_6['position'], good_6['rotation'])
+    assert are_adjacent(center, good_6)
+
+    good_7 = {'position': {'x': -1, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_7['bounding_box'] = generate_object_bounds(dimensions, offset, good_7['position'], good_7['rotation'])
+    assert are_adjacent(center, good_7)
+
+    good_8 = {'position': {'x': -1, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    good_8['bounding_box'] = generate_object_bounds(dimensions, offset, good_8['position'], good_8['rotation'])
+    assert are_adjacent(center, good_8)
+
+    bad_1 = {'position': {'x': 4, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_1['bounding_box'] = generate_object_bounds(dimensions, offset, bad_1['position'], bad_1['rotation'])
+    assert not are_adjacent(center, bad_1)
+
+    bad_2 = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_2['bounding_box'] = generate_object_bounds(dimensions, offset, bad_2['position'], bad_2['rotation'])
+    assert not are_adjacent(center, bad_2)
+
+    bad_3 = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_3['bounding_box'] = generate_object_bounds(dimensions, offset, bad_3['position'], bad_3['rotation'])
+    assert not are_adjacent(center, bad_3)
+
+    bad_4 = {'position': {'x': 0, 'y': 0, 'z': -4}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_4['bounding_box'] = generate_object_bounds(dimensions, offset, bad_4['position'], bad_4['rotation'])
+    assert not are_adjacent(center, bad_4)
+
+    bad_5 = {'position': {'x': 3.5, 'y': 0, 'z': 1.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_5['bounding_box'] = generate_object_bounds(dimensions, offset, bad_5['position'], bad_5['rotation'])
+    assert not are_adjacent(center, bad_5)
+
+    bad_6 = {'position': {'x': 3.5, 'y': 0, 'z': -3.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_6['bounding_box'] = generate_object_bounds(dimensions, offset, bad_6['position'], bad_6['rotation'])
+    assert not are_adjacent(center, bad_6)
+
+    bad_7 = {'position': {'x': -1.5, 'y': 0, 'z': 1.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_7['bounding_box'] = generate_object_bounds(dimensions, offset, bad_7['position'], bad_7['rotation'])
+    assert not are_adjacent(center, bad_7)
+
+    bad_8 = {'position': {'x': -1.5, 'y': 0, 'z': -3.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    bad_8['bounding_box'] = generate_object_bounds(dimensions, offset, bad_8['position'], bad_8['rotation'])
+    assert not are_adjacent(center, bad_8)
 
 
 def test_get_adjacent_location():
-    target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-    target = util.instantiate_object(target_def, ORIGIN_LOCATION)
-    obj_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], \
+            (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
+            target_location['rotation'])
+    target_poly = get_bounding_polygon(target_location)
+    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
 
-    location = get_adjacent_location(obj_def, target, ORIGIN_LOCATION)
-    assert location is not None
+    # Set the performer start out-of-the-way.
+    performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
 
-    # check that their bounding boxes are near each other
-    obj = util.instantiate_object(obj_def, location)
-    obj_bb = get_bounding_polygon(obj)
-    target_bb = get_bounding_polygon(target)
-    assert obj_bb.distance(target_bb) < 0.5
-    
+    location = get_adjacent_location(object_definition, target_definition, target_location, performer_start)
+    assert location
+    object_poly = get_bounding_polygon(location)
+    assert object_poly.distance(target_poly) < 0.5
+
+
+def test_get_adjacent_location_with_obstruct():
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], \
+            (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
+            target_location['rotation'])
+    target_poly = get_bounding_polygon(target_location)
+
+    # Use the sofa here because it should obstruct any possible pickupable object.
+    sofa_list = [item for item in objects.get_all_object_defs() if 'type' in item and item['type'] == 'sofa_1']
+    object_definition = util.finalize_object_definition(sofa_list[0])
+
+    # Set the performer start in the back of the room facing inward.
+    performer_start = {'position': {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, 'rotation': {'y': 0}}
+
+    location = get_adjacent_location(object_definition, target_definition, target_location, performer_start, True)
+    assert location
+    object_poly = get_bounding_polygon(location)
+    assert object_poly.distance(target_poly) < 0.5
+    assert does_fully_obstruct_target(performer_start['position'], target_location, object_poly)
+
+
+def get_min_and_max_in_bounds(bounds):
+    return bounds[2]['x'], bounds[0]['x'], bounds[2]['z'], bounds[0]['z']
+
 
 def test_get_adjacent_location_on_side():
-    for side in list(Side):
-        target_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-        target = util.instantiate_object(target_def, ORIGIN_LOCATION)
-        obj_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-        location = get_adjacent_location_on_side(obj_def, target, ORIGIN_LOCATION, side, False)
-        assert location is not None
-        angle = math.degrees(math.atan2(location['position']['z'], location['position']['x']))
-        target_angle = target['shows'][0]['rotation']['y']
-        delta = angle - target_angle
-        expected_angle = 90 * side
-        if expected_angle > 180:
-            expected_angle -= 360
-        # need to allow some tolerance because of object offsets
-        assert delta == pytest.approx(expected_angle, abs=15)
+    target_definition = util.finalize_object_definition(random.choice(objects.OBJECTS_PICKUPABLE))
+    target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
+    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
+            target_location['position'], target_location['rotation'])
+    target_poly = get_bounding_polygon(target_location)
+
+    target_x_min, target_x_max, target_z_min, target_z_max = get_min_and_max_in_bounds(target_location['bounding_box'])
+
+    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
+    object_offset = object_definition['offset'] if 'offset' in object_definition else {'x': 0, 'z': 0}
+
+    # Set the performer start out-of-the-way.
+    performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
+
+    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
+            Side.RIGHT, False)
+    assert location
+    x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+    assert target_x_max <= x_min <= ROOM_X_MAX
+    assert target_x_max <= x_max <= ROOM_X_MAX
+    assert target_location['position']['z'] + target_offset['z'] == \
+            pytest.approx(location['position']['z'] + object_offset['z'])
+    object_poly = get_bounding_polygon(location)
+    assert object_poly.distance(target_poly) < 0.5
+
+    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
+            Side.LEFT, False)
+    assert location
+    x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+    assert ROOM_X_MIN <= x_min <= target_x_min
+    assert ROOM_X_MIN <= x_max <= target_x_min
+    assert target_location['position']['z'] + target_offset['z'] == \
+            pytest.approx(location['position']['z'] + object_offset['z'])
+    object_poly = get_bounding_polygon(location)
+    assert object_poly.distance(target_poly) < 0.5
+
+    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
+            Side.FRONT, False)
+    assert location
+    x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+    assert target_z_max <= z_min <= ROOM_Z_MAX
+    assert target_z_max <= z_max <= ROOM_Z_MAX
+    assert target_location['position']['x'] + target_offset['x'] == \
+            pytest.approx(location['position']['x'] + object_offset['x'])
+    object_poly = get_bounding_polygon(location)
+    assert object_poly.distance(target_poly) < 0.5
+
+    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
+            Side.BACK, False)
+    assert location
+    x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+    assert ROOM_Z_MIN <= z_min <= target_z_min
+    assert ROOM_Z_MIN <= z_max <= target_z_min
+    assert target_location['position']['x'] + target_offset['x'] == \
+            pytest.approx(location['position']['x'] + object_offset['x'])
+    object_poly = get_bounding_polygon(location)
+    assert object_poly.distance(target_poly) < 0.5
+
+
+def test_get_adjacent_location_on_side_next_to_room_wall():
+    target_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
+    target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
+    target_location = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
+            target_location['position'], target_location['rotation'])
+    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
+
+    # Set the performer start out-of-the-way.
+    performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
+
+    location = get_adjacent_location_on_side(object_definition, target_definition, target_location, performer_start, \
+            Side.RIGHT, False)
+    assert not location
 
 
 def test_get_wider_and_taller_defs():
-    obj_def = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
-    obj_dim = obj_def['closed_dimensions'] if 'closed_dimensions' in obj_def else obj_def['dimensions']
-    big_defs = get_wider_and_taller_defs(obj_def, True)
-    for big_def_tuple in big_defs:
-        big_def, angle = big_def_tuple
-        big_def = util.finalize_object_definition(big_def)
-        big_dim = big_def['closed_dimensions'] if 'closed_dimensions' in big_def else big_def['dimensions']
-        assert big_dim['y'] >= obj_dim['y']
+    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
+    object_dimensions = object_definition['closed_dimensions'] if 'closed_dimensions' in object_definition else \
+            object_definition['dimensions']
+    bigger_definition_list = get_wider_and_taller_defs(object_definition, False)
+    for bigger_definition_result in bigger_definition_list:
+        bigger_definition, angle = bigger_definition_result
+        bigger_definition = util.finalize_object_definition(bigger_definition)
+        bigger_dimensions = bigger_definition['closed_dimensions'] if 'closed_dimensions' in bigger_definition else \
+                bigger_definition['dimensions']
+        assert bigger_definition['obstruct'] == 'navigation'
+        assert bigger_dimensions['y'] >= 0.2
         if angle == 0:
-            assert big_dim['x'] >= obj_dim['x']
+            assert bigger_dimensions['x'] >= object_dimensions['x']
         else:
-            assert big_dim['z'] >= obj_dim['x']
+            # We rotate the bigger object so compare its side to the original object's front.
+            assert bigger_dimensions['z'] >= object_dimensions['x']
+
+
+def test_get_wider_and_taller_defs_obstruct_vision():
+    object_definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
+    object_dimensions = object_definition['closed_dimensions'] if 'closed_dimensions' in object_definition else \
+            object_definition['dimensions']
+    bigger_definition_list = get_wider_and_taller_defs(object_definition, True)
+    for bigger_definition_result in bigger_definition_list:
+        bigger_definition, angle = bigger_definition_result
+        bigger_definition = util.finalize_object_definition(bigger_definition)
+        bigger_dimensions = bigger_definition['closed_dimensions'] if 'closed_dimensions' in bigger_definition else \
+                bigger_definition['dimensions']
+        assert bigger_definition['obstruct'] == 'vision'
+        assert bigger_dimensions['y'] >= object_dimensions['y']
+        if angle == 0:
+            assert bigger_dimensions['x'] >= object_dimensions['x']
+        else:
+            # We rotate the bigger object so compare its side to the original object's front.
+            assert bigger_dimensions['z'] >= object_dimensions['x']
+
+
+def test_get_bounding_poly():
+    # TODO
+    pass
 
 
 def test_rect_to_poly():
@@ -420,4 +796,217 @@ def test_find_performer_rect():
     expected2 = [{'x': 0.95, 'z': 0.95}, {'x': 0.95, 'z': 1.05}, {'x': 1.05, 'z': 1.05}, {'x': 1.05, 'z': 0.95}]
     actual2 = find_performer_rect({'x': 1, 'y': 1, 'z': 1})
     assert actual2 == expected2
+
+
+def test_set_location_rotation():
+    definition = util.finalize_object_definition(random.choice(objects.get_all_object_defs()))
+    offset = definition['offset'] if 'offset' in definition else {'x': 0, 'z': 0}
+
+    location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    location = set_location_rotation(definition, location, 0)
+    assert location['rotation']['y'] == 0
+    assert location['bounding_box'][0]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+    assert location['bounding_box'][0]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+    assert location['bounding_box'][1]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+    assert location['bounding_box'][1]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+    assert location['bounding_box'][2]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+    assert location['bounding_box'][2]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+    assert location['bounding_box'][3]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+    assert location['bounding_box'][3]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+
+    location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    location = set_location_rotation(definition, location, 90)
+    assert location['rotation']['y'] == 90
+    assert location['bounding_box'][0]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+    assert location['bounding_box'][0]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+    assert location['bounding_box'][1]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+    assert location['bounding_box'][1]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+    assert location['bounding_box'][2]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+    assert location['bounding_box'][2]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+    assert location['bounding_box'][3]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+    assert location['bounding_box'][3]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+
+    location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    location = set_location_rotation(definition, location, 180)
+    assert location['rotation']['y'] == 180
+    assert location['bounding_box'][0]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+    assert location['bounding_box'][0]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+    assert location['bounding_box'][1]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+    assert location['bounding_box'][1]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+    assert location['bounding_box'][2]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+    assert location['bounding_box'][2]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+    assert location['bounding_box'][3]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+    assert location['bounding_box'][3]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+
+    location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    location = set_location_rotation(definition, location, 270)
+    assert location['rotation']['y'] == 270
+    assert location['bounding_box'][0]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+    assert location['bounding_box'][0]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+    assert location['bounding_box'][1]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+    assert location['bounding_box'][1]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+    assert location['bounding_box'][2]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+    assert location['bounding_box'][2]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+    assert location['bounding_box'][3]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+    assert location['bounding_box'][3]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+
+
+def test_does_fully_obstruct_target():
+    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    target_location['bounding_box'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
+            target_location['position'], target_location['rotation'])
+
+    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+
+
+def test_does_fully_obstruct_target_returns_false_too_small():
+    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    target_location['bounding_box'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
+            target_location['position'], target_location['rotation'])
+
+    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+
+
+def test_does_fully_obstruct_target_returns_false_performer_start():
+    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    target_location['bounding_box'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
+            target_location['position'], target_location['rotation'])
+
+    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+
+
+def test_does_fully_obstruct_target_returns_false_visible_corners():
+    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    target_location['bounding_box'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
+            target_location['position'], target_location['rotation'])
+
+    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': -1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': -1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 1, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': -1, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': 1, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+
+    obstructor_location = {'position': {'x': -1, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_poly = get_bounding_polygon(obstructor_location)
+    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 

--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -52,7 +52,7 @@ def generate_wall(wall_material: str, wall_colors: List[str], performer_position
         if is_ok:
             if target_list:
                 for target in target_list:
-                    if geometry.does_obstruct_target(performer_position, target, wall_poly):
+                    if geometry.does_fully_obstruct_target(performer_position, target, wall_poly):
                         is_ok = False
                         break
             if is_ok:
@@ -66,7 +66,7 @@ def generate_wall(wall_material: str, wall_colors: List[str], performer_position
             'type': 'cube',
             'kinematic': 'true',
             'structure': 'true',
-            'mass': 100,
+            'mass': 200,
             'info': wall_colors,
             'info_string': ' '.join(wall_colors)
         }
@@ -93,9 +93,8 @@ class GoalCategory(Enum):
 
 
 class Goal(ABC):
-    """An abstract Goal. Subclasses must implement compute_objects and
-    get_config. Users of a goal object should normally only need to call 
-    update_body."""
+    """An abstract Goal. Subclasses must implement compute_objects and _get_subclass_config. Users of a goal object
+    should normally only need to call update_body."""
 
     def __init__(self, name: str):
         self._name = name
@@ -110,7 +109,7 @@ class Goal(ABC):
 
         body['performerStart'] = self._performer_start
         body['objects'] = [element for value in self._tag_to_objects.values() for element in value]
-        body['goal'] = self.get_config(self._tag_to_objects)
+        body['goal'] = self._get_config(self._tag_to_objects)
 
         if find_path:
             body['answer']['actions'] = self._find_optimal_path(self._tag_to_objects['target'], body['objects'])
@@ -124,13 +123,13 @@ class Goal(ABC):
             self._performer_start = {
                 'position': {
                     'x': round(random.uniform(
-                        geometry.ROOM_DIMENSIONS[0][0] + util.PERFORMER_HALF_WIDTH,
-                        geometry.ROOM_DIMENSIONS[0][1] - util.PERFORMER_HALF_WIDTH
+                        geometry.ROOM_X_MIN + util.PERFORMER_HALF_WIDTH,
+                        geometry.ROOM_X_MAX - util.PERFORMER_HALF_WIDTH
                     ), geometry.POSITION_DIGITS),
                     'y': 0,
                     'z': round(random.uniform(
-                        geometry.ROOM_DIMENSIONS[1][0] + util.PERFORMER_HALF_WIDTH,
-                        geometry.ROOM_DIMENSIONS[1][1] - util.PERFORMER_HALF_WIDTH
+                        geometry.ROOM_Z_MIN + util.PERFORMER_HALF_WIDTH,
+                        geometry.ROOM_Z_MAX - util.PERFORMER_HALF_WIDTH
                     ), geometry.POSITION_DIGITS)
                 },
                 'rotation': {
@@ -158,7 +157,7 @@ class Goal(ABC):
                 info_set |= set([(key + ' ' + info) for info in info_list])
         return list(info_set)
 
-    def get_config(self, tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+    def _get_config(self, tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
         """Create and return the goal configuration."""
         goal_config = self._get_subclass_config(tag_to_objects['target'])
         goal_config['category'] = goal_config.get('category', '')

--- a/scene_generator/goal_test.py
+++ b/scene_generator/goal_test.py
@@ -1,5 +1,7 @@
+import geometry
 import uuid
 
+from goal import generate_wall, MAX_WALL_WIDTH, MIN_WALL_WIDTH, WALL_DEPTH, WALL_HEIGHT, WALL_Y_POS
 from goals import *
 from util import instantiate_object
 
@@ -66,10 +68,111 @@ def create_tags_test_object_2():
     }
 
 
+def test_generate_wall():
+    wall = generate_wall('test_material', ['test_color_1', 'test_color_2'], geometry.ORIGIN, [])
+
+    assert wall
+    assert wall['id']
+    assert wall['materials'] == ['test_material']
+    assert wall['type'] == 'cube'
+    assert wall['kinematic'] == 'true'
+    assert wall['structure'] == 'true'
+    assert wall['mass'] == 200
+    assert wall['info'] == ['test_color_1', 'test_color_2']
+    assert wall['info_string'] == 'test_color_1 test_color_2'
+
+    assert len(wall['shows']) == 1
+    assert wall['shows'][0]['stepBegin'] == 0
+    assert wall['shows'][0]['scale']['x'] >= MIN_WALL_WIDTH and wall['shows'][0]['scale']['x'] <= MAX_WALL_WIDTH
+    assert wall['shows'][0]['scale']['y'] == WALL_HEIGHT
+    assert wall['shows'][0]['scale']['z'] == WALL_DEPTH
+    assert wall['shows'][0]['rotation']['x'] == 0
+    assert wall['shows'][0]['rotation']['y'] % 90 == 0
+    assert wall['shows'][0]['rotation']['z'] == 0
+    assert wall['shows'][0]['position']['x'] is not None
+    assert wall['shows'][0]['position']['y'] == WALL_Y_POS
+    assert wall['shows'][0]['position']['z'] is not None
+    assert wall['shows'][0]['bounding_box'] is not None
+
+    assert not 'hides' in wall
+    assert not 'moves' in wall
+    assert not 'rotates' in wall
+    assert not 'teleports' in wall
+
+    player_rect = geometry.find_performer_rect(geometry.ORIGIN)
+    player_poly = geometry.rect_to_poly(player_rect)
+    wall_poly = geometry.rect_to_poly(wall['shows'][0]['bounding_box'])
+    assert not wall_poly.intersects(player_poly)
+    assert geometry.rect_within_room(wall['shows'][0]['bounding_box'])
+
+
+def test_generate_wall_multiple():
+    wall_1 = generate_wall('test_material', [], geometry.ORIGIN, [])
+    wall_2 = generate_wall('test_material', [], geometry.ORIGIN, [wall_1['shows'][0]['bounding_box']])
+    wall_1_poly = geometry.rect_to_poly(wall_1['shows'][0]['bounding_box'])
+    wall_2_poly = geometry.rect_to_poly(wall_2['shows'][0]['bounding_box'])
+    assert not wall_1_poly.intersects(wall_2_poly)
+
+
+def test_generate_wall_with_bounds_list():
+    bounds = [{'x': 4, 'y': 0, 'z': 4}, {'x': 4, 'y': 0, 'z': 1}, {'x': 1, 'y': 0, 'z': 1}, {'x': 1, 'y': 0, 'z': 4}]
+    wall = generate_wall('test_material', [], geometry.ORIGIN, [bounds])
+    poly = geometry.rect_to_poly(bounds)
+    wall_poly = geometry.rect_to_poly(wall['shows'][0]['bounding_box'])
+    assert not wall_poly.intersects(poly)
+
+
+def test_generate_wall_with_target_list():
+    bounds = [{'x': 4, 'y': 0, 'z': 4}, {'x': 4, 'y': 0, 'z': 3}, {'x': 3, 'y': 0, 'z': 3}, {'x': 3, 'y': 0, 'z': 4}]
+    target = {'shows': [{'bounding_box': bounds}]}
+    wall = generate_wall('test_material', [], geometry.ORIGIN, [bounds], [target])
+    wall_poly = geometry.rect_to_poly(wall['shows'][0]['bounding_box'])
+    assert not geometry.does_fully_obstruct_target(geometry.ORIGIN, target, wall_poly)
+
+
+def test_Goal_update_goal_info_list():
+    goal_object = RetrievalGoal()
+
+    info_list = goal_object.update_goal_info_list([], {})
+    assert info_list == []
+
+    info_list = goal_object.update_goal_info_list([], {'target': []})
+    assert info_list == []
+
+    info_list = goal_object.update_goal_info_list([], {'target': [{'info': []}]})
+    assert info_list == []
+
+    info_list = goal_object.update_goal_info_list([], {'target': [{'info': ['a', 'b']}]})
+    assert set(info_list) == set(['target a', 'target b'])
+
+    info_list = goal_object.update_goal_info_list(['target a'], {'target': [{'info': ['a', 'b']}]})
+    assert set(info_list) == set(['target a', 'target b'])
+
+    info_list = goal_object.update_goal_info_list(['target a'], {'target': [{'info': ['b', 'c']}]})
+    assert set(info_list) == set(['target a', 'target b', 'target c'])
+
+    info_list = goal_object.update_goal_info_list(['target a'], {'target': [{'info': ['a', 'b']}, \
+            {'info': ['b', 'c']}]})
+    assert set(info_list) == set(['target a', 'target b', 'target c'])
+
+    info_list = goal_object.update_goal_info_list(['target a', 'distractor b'], {'target': [{'info': ['a', 'b']}], \
+            'distractor': [{'info': ['b', 'c']}]})
+    assert set(info_list) == set(['target a', 'target b', 'distractor b', 'distractor c'])
+
+
+def test_Goal_reset_performer_start():
+    goal_object = RetrievalGoal()
+    old_performer_start = goal_object.get_performer_start()
+    assert old_performer_start == goal_object.get_performer_start()
+    new_performer_start = goal_object.reset_performer_start()
+    assert new_performer_start == goal_object.get_performer_start()
+    assert old_performer_start != new_performer_start
+
+
 def test_Goal_tags():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    goal = goal_object.get_config({ 'target': [target] })
+    goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -110,7 +213,7 @@ def test_Goal_tags_multiple_target():
     goal_object = RetrievalGoal()
     target_1 = create_tags_test_object_1()
     target_2 = create_tags_test_object_2()
-    goal = goal_object.get_config({ 'target': [target_1, target_2] })
+    goal = goal_object._get_config({ 'target': [target_1, target_2] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -134,7 +237,7 @@ def test_Goal_tags_with_distractor():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
-    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -167,7 +270,7 @@ def test_Goal_tags_multiple_target_multiple_distractor():
     target_2 = create_tags_test_object_1()
     distractor_1 = create_tags_test_object_2()
     distractor_2 = create_tags_test_object_2()
-    goal = goal_object.get_config({ 'target': [target_1, target_2], \
+    goal = goal_object._get_config({ 'target': [target_1, target_2], \
             'distractor': [distractor_1, distractor_2] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -200,7 +303,7 @@ def test_Goal_tags_with_occluder():
     target = create_tags_test_object_1()
     occluder_wall = { 'info': ['white'] }
     occluder_pole = { 'info': ['brown'] }
-    goal = goal_object.get_config({ 'target': [target], 'occluder': [occluder_wall, occluder_pole] })
+    goal = goal_object._get_config({ 'target': [target], 'occluder': [occluder_wall, occluder_pole] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -223,7 +326,7 @@ def test_Goal_tags_with_wall():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     wall = { 'info': ['white'] }
-    goal = goal_object.get_config({ 'target': [target], 'wall': [wall] })
+    goal = goal_object._get_config({ 'target': [target], 'wall': [wall] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -245,7 +348,7 @@ def test_Goal_tags_with_background_object():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     background_object = { 'info': ['red'] }
-    goal = goal_object.get_config({ 'target': [target], 'background object': [background_object] })
+    goal = goal_object._get_config({ 'target': [target], 'background object': [background_object] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -267,7 +370,7 @@ def test_Goal_tags_target_enclosed():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['locationParent'] = 'parent'
-    goal = goal_object.get_config({ 'target': [target] })
+    goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -287,7 +390,7 @@ def test_Goal_tags_target_novel_color():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novel_color'] = True
-    goal = goal_object.get_config({ 'target': [target] })
+    goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -307,7 +410,7 @@ def test_Goal_tags_target_novel_combination():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novel_combination'] = True
-    goal = goal_object.get_config({ 'target': [target] })
+    goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -327,7 +430,7 @@ def test_Goal_tags_target_novel_shape():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novel_shape'] = True
-    goal = goal_object.get_config({ 'target': [target] })
+    goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -349,7 +452,7 @@ def test_Goal_tags_target_enclosed_novel_color_novel_shape():
     target['locationParent'] = 'parent'
     target['novel_color'] = True
     target['novel_shape'] = True
-    goal = goal_object.get_config({ 'target': [target] })
+    goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -370,7 +473,7 @@ def test_Goal_tags_distractor_enclosed():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['locationParent'] = 'parent'
-    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -402,7 +505,7 @@ def test_Goal_tags_distractor_novel_color():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novel_color'] = True
-    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -434,7 +537,7 @@ def test_Goal_tags_distractor_novel_combination():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novel_combination'] = True
-    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -466,7 +569,7 @@ def test_Goal_tags_distractor_novel_shape():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novel_shape'] = True
-    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -500,7 +603,7 @@ def test_Goal_tags_distractor_enclosed_novel_color_novel_shape():
     distractor['locationParent'] = 'parent'
     distractor['novel_color'] = True
     distractor['novel_shape'] = True
-    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -537,7 +640,7 @@ def test_Goal_tags_target_distractor_enclosed_novel_color_novel_shape():
     distractor['locationParent'] = 'parent'
     distractor['novel_color'] = True
     distractor['novel_shape'] = True
-    goal = goal_object.get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -22,7 +22,7 @@ from util import finalize_object_definition, instantiate_object
 
 
 def generate_image_file_name(target: Dict[str, Any]) -> str:
-    if 'materials' not in target:
+    if 'materials' not in target or not target['materials']:
         return target['type']
 
     material_name_list = [item[(item.rfind('/') + 1):].lower().replace(' ', '_') for item in target['materials']]
@@ -554,8 +554,10 @@ class RetrievalGoal(InteractionGoal):
     def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         if len(goal_objects) < 1:
             raise exceptions.SceneException('need at least 1 object for this goal')
-
         target = goal_objects[0]
+        if not target.get('pickupable', False):
+            raise exceptions.SceneException(f'first object must be "pickupable": {target}')
+
         target_image_obj = find_image_for_object(target)
         image_name = find_image_name(target)
 

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -18,7 +18,7 @@ from geometry import POSITION_DIGITS
 from goal import Goal, GoalCategory, generate_wall
 from machine_common_sense.mcs_controller_ai2thor import MAX_MOVE_DISTANCE, MAX_REACH_DISTANCE, PERFORMER_CAMERA_Y
 from optimal_path import generatepath
-from util import finalize_object_definition, instantiate_object
+from util import finalize_object_definition, finalize_object_materials_and_colors, instantiate_object
 
 
 def generate_image_file_name(target: Dict[str, Any]) -> str:
@@ -215,7 +215,8 @@ class ObjectRule():
             [objects.OBJECTS_PICKUPABLE, objects.OBJECTS_MOVEABLE, objects.OBJECTS_IMMOBILE]
         )
         # Same chance to pick each object definition from the list.
-        return finalize_object_definition(random.choice(object_definition_list))
+        object_definition = finalize_object_definition(random.choice(object_definition_list))
+        return random.choice(finalize_object_materials_and_colors(object_definition))
 
     def choose_location(self, object_definition: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], \
             bounds_list: List[List[Dict[str, float]]]) -> Tuple[Dict[str, Any], List[List[Dict[str, float]]]]:
@@ -237,7 +238,8 @@ class PickupableObjectRule(ObjectRule):
 
     def choose_definition(self) -> Dict[str, Any]:
         object_definition_list = random.choice(objects.OBJECTS_PICKUPABLE_LISTS)
-        return finalize_object_definition(random.choice(object_definition_list))
+        object_definition = finalize_object_definition(random.choice(object_definition_list))
+        return random.choice(finalize_object_materials_and_colors(object_definition))
 
 
 class TransferToObjectRule(ObjectRule):
@@ -266,7 +268,8 @@ class TransferToObjectRule(ObjectRule):
         # Same chance to pick each list.
         object_definition_list = random.choice(choice_list)
         # Same chance to pick each object definition from the list.
-        return finalize_object_definition(random.choice(object_definition_list))
+        object_definition = finalize_object_definition(random.choice(object_definition_list))
+        return random.choice(finalize_object_materials_and_colors(object_definition))
 
     def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
             performer_start: Dict[str, Dict[str, float]]) -> bool:
@@ -325,7 +328,7 @@ class ConfusorObjectRule(ObjectRule):
                 copy.deepcopy(objects.get_all_object_defs()))
         if not confusor_definition:
             raise exceptions.SceneException(f'cannot find a confusor to create with target={self._target_definition}')
-        return util.finalize_object_definition(confusor_definition)
+        return confusor_definition
 
 
 class ObstructorObjectRule(ObjectRule):

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -441,15 +441,15 @@ def test_ConfusorObjectRule_choose_definition():
     definition = rule.choose_definition()
     assert definition
 
-    is_same_size = definition['info'][0] == target_definition['info'][0] and \
+    is_same_color = set(definition['color']) == set(target_definition['color'])
+    is_same_shape = definition['shape'] == target_definition['shape']
+    is_same_size = definition['size'] == target_definition['size'] and \
             (definition['dimensions']['x'] >= target_definition['dimensions']['x'] - MAX_SIZE_DIFFERENCE) and \
             (definition['dimensions']['x'] <= target_definition['dimensions']['x'] + MAX_SIZE_DIFFERENCE) and \
+            (definition['dimensions']['y'] >= target_definition['dimensions']['y'] - MAX_SIZE_DIFFERENCE) and \
+            (definition['dimensions']['y'] <= target_definition['dimensions']['y'] + MAX_SIZE_DIFFERENCE) and \
             (definition['dimensions']['z'] >= target_definition['dimensions']['z'] - MAX_SIZE_DIFFERENCE) and \
             (definition['dimensions']['z'] <= target_definition['dimensions']['z'] + MAX_SIZE_DIFFERENCE)
-    is_same_shape = definition['info'][-1] == target_definition['info'][-1]
-    is_same_color = ('materialCategory' not in definition and 'materialCategory' not in target_definition and \
-            definition['type'] == target_definition['type']) or \
-            (definition['materialCategory'] == target_definition['materialCategory'])
     assert (is_same_size and is_same_shape and not is_same_color) or \
             (is_same_size and is_same_color and not is_same_shape) or \
             (is_same_shape and is_same_color and not is_same_size)

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -15,8 +15,9 @@ import scene_generator
 from geometry import POSITION_DIGITS
 from goals import *
 from interaction_goals import move_to_container, parse_path_section, get_navigation_actions, trim_actions_to_reach, \
-        PathfindingException
-from util import MAX_TRIES, finalize_object_definition, instantiate_object
+        PathfindingException, ObjectRule, PickupableObjectRule, TransferToObjectRule, FarOffObjectRule, \
+        DistractorObjectRule, ConfusorObjectRule, ObstructorObjectRule
+from util import MAX_SIZE_DIFFERENCE, MAX_TRIES, finalize_object_definition, instantiate_object
 
 
 def test_move_to_container():
@@ -362,15 +363,179 @@ def test_trim_actions_to_reach():
     assert actions == expected_actions
 
 
-def test_RetrievalGoal_get_goal():
+def test_ObjectRule_choose_definition():
+    rule = ObjectRule()
+    definition = rule.choose_definition()
+    assert definition
+
+
+def test_ObjectRule_choose_location():
+    performer_start = geometry.ORIGIN_LOCATION
+    rule = ObjectRule()
+    definition = rule.choose_definition()
+    location, bounds_list = rule.choose_location(definition, performer_start, [])
+    assert location
+    assert len(bounds_list) == 1
+
+
+def test_PickupableObjectRule_choose_definition():
+    rule = PickupableObjectRule()
+    definition = rule.choose_definition()
+    assert definition
+    assert 'pickupable' in definition['attributes']
+
+
+def test_TransferToObjectRule_choose_definition():
+    rule = TransferToObjectRule()
+    definition = rule.choose_definition()
+    assert definition
+    assert 'stackTarget' in definition['attributes']
+
+
+def test_TransferToObjectRule_validate_location():
+    performer_start = geometry.ORIGIN_LOCATION
+
+    target_rule = ObjectRule()
+    target_definition = target_rule.choose_definition()
+    target_location, bounds_list = target_rule.choose_location(target_definition, performer_start, [])
+    target = instantiate_object(target_definition, target_location)
+    assert target
+
+    rule = TransferToObjectRule()
+    definition = rule.choose_definition()
+    location, bounds_list = rule.choose_location(definition, performer_start, bounds_list)
+    assert rule.validate_location(location, [target], performer_start) == (geometry.position_distance( \
+            target_location['position'], location['position']) >= geometry.MINIMUM_TARGET_SEPARATION)
+
+
+def test_FarOffObjectRule_validate_location():
+    performer_start = geometry.ORIGIN_LOCATION
+    rule = FarOffObjectRule()
+    definition = rule.choose_definition()
+    location, bounds_list = rule.choose_location(definition, performer_start, [])
+    assert rule.validate_location(location, [], performer_start) == (geometry.position_distance( \
+            performer_start['position'], location['position']) >= geometry.MINIMUM_START_DIST_FROM_TARGET)
+
+
+def test_DistractorObjectRule_choose_definition():
+    performer_start = geometry.ORIGIN_LOCATION
+
+    target_rule = ObjectRule()
+    target_definition = target_rule.choose_definition()
+    target_location, bounds_list = target_rule.choose_location(target_definition, performer_start, [])
+    target = instantiate_object(target_definition, target_location)
+    assert target
+
+    rule = DistractorObjectRule([target])
+    definition = rule.choose_definition()
+    assert definition
+    assert definition['info'][-1] != target['info'][-1]
+
+
+def test_ConfusorObjectRule_choose_definition():
+    target_rule = PickupableObjectRule()
+    target_definition = target_rule.choose_definition()
+    assert target_definition
+
+    rule = ConfusorObjectRule(target_definition)
+    definition = rule.choose_definition()
+    assert definition
+
+    is_same_size = definition['info'][0] == target_definition['info'][0] and \
+            (definition['dimensions']['x'] >= target_definition['dimensions']['x'] - MAX_SIZE_DIFFERENCE) and \
+            (definition['dimensions']['x'] <= target_definition['dimensions']['x'] + MAX_SIZE_DIFFERENCE) and \
+            (definition['dimensions']['z'] >= target_definition['dimensions']['z'] - MAX_SIZE_DIFFERENCE) and \
+            (definition['dimensions']['z'] <= target_definition['dimensions']['z'] + MAX_SIZE_DIFFERENCE)
+    is_same_shape = definition['info'][-1] == target_definition['info'][-1]
+    is_same_color = ('materialCategory' not in definition and 'materialCategory' not in target_definition and \
+            definition['type'] == target_definition['type']) or \
+            (definition['materialCategory'] == target_definition['materialCategory'])
+    assert (is_same_size and is_same_shape and not is_same_color) or \
+            (is_same_size and is_same_color and not is_same_shape) or \
+            (is_same_shape and is_same_color and not is_same_size)
+
+
+def test_ObstructorObjectRule_choose_definition():
+    performer_start = geometry.ORIGIN_LOCATION
+
+    target_rule = PickupableObjectRule()
+    target_definition = target_rule.choose_definition()
+    assert target_definition
+
+    rule = ObstructorObjectRule(target_definition, performer_start, False)
+    definition = rule.choose_definition()
+    assert definition
+    assert definition['obstruct'] == 'navigation'
+
+    if definition['rotation']['y'] == 0:
+        assert (definition['dimensions']['x'] >= target_definition['dimensions']['x'] - MAX_SIZE_DIFFERENCE)
+    elif definition['rotation']['y'] == 90:
+        assert (definition['dimensions']['z'] >= target_definition['dimensions']['z'] - MAX_SIZE_DIFFERENCE)
+    else:
+        assert False
+
+
+def test_ObstructorObjectRule_choose_definition_obstruct_vision():
+    performer_start = geometry.ORIGIN_LOCATION
+
+    target_rule = PickupableObjectRule()
+    target_definition = target_rule.choose_definition()
+    assert target_definition
+
+    rule = ObstructorObjectRule(target_definition, performer_start, True)
+    definition = rule.choose_definition()
+    assert definition
+    assert definition['obstruct'] == 'vision'
+    assert (definition['dimensions']['y'] >= target_definition['dimensions']['y'] - MAX_SIZE_DIFFERENCE)
+
+    if definition['rotation']['y'] == 0:
+        assert (definition['dimensions']['x'] >= target_definition['dimensions']['x'] - MAX_SIZE_DIFFERENCE)
+    elif definition['rotation']['y'] == 90:
+        assert (definition['dimensions']['z'] >= target_definition['dimensions']['z'] - MAX_SIZE_DIFFERENCE)
+    else:
+        assert False
+
+
+def test_RetrievalGoal_get_config_arg_count():
+    goal_obj = RetrievalGoal()
+    with pytest.raises(exceptions.SceneException):
+        goal_obj._get_config({'target': []})
+
+
+def test_RetrievalGoal_get_config_arg_invalid():
+    goal_obj = RetrievalGoal()
+    with pytest.raises(exceptions.SceneException):
+        goal_obj._get_config({'target': [{'pickupable': False}]})
+
+
+def test_RetrievalGoal_update_body():
+    goal = RetrievalGoal()
+    body = goal.update_body({'wallMaterial': 'test_material', 'wallColors': []}, False)
+    assert body['performerStart'] == goal.get_performer_start()
+    assert body['goal']['category'] == 'retrieval'
+    assert body['goal']['metadata']['target']
+    assert len(body['goal']['domain_list']) > 0
+    assert len(body['goal']['info_list']) > 0
+    assert len(body['goal']['type_list']) > 0
+    assert len(body['objects']) > 0
+
+    target = body['objects'][0]
+    assert target['pickupable']
+    assert target['id'] == body['goal']['metadata']['target']['id']
+    assert body['goal']['description'] == ('Find and pick up the ' + target['goal_string'] + '.')
+
+
+def test_RetrievalGoal_get_config():
     goal_obj = RetrievalGoal()
     obj = {
         'id': str(uuid.uuid4()),
         'info': ['blue', 'rubber', 'ball'],
         'info_string': 'blue rubber ball',
+        'pickupable': True,
         'type': 'sphere'
     }
-    goal = goal_obj.get_config({ 'target': [obj] })
+    goal = goal_obj._get_config({ 'target': [obj] })
+    assert goal['category'] == 'retrieval'
     assert goal['description'] == 'Find and pick up the blue rubber ball.'
     assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball'}
     target = goal['metadata']['target']
@@ -378,7 +543,29 @@ def test_RetrievalGoal_get_goal():
     assert target['info'] == ['blue', 'rubber', 'ball']
 
 
-def test_TraversalGoal_get_goal():
+def test_TraversalGoal_get_config_arg_count():
+    goal_obj = TraversalGoal()
+    with pytest.raises(exceptions.SceneException):
+        goal_obj._get_config({'target': []})
+
+
+def test_TraversalGoal_update_body():
+    goal = TraversalGoal()
+    body = goal.update_body({'wallMaterial': 'test_material', 'wallColors': []}, False)
+    assert body['performerStart'] == goal.get_performer_start()
+    assert body['goal']['category'] == 'traversal'
+    assert body['goal']['metadata']['target']
+    assert len(body['goal']['domain_list']) > 0
+    assert len(body['goal']['info_list']) > 0
+    assert len(body['goal']['type_list']) > 0
+    assert len(body['objects']) > 0
+
+    target = body['objects'][0]
+    assert target['id'] == body['goal']['metadata']['target']['id']
+    assert body['goal']['description'] == ('Find the ' + target['goal_string'] + ' and move near it.')
+
+
+def test_TraversalGoal_get_config():
     goal_obj = TraversalGoal()
     obj = {
         'id': str(uuid.uuid4()),
@@ -386,7 +573,8 @@ def test_TraversalGoal_get_goal():
         'info_string': 'blue rubber ball',
         'type': 'sphere'
     }
-    goal = goal_obj.get_config({ 'target': [obj] })
+    goal = goal_obj._get_config({ 'target': [obj] })
+    assert goal['category'] == 'traversal'
     assert goal['description'] == 'Find the blue rubber ball and move near it.'
     assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball'}
     target = goal['metadata']['target']
@@ -394,20 +582,47 @@ def test_TraversalGoal_get_goal():
     assert target['info'] == ['blue', 'rubber', 'ball']
 
 
-def test_TransferralGoal_get_goal_argcount():
+def test_TransferralGoal_update_body():
+    goal = TransferralGoal()
+    body = goal.update_body({'wallMaterial': 'test_material', 'wallColors': []}, False)
+    assert body['performerStart'] == goal.get_performer_start()
+    assert body['goal']['category'] == 'transferral'
+    assert body['goal']['metadata']['target_1']
+    assert body['goal']['metadata']['target_2']
+    assert len(body['goal']['domain_list']) > 0
+    assert len(body['goal']['info_list']) > 0
+    assert len(body['goal']['type_list']) > 0
+    assert len(body['objects']) > 0
+
+    target_1 = body['objects'][0]
+    target_2 = body['objects'][1]
+    assert target_1['pickupable']
+    assert target_2['stackTarget']
+    assert target_1['id'] == body['goal']['metadata']['target_1']['id']
+    assert target_2['id'] == body['goal']['metadata']['target_2']['id']
+    assert body['goal']['description'] == ('Find and pick up the ' + target_1['goal_string'] + ' and move it ' + \
+            body['goal']['metadata']['relationship'][1] + ' the ' + target_2['goal_string'] + '.')
+
+
+def test_TransferralGoal_get_config_arg_count():
     goal_obj = TransferralGoal()
     with pytest.raises(exceptions.SceneException):
-        goal_obj.get_config({ 'target': ['one object'] })
+        goal_obj._get_config({'target': []})
 
 
-def test_TransferralGoal_get_goal_argvalid():
+def test_TransferralGoal_get_config_arg_invalid_1():
     goal_obj = TransferralGoal()
-    target_list = [{'attributes': ['']}, {'attributes': ['']}]
     with pytest.raises(exceptions.SceneException):
-        goal_obj.get_config({ 'target': target_list })
+        goal_obj._get_config({'target': [{'pickupable': False}, {'stackTarget': True}]})
 
 
-def test__generate_transferral_goal():
+def test_TransferralGoal_get_config_arg_invalid_2():
+    goal_obj = TransferralGoal()
+    with pytest.raises(exceptions.SceneException):
+        goal_obj._get_config({'target': [{'pickupable': True}, {'stackTarget': False}]})
+
+
+def test_TransferralGoal_get_config():
     goal_obj = TransferralGoal()
     pickupable_id = str(uuid.uuid4())
     pickupable_obj = {
@@ -426,7 +641,7 @@ def test__generate_transferral_goal():
         'type': 'changing_table',
         'stackTarget': True
     }
-    goal = goal_obj.get_config({ 'target': [pickupable_obj, other_obj] })
+    goal = goal_obj._get_config({ 'target': [pickupable_obj, other_obj] })
 
     assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball', \
             'target yellow', 'target wood', 'target changing table', 'target yellow wood changing table'}
@@ -442,32 +657,9 @@ def test__generate_transferral_goal():
     relationship_type = relationship[1]
     assert relationship_type in [g.value for g in TransferralGoal.RelationshipType]
 
+    assert goal['category'] == 'transferral'
     assert goal['description'] == 'Find and pick up the blue rubber ball and move it ' + \
             relationship_type + ' the yellow wood changing table.'
-
-
-def test__generate_transferral_goal_with_nonstackable_goal():
-    goal_obj = TransferralGoal()
-    pickupable_id = str(uuid.uuid4())
-    pickupable_obj = {
-        'id': pickupable_id,
-        'info': ['blue', 'rubber', 'ball'],
-        'info_string': 'blue rubber ball',
-        'pickupable': True,
-        'type': 'sphere',
-        'attributes': ['pickupable']
-    }
-    other_id = str(uuid.uuid4())
-    other_obj = {
-        'id': other_id,
-        'info': ['yellow', 'wood', 'changing table'],
-        'info_string': 'yellow wood changing table',
-        'type': 'changing_table',
-        'attributes': []
-    }
-    with pytest.raises(exceptions.SceneException) as excinfo:
-        goal = goal_obj.get_config({ 'target': [pickupable_obj, other_obj] })
-    assert "second object must be" in str(excinfo.value)
 
 
 def test_TransferralGoal_ensure_pickup_action():
@@ -613,7 +805,7 @@ def test_add_RotateLook_to_action_list_before_Pickup_or_Put_Object():
     assert path[-1]['action'] == 'RotateLook'
 
 
-def test_traversal_performer_start_not_close_to_target():
+def test_TraversalGoal_performer_start_not_close_to_target():
     """Ensure the performerStart is not right next to the target object
     (for TraversalGoal). For MCS-158."""
     goal_obj = TraversalGoal()
@@ -628,7 +820,7 @@ def test_traversal_performer_start_not_close_to_target():
     assert dist >= geometry.MINIMUM_START_DIST_FROM_TARGET
 
 
-def test_transferral_targets_not_close_to_each_other():
+def test_TransferralGoal_targets_not_close_to_each_other():
     """Ensure that the targets for TransferralGoal aren't too close to
     each other. For MCS-158."""
     goal_obj = TransferralGoal()
@@ -642,3 +834,4 @@ def test_transferral_targets_not_close_to_each_other():
     distance = geometry.position_distance(target1['shows'][0]['position'],
                                           target2['shows'][0]['position'])
     assert distance >= geometry.MINIMUM_TARGET_SEPARATION
+

--- a/scene_generator/optimal_path.py
+++ b/scene_generator/optimal_path.py
@@ -6,13 +6,8 @@ from shapely.geometry import Polygon, Point
 from shapely.ops import unary_union
 
 from extremitypathfinder.extremitypathfinder import PolygonEnvironment as Environment
-from geometry import ROOM_DIMENSIONS
+from geometry import ROOM_X_MIN, ROOM_X_MAX, ROOM_Z_MIN, ROOM_Z_MAX
 from util import PERFORMER_WIDTH
-
-MIN_X = ROOM_DIMENSIONS[0][0]
-MAX_X = ROOM_DIMENSIONS[0][1]
-MIN_Z = ROOM_DIMENSIONS[1][0]
-MAX_Z = ROOM_DIMENSIONS[1][1]
 
 
 def _dilate_polygons(rects: List[List[Dict[str, float]]], dilation: float,
@@ -78,10 +73,10 @@ def generatepath(source_loc: Tuple[float, float],
     poly_coords = _unify_and_clean_polygons(polygons)
 
     environment = Environment()
-    boundary_coordinates = [(MAX_X - dilation, MAX_Z - dilation),
-                            (MIN_X + dilation, MAX_Z - dilation),
-                            (MIN_X + dilation, MIN_Z + dilation),
-                            (MAX_X - dilation, MIN_Z + dilation)]
+    boundary_coordinates = [(ROOM_X_MAX - dilation, ROOM_Z_MAX - dilation),
+                            (ROOM_X_MIN + dilation, ROOM_Z_MAX - dilation),
+                            (ROOM_X_MIN + dilation, ROOM_Z_MIN + dilation),
+                            (ROOM_X_MAX - dilation, ROOM_Z_MIN + dilation)]
     try:
         environment.store(boundary_coordinates, poly_coords, validate=True)
         environment.prepare()

--- a/scene_generator/pairs_test.py
+++ b/scene_generator/pairs_test.py
@@ -39,7 +39,8 @@ def verify_confusor(target, confusor):
     assert target['id'] != confusor['id']
     is_same_color = set(target['color']) == set(confusor['color'])
     is_same_shape = target['shape'] == confusor['shape']
-    is_same_size = (target['dimensions']['x'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['x'] <= \
+    is_same_size = target['size'] == confusor['size'] and \
+            (target['dimensions']['x'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['x'] <= \
             (target['dimensions']['x'] + util.MAX_SIZE_DIFFERENCE) and \
             (target['dimensions']['y'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['y'] <= \
             (target['dimensions']['y'] + util.MAX_SIZE_DIFFERENCE) and \

--- a/scene_generator/pairs_test.py
+++ b/scene_generator/pairs_test.py
@@ -1,13 +1,16 @@
 from typing import Dict, Any
 
 import shapely
+from shapely import affinity
 
 import containers
 import geometry
 from geometry_test import are_adjacent
-from pairs import Pair1, Pair2, Pair3, Pair4, Pair5, Pair6, Pair7
+from pairs import BoolPairOption, Pair1, Pair2, Pair3, Pair4, Pair5, Pair6, Pair7, Pair8, Pair9, Pair11
+import util
 
 
+MAX_DIMENSION = max(geometry.ROOM_X_MAX - geometry.ROOM_X_MIN, geometry.ROOM_Z_MAX - geometry.ROOM_Z_MIN)
 BODY_TEMPLATE = {
     'wallMaterial': 'test_wall_material',
     'wallColors': ['test_wall_color'],
@@ -26,151 +29,482 @@ BODY_TEMPLATE = {
 }
 
 
-def test_SimilarAdjacentPair():
-    pair = Pair3(BODY_TEMPLATE)
-    assert pair is not None
+def get_parent(object_instance, object_list):
+    parent_id = object_instance['locationParent']
+    parent = next((o for o in object_list if o['id'] == parent_id))
+    return parent
 
 
-def test_SimilarAdjacentPair_get_scenes():
-    pair = Pair3(BODY_TEMPLATE)
-    scene1, scene2 = pair.get_scenes()
-    assert scene1 is not None
-    assert scene2 is not None
-    assert len(scene1['objects']) >= 1
-    assert len(scene2['objects']) >= 2
-    target1 = pair._goal_1.get_target_list()[0]
-    in_container = 'locationParent' in target1
-    target2 = pair._goal_2.get_target_list()[0]
-    similar = pair._goal_2.get_confusor_list()[0]
-    assert ('locationParent' in target2) == in_container
-    assert ('locationParent' in similar) == in_container
-    assert are_adjacent(target2, similar)
+def verify_confusor(target, confusor):
+    assert target['id'] != confusor['id']
+    is_same_color = set(target['color']) == set(confusor['color'])
+    is_same_shape = target['shape'] == confusor['shape']
+    is_same_size = (target['dimensions']['x'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['x'] <= \
+            (target['dimensions']['x'] + util.MAX_SIZE_DIFFERENCE) and \
+            (target['dimensions']['y'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['y'] <= \
+            (target['dimensions']['y'] + util.MAX_SIZE_DIFFERENCE) and \
+            (target['dimensions']['z'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['z'] <= \
+            (target['dimensions']['z'] + util.MAX_SIZE_DIFFERENCE)
+    if (not is_same_color and not is_same_shape) or (not is_same_color and not is_same_size) or \
+            (not is_same_shape and not is_same_size) or (is_same_color and is_same_shape and is_same_size):
+        print(f'confusor should be same as target in all except one: color={is_same_color} shape={is_same_shape} size={is_same_size}\ntarget={target}\nconfusor={confusor}')
+        return False
+    return True
 
 
-def test_SimilarFarPair():
-    pair = Pair4(BODY_TEMPLATE)
-    assert pair is not None
+def verify_immediately_visible(performer_start, object_list, target, name = 'target'):
+    performer_point = shapely.geometry.Point(performer_start['position']['x'], performer_start['position']['z'])
+
+    target_or_parent = get_parent(target, object_list) if 'locationParent' in target else target
+    target_poly = geometry.get_bounding_polygon(target_or_parent)
+
+    view_line = shapely.geometry.LineString([[0, 0], [0, MAX_DIMENSION]])
+    view_line = affinity.rotate(view_line, -performer_start['rotation']['y'], origin=(0, 0))
+    view_line = affinity.translate(view_line, performer_start['position']['x'], performer_start['position']['z'])
+
+    if not target_poly.intersection(view_line):
+        print(f'{name} not visible in front of performer:\n{name}={target_or_parent}\nperformer_start={performer_start}')
+        return False
+
+    ignore_id_list = [target['id'], target_or_parent['id']]
+    for object_instance in object_list:
+        if object_instance['id'] not in ignore_id_list:
+            object_poly = geometry.get_bounding_polygon(object_instance)
+            if geometry.does_fully_obstruct_target(performer_start['position'], target_or_parent, object_poly):
+                print(f'non-{name} does obstruct {name}:\n{name}={target_or_parent}\nnon-{name}={object_instance}\nperformer_start={performer_start}')
+                return False
+
+    return True
 
 
-def test_SimilarFarPair_get_scenes():
-    pair = Pair4(BODY_TEMPLATE)
-    scene1, scene2 = pair.get_scenes()
-    assert scene1 is not None
-    assert scene2 is not None
-    target = pair._goal_1.get_target_list()[0]
-    in_container = 'locationParent' in target
-    target2 = pair._goal_2.get_target_list()[0]
-    similar = pair._goal_2.get_confusor_list()[0]
-    assert target2 == target
-    assert ('locationParent' in similar) == in_container
-    if in_container:
-        container1 = containers.get_parent(target2, scene2['objects'])
-        container2 = containers.get_parent(similar, scene2['objects'])
-        assert not are_adjacent(container1, container2)
-    else:
-        assert not are_adjacent(target2, similar)
+def verify_not_immediately_visible(performer_start, object_list, target, name = 'target'):
+    result = verify_immediately_visible(performer_start, object_list, target, name)
+    if result:
+        target_or_parent = get_parent(target, object_list) if 'locationParent' in target else target
+        print(f'{name} visible in front of performer:\n{name}={target_or_parent}\nperformer_start={performer_start}')
+    return not result
 
 
-def test_SimilarAdjacentFarPair():
-    pair = Pair5(BODY_TEMPLATE)
-    assert pair is not None
+def verify_obstructor(goal, scene, obstruct_vision = False):
+    performer_start = goal.get_performer_start()
+    target = goal.get_target_list()[0]
+    obstructor = goal.get_obstructor_list()[0]
+    dimensions = obstructor['closed_dimensions'] if 'closed_dimensions' in obstructor else obstructor['dimensions']
+
+    is_bigger = (target['dimensions']['x'] <= dimensions['x'] or target['dimensions']['z'] <= dimensions['z']) and \
+            (not obstruct_vision or target['dimensions']['y'] <= dimensions['y'])
+    if not is_bigger:
+        printf('obstructor isn\'t bigger than target:\ntarget={target}\nobstructor={obstructor}')
+        return False
+
+    obstructor_poly = geometry.get_bounding_polygon(obstructor)
+    if not geometry.does_fully_obstruct_target(performer_start['position'], target, obstructor_poly):
+        printf('obstructor doesn\'t completely obstruct target:\ntarget={target}\nobstructor={obstructor}')
+        return False
+
+    object_list = scene['objects']
+    ignore_id_list = [obstructor['id'], target['id'], target['locationParent'] if 'locationParent' in target else None]
+    for object_instance in object_list:
+        if object_instance['id'] not in ignore_id_list:
+            object_poly = geometry.get_bounding_polygon(object_instance)
+            if geometry.does_fully_obstruct_target(performer_start['position'], target, object_poly):
+                print(f'non-obstructor does obstruct target:\nobject={object_instance}\ntarget={target}\nperformer_start={performer_start}')
+                return False
+
+    return True
 
 
-def test_SimilarAdjacentFarPair_get_scene():
-    pair = Pair5(BODY_TEMPLATE)
-    scene1, scene2 = pair.get_scenes()
-    assert scene1 is not None
-    assert scene2 is not None
-    target = pair._goal_1.get_target_list()[0]
-    similar = pair._goal_1.get_confusor_list()[0]
-    is_contained = 'locationParent' in target
-    assert is_contained == ('locationParent' in similar)
-    if is_contained:
-        assert target['locationParent'] == similar['locationParent']
-    else:
-        assert are_adjacent(target, similar)
-    
-    target2 = pair._goal_2.get_target_list()[0]
-    similar2 = pair._goal_2.get_confusor_list()[0]
-    if is_contained:
-        assert target2['locationParent'] != similar2['locationParent']
-        target2Parent = containers.get_parent(target2, scene2['objects'])
-        similar2Parent = containers.get_parent(similar2, scene2['objects'])
-        assert not are_adjacent(target2Parent, similar2Parent)
-    else:
-        assert not are_adjacent(target2, similar2)
+def verify_same_object_list(name, object_list_1, object_list_2, ignore_id_list):
+    modified_object_list_1 = [obj for obj in object_list_1 if obj['id'] not in ignore_id_list]
+    modified_object_list_2 = [obj for obj in object_list_2 if obj['id'] not in ignore_id_list]
+    if len(modified_object_list_1) != len(modified_object_list_2):
+        print(f'{name} list should be same length')
+        return False
+    for index in range(len(modified_object_list_1)):
+        object_instance_1 = modified_object_list_1[index]
+        object_instance_2 = modified_object_list_2[index]
+        if object_instance_1 != object_instance_2:
+            print(f'{name} should be the same:\n{name}_1={object_instance_1}\n{name}_2={object_instance_2}')
+            return False
+    return True
 
 
-def test_ImmediatelyVisiblePair():
+def verify_same_object(name, object_1, object_2, difference_list):
+    key_set_1 = set(object_1.keys())
+    key_set_2 = set(object_2.keys())
+    for key in key_set_1.union(key_set_2):
+        if key in difference_list:
+            if (key in object_1 and key not in object_2) or (key not in object_1 and key in object_2):
+                pass
+            elif (key not in object_1 and key not in object_2) or object_1[key] == object_2[key]:
+                print(f'"{key}" property shouldn\'t be the same:\n{name}_1={object_1}\n{name}_2={object_2}')
+                return False
+        else:
+            if key not in object_1 or key not in object_2 or object_1[key] != object_2[key]:
+                print(f'"{key}" property should be the same:\n{name}_1={object_1}\n{name}_2={object_2}')
+                return False
+    return True
+
+
+def verify_pair(pair, scene_1, scene_2, target_same_position = True, confusor_same_position = True, \
+        target_parent_same_position = True, confusor_parent_same_position = True, target_parent_same = True, \
+        confusor_parent_same = True):
+    assert scene_1
+    assert scene_2
+
+    # Ensure the performer start in each scene is the same.
+    performer_start_1 = pair._goal_1.get_performer_start()
+    assert performer_start_1
+    performer_start_2 = pair._goal_2.get_performer_start()
+    assert performer_start_2
+    if performer_start_1 != performer_start_2:
+        print(f'performer_start should be the same: {performer_start_1} != {performer_start_2}')
+        return False
+
+    # Ensure the target object in each scene is the same, except for expected differences.
+    target_1 = pair._goal_1.get_target_list()[0]
+    assert target_1
+    target_2 = pair._goal_2.get_target_list()[0]
+    assert target_2
+    if not verify_same_object('target', target_1, target_2, ([] if target_same_position else ['shows']) + \
+            ([] if target_parent_same else ['locationParent'])):
+        return False
+
+    # If the target in each scene has a parent, ensure each target's parent is the same.
+    target_parent_1 = get_parent(target_1, scene_1['objects']) if 'locationParent' in target_1 else None
+    target_parent_2 = get_parent(target_2, scene_2['objects']) if 'locationParent' in target_2 else None
+    if target_parent_1 and target_parent_2 and target_parent_same:
+        if not verify_same_object('target_parent', target_parent_1, target_parent_2, \
+                [] if target_parent_same_position else ['shows']):
+            return False
+
+    # If a scene has a confusor, verify that it's a confusor of the target.
+    confusor_1 = pair._goal_1.get_confusor_list()[0] if len(pair._goal_1.get_confusor_list()) > 0 else None
+    if confusor_1 and not verify_confusor(target_1, confusor_1):
+        return False
+    confusor_2 = pair._goal_2.get_confusor_list()[0] if len(pair._goal_2.get_confusor_list()) > 0 else None
+    if confusor_2 and not verify_confusor(target_2, confusor_2):
+        return False
+    if confusor_1 and confusor_2:
+        if not verify_same_object('confusor', confusor_1, confusor_2, ([] if confusor_same_position else ['shows']) + \
+                ([] if confusor_parent_same else ['locationParent'])):
+            return False
+
+    # If each scene has a confusor with a parent, ensure each confusor's parent is the same.
+    confusor_parent_1 = get_parent(confusor_1, scene_1['objects']) if (confusor_1 and 'locationParent' in confusor_1) \
+            else None
+    confusor_parent_2 = get_parent(confusor_2, scene_2['objects']) if (confusor_2 and 'locationParent' in confusor_2) \
+            else None
+    if confusor_parent_1 and confusor_parent_2 and confusor_parent_same:
+        if not verify_same_object('confusor_parent', confusor_parent_1, confusor_parent_2, \
+                [] if confusor_parent_same_position else ['shows']):
+            return False
+
+    target_parent_id = target_parent_1['id'] if target_parent_1 else (target_parent_2['id'] if target_parent_2 else \
+            None)
+    confusor_id = confusor_1['id'] if confusor_1 else (confusor_2['id'] if confusor_2 else None)
+    confusor_parent_id = confusor_parent_1['id'] if confusor_parent_1 else (confusor_parent_2['id'] if \
+            confusor_parent_2 else None)
+
+    # Ignore the IDs of the target, confusor, and target/confusor parent, because they may change across the scenes.
+    ignore_id_list = [object_id for object_id in [
+        target_1['id'],
+        target_2['id'],
+        target_parent_1['id'] if target_parent_1 else None,
+        target_parent_2['id'] if target_parent_2 else None,
+        confusor_1['id'] if confusor_1 else None,
+        confusor_2['id'] if confusor_2 else None,
+        confusor_parent_1['id'] if confusor_parent_1 else None,
+        confusor_parent_2['id'] if confusor_parent_2 else None
+    ] if object_id]
+
+    # Ensure the random distractors are the same across the scenes.
+    distractor_list_1 = pair._goal_1.get_distractor_list()
+    distractor_list_2 = pair._goal_2.get_distractor_list()
+    if not verify_same_object_list('distractor', distractor_list_1, distractor_list_2, ignore_id_list):
+        return False
+
+    return True
+
+
+def test_Pair1():
     pair = Pair1(BODY_TEMPLATE)
-    assert pair is not None
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    containerize = pair._options.target_containerize == BoolPairOption.YES_YES
+    # The target's position is the same if it's in a box because only its box will have a different position.
+    assert verify_pair(pair, scene_1, scene_2, target_same_position = containerize, target_parent_same_position = False)
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    if containerize:
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
+                get_parent(target_1, scene_1['objects']))
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
+                get_parent(target_2, scene_2['objects']))
+    else:
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+
+    assert len(pair._goal_1.get_confusor_list()) == 0
+    assert len(pair._goal_2.get_confusor_list()) == 0
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 0
 
 
-def test_ImmediatelyVisiblePair_get_scenes():
-    pair = Pair1(BODY_TEMPLATE)
-    scene1, scene2 = pair.get_scenes()
-    assert scene1 is not None
-    assert scene2 is not None
-
-
-def test_ImmediatelyVisibleSimilar():
-    pair = Pair6(BODY_TEMPLATE)
-    assert pair is not None
-
-
-def is_contained(obj: Dict[str, Any]) -> bool:
-    return 'locationParent' in obj
-
-
-def test_ImmediatelyVisibleSimilar_get_scenes():
-    pair = Pair6(BODY_TEMPLATE)
-    scene1, scene2 = pair.get_scenes()
-    assert scene1 is not None
-    assert scene2 is not None
-    target1 = pair._goal_1.get_target_list()[0]
-    similar1 = pair._goal_1.get_confusor_list()[0]
-    assert is_contained(target1) == is_contained(similar1)
-    target2 = pair._goal_2.get_target_list()[0]
-    similar2 = pair._goal_2.get_confusor_list()[0]
-    assert is_contained(target2) == is_contained(similar2)
-
-
-def test_HiddenBehindPair_get_scenes():
+def test_Pair2():
     pair = Pair2(BODY_TEMPLATE)
-    scene1, scene2 = pair.get_scenes()
-    assert scene1 is not None
-    assert scene2 is not None
-    # ensure the obstructor is between the target and the performer
-    target = pair._goal_2.get_target_list()[0]
-    if 'locationParent' in target:
-        for distractor in pair._goal_2.get_distractor_list():
-            if target['locationParent'] == distractor['id']:
-                target = distractor
-                break
-    obstructor = pair._goal_2.get_obstructor_list()[0]
-    obstructor_dimensions = obstructor['closed_dimensions'] if 'closed_dimensions' in obstructor else \
-            obstructor['dimensions']
-    assert (target['dimensions']['x'] <= obstructor_dimensions['x'] or \
-            target['dimensions']['z'] <= obstructor_dimensions['z'])
-    assert target['dimensions']['y'] <= obstructor_dimensions['y']
-    assert geometry.does_obstruct_target(scene2['performerStart']['position'], target, \
-            geometry.get_bounding_polygon(obstructor))
-    for distractor in pair._goal_2.get_distractor_list():
-        if distractor['id'] != target['id']:
-            assert not geometry.does_obstruct_target(scene2['performerStart']['position'], target, \
-                    geometry.get_bounding_polygon(distractor))
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    containerize = pair._options.target_containerize == BoolPairOption.YES_YES
+    assert verify_pair(pair, scene_1, scene_2)
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    if containerize:
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
+                get_parent(target_1, scene_1['objects']))
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
+                get_parent(target_2, scene_2['objects']))
+    else:
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+
+    assert len(pair._goal_1.get_confusor_list()) == 0
+    assert len(pair._goal_2.get_confusor_list()) == 0
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 1
+
+    assert verify_obstructor(pair._goal_2, scene_2, obstruct_vision = True)
 
 
-def test_OneEnclosedPair_get_scenes():
+def test_Pair3():
+    pair = Pair3(BODY_TEMPLATE)
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    containerize = pair._options.target_containerize == BoolPairOption.YES_YES
+    # The target's position is NOT the same if it's in a box because of how the confusor's positioned next to it.
+    assert verify_pair(pair, scene_1, scene_2, target_same_position = (not containerize))
+
+    assert len(pair._goal_1.get_confusor_list()) == 0
+    assert len(pair._goal_2.get_confusor_list()) == 1
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 0
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    confusor_2 = pair._goal_2.get_confusor_list()[0]
+    assert geometry.are_adjacent(target_2, confusor_2)
+    if containerize:
+        assert target_1['locationParent']
+        assert target_2['locationParent'] == confusor_2['locationParent']
+    else:
+        assert not 'locationParent' in target_1
+        assert not 'locationParent' in target_2
+        assert not 'locationParent' in confusor_2
+
+
+def test_Pair4():
+    pair = Pair4(BODY_TEMPLATE)
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    containerize = pair._options.target_containerize == BoolPairOption.YES_YES
+    assert verify_pair(pair, scene_1, scene_2)
+
+    assert len(pair._goal_1.get_confusor_list()) == 0
+    assert len(pair._goal_2.get_confusor_list()) == 1
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 0
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    confusor_2 = pair._goal_2.get_confusor_list()[0]
+    if containerize:
+        assert target_1['locationParent']
+        assert target_2['locationParent'] != confusor_2['locationParent']
+        assert not geometry.are_adjacent(get_parent(target_2, scene_2['objects']), \
+                get_parent(confusor_2, scene_2['objects']))
+    else:
+        assert not 'locationParent' in target_1
+        assert not 'locationParent' in target_2
+        assert not 'locationParent' in confusor_2
+        assert not geometry.are_adjacent(target_2, confusor_2)
+
+
+def test_Pair5():
+    pair = Pair5(BODY_TEMPLATE)
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    containerize = pair._options.target_containerize == BoolPairOption.YES_YES
+    # The target's position is NOT the same if it's in a box because of how the confusor's positioned next to it.
+    assert verify_pair(pair, scene_1, scene_2, target_same_position = (not containerize), \
+            confusor_same_position = False, confusor_parent_same = False)
+
+    assert len(pair._goal_1.get_confusor_list()) == 1
+    assert len(pair._goal_2.get_confusor_list()) == 1
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 0
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    confusor_1 = pair._goal_1.get_confusor_list()[0]
+    confusor_2 = pair._goal_2.get_confusor_list()[0]
+    assert geometry.are_adjacent(target_1, confusor_1)
+    if containerize:
+        assert target_1['locationParent'] == confusor_1['locationParent']
+        assert target_2['locationParent'] != confusor_2['locationParent']
+        assert not geometry.are_adjacent(get_parent(target_2, scene_2['objects']), \
+                get_parent(confusor_2, scene_2['objects']))
+    else:
+        assert not 'locationParent' in target_1
+        assert not 'locationParent' in target_2
+        assert not 'locationParent' in confusor_1
+        assert not 'locationParent' in confusor_2
+        assert not geometry.are_adjacent(target_2, confusor_2)
+
+
+def test_Pair6():
+    pair = Pair6(BODY_TEMPLATE)
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    containerize = pair._options.target_containerize == BoolPairOption.YES_YES
+    # The object's position is the same if it's in a box because only its box will have a different position.
+    assert verify_pair(pair, scene_1, scene_2, target_same_position = containerize, \
+            confusor_same_position = containerize, target_parent_same_position = False,
+            confusor_parent_same_position = False)
+
+    assert len(pair._goal_1.get_confusor_list()) == 1
+    assert len(pair._goal_2.get_confusor_list()) == 1
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 0
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    confusor_1 = pair._goal_1.get_confusor_list()[0]
+    confusor_2 = pair._goal_2.get_confusor_list()[0]
+    if containerize:
+        assert target_1['locationParent'] != confusor_1['locationParent']
+        assert target_2['locationParent'] != confusor_2['locationParent']
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
+                get_parent(target_1, scene_1['objects']))
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
+                get_parent(target_2, scene_2['objects']))
+        assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
+                get_parent(confusor_1, scene_1['objects']), 'confusor')
+        assert verify_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
+                get_parent(confusor_2, scene_2['objects']), 'confusor')
+    else:
+        assert not 'locationParent' in target_1
+        assert not 'locationParent' in target_2
+        assert not 'locationParent' in confusor_1
+        assert not 'locationParent' in confusor_2
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+        assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], confusor_1, \
+                'confusor')
+        assert verify_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], confusor_2, \
+                'confusor')
+
+
+def test_Pair7():
     pair = Pair7(BODY_TEMPLATE)
-    scene1, scene2 = pair.get_scenes()
-    assert scene1 is not None
-    assert scene2 is not None
-    target = pair._goal_1.get_target_list()[0]
-    similar = pair._goal_1.get_confusor_list()[0]
-    assert ('locationParent' in target) != ('locationParent' in similar)
-    target2 = pair._goal_2.get_target_list()[0]
-    similar2 = pair._goal_2.get_confusor_list()[0]
-    assert ('locationParent' in target2) != ('locationParent' in similar2)
-    assert ('locationParent' in target) == ('locationParent' in target2)
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    # The target's position is the same if it's in a box because only its box will have a different position.
+    assert verify_pair(pair, scene_1, scene_2, confusor_same_position = False, target_parent_same_position = False)
+
+    assert len(pair._goal_1.get_confusor_list()) == 1
+    assert len(pair._goal_2.get_confusor_list()) == 1
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 0
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    confusor_1 = pair._goal_1.get_confusor_list()[0]
+    confusor_2 = pair._goal_2.get_confusor_list()[0]
+    assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], confusor_1, \
+            'confusor')
+    assert verify_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], confusor_2, 'confusor')
+    assert 'locationParent' in target_1
+    assert 'locationParent' in target_2
+    assert not 'locationParent' in confusor_1
+    assert not 'locationParent' in confusor_2
+    assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
+            get_parent(target_1, scene_1['objects']))
+    assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
+            get_parent(target_2, scene_2['objects']))
+
+
+def test_Pair8():
+    pair = Pair8(BODY_TEMPLATE)
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    assert verify_pair(pair, scene_1, scene_2, target_same_position = False, target_parent_same = False)
+
+    assert len(pair._goal_1.get_confusor_list()) == 1
+    assert len(pair._goal_2.get_confusor_list()) == 1
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 0
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    confusor_1 = pair._goal_1.get_confusor_list()[0]
+    confusor_2 = pair._goal_2.get_confusor_list()[0]
+    assert geometry.are_adjacent(target_1, confusor_1)
+    assert geometry.are_adjacent(get_parent(target_2, scene_2['objects']), confusor_2)
+    assert not 'locationParent' in target_1
+    assert 'locationParent' in target_2
+    assert not 'locationParent' in confusor_1
+    assert not 'locationParent' in confusor_2
+
+
+def test_Pair9():
+    pair = Pair9(BODY_TEMPLATE)
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    containerize = pair._options.target_containerize == BoolPairOption.YES_YES
+    assert verify_pair(pair, scene_1, scene_2)
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    if containerize:
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
+                get_parent(target_1, scene_1['objects']))
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
+                get_parent(target_2, scene_2['objects']))
+    else:
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+
+    assert len(pair._goal_1.get_confusor_list()) == 0
+    assert len(pair._goal_2.get_confusor_list()) == 0
+    assert len(pair._goal_1.get_obstructor_list()) == 0
+    assert len(pair._goal_2.get_obstructor_list()) == 1
+
+    assert verify_obstructor(pair._goal_2, scene_2, obstruct_vision = False)
+
+
+def test_Pair11():
+    pair = Pair11(BODY_TEMPLATE)
+    assert pair
+    scene_1, scene_2 = pair.get_scenes()
+    assert verify_pair(pair, scene_1, scene_2, target_same_position = False, confusor_same_position = False)
+
+    target_1 = pair._goal_1.get_target_list()[0]
+    target_2 = pair._goal_2.get_target_list()[0]
+    confusor_1 = pair._goal_1.get_confusor_list()[0]
+    confusor_2 = pair._goal_2.get_confusor_list()[0]
+    assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
+    assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+    """
+    assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], confusor_1, 'confusor')
+    assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], confusor_2, \
+            'confusor')
+    """
+    assert geometry.are_adjacent(target_1, confusor_1)
+    assert geometry.are_adjacent(target_2, confusor_2)
+    assert not 'locationParent' in target_1
+    assert not 'locationParent' in target_2
+    assert not 'locationParent' in confusor_1
+    assert not 'locationParent' in confusor_2
 

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -345,3 +345,16 @@ def move_to_location(obj_def: Dict[str, Any], obj: Dict[str, Any], location: Dic
         obj['shows'][0]['bounding_box'] = new_location['bounding_box']
     return obj
 
+
+def retrieve_full_object_definition_list(base_definition_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return the given object definition list in which finalize_object_definition was called on each definition with
+    each possible choice."""
+    object_definition_list = []
+    for base_object_definition in base_definition_list:
+        if 'choose' in base_object_definition:
+            for choice in base_object_definition['choose']:
+                object_definition_list.append(finalize_object_definition(base_object_definition, choice))
+        else:
+            object_definition_list.append(finalize_object_definition(base_object_definition))
+    return object_definition_list
+

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -10,7 +10,7 @@ import objects
 
 
 MAX_SIZE_DIFFERENCE = 0.1
-MAX_TRIES = 100
+MAX_TRIES = 50
 MIN_RANDOM_INTERVAL = 0.05
 PERFORMER_WIDTH = 0.1
 PERFORMER_HALF_WIDTH = PERFORMER_WIDTH / 2.0
@@ -43,6 +43,62 @@ def finalize_object_definition(object_def: Dict[str, Any],
     return object_def_copy
 
 
+def generate_materials_lists(material_category_list, previous_materials_lists):
+    if len(material_category_list) == 0:
+        return previous_materials_lists
+
+    output_materials_lists = []
+    material_category = material_category_list[0]
+    for material_and_color in getattr(materials, material_category.upper() + '_MATERIALS'):
+        if not previous_materials_lists:
+            output_materials_lists.append([material_and_color])
+        else:
+            for material_list in previous_materials_lists:
+                output_materials_lists.append(copy.deepcopy(material_list) + [material_and_color])
+    return generate_materials_lists(material_category_list[1:], output_materials_lists)
+
+
+def finalize_object_materials_and_colors(object_definition: Dict[str, Any], \
+        override_materials_list: Optional[List[Tuple[str, List[str]]]] = None) -> List[Dict[str, Any]]:
+    """Finalizes each possible choice of materials (patterns/textures) and colors as a copy of the given object
+    definition and returns the list."""
+
+    materials_lists = [override_materials_list] if override_materials_list else []
+
+    if not 'materialCategory' in object_definition or not object_definition['materialCategory']:
+        # TODO MCS-327 Uncomment
+        # raise exceptions.SceneException(f'object definition "{object_definition["type"]}" doesn\'t have material category')
+        object_definition['materialCategory'] = []
+
+    if not materials_lists:
+        materials_lists = generate_materials_lists(object_definition['materialCategory'], [])
+
+    if not materials_lists:
+        # TODO MCS-327 Uncomment
+        # raise exceptions.SceneException(f'object definition "{object_definition["type"]}" doesn\'t have materials')
+        object_definition_copy = copy.deepcopy(object_definition)
+        object_definition_copy['color'] = object_definition_copy['color'] if 'color' in object_definition_copy else []
+        object_definition_copy['materials_list'] = []
+        object_definition_copy['materials'] = None
+        return [object_definition_copy]
+
+    object_definition_list = []
+    for materials_list in materials_lists:
+        object_definition_copy = copy.deepcopy(object_definition)
+        object_definition_copy['color'] = []
+        object_definition_copy['materials_list'] = materials_list
+        object_definition_copy['materials'] = [material_and_color[0] for material_and_color in materials_list]
+        for material_and_color in materials_list:
+            if material_and_color[0] in materials.NOVEL_COLOR_LIST:
+                object_definition_copy['novel_color'] = True
+            for color in material_and_color[1]:
+                if color not in object_definition_copy['color']:
+                    object_definition_copy['color'].append(color)
+        object_definition_list.append(object_definition_copy)
+    return object_definition_list
+
+
+
 def instantiate_object(object_def: Dict[str, Any],
                        object_location: Dict[str, Any],
                        materials_list: Optional[List[Tuple[str, List[str]]]] = None) \
@@ -67,7 +123,7 @@ def instantiate_object(object_def: Dict[str, Any],
     if 'dimensions' in object_def:
         new_object['dimensions'] = object_def['dimensions']
     else:
-        exceptions.SceneException(f'object definition of type "{object_def["type"]}" doesn\'t have any dimensions')
+        raise exceptions.SceneException(f'object definition "{object_def["type"]}" doesn\'t have dimensions')
 
     for attribute in object_def['attributes']:
         new_object[attribute] = True
@@ -93,21 +149,17 @@ def instantiate_object(object_def: Dict[str, Any],
     new_object['shows'] = shows
     object_location['stepBegin'] = 0
     object_location['scale'] = object_def['scale']
-    colors = []
-    if materials_list is None and 'materialCategory' in object_def:
-        new_object['materialCategory'] = object_def['materialCategory']
-        materials_list = [random.choice(getattr(materials, name.upper() + '_MATERIALS')) for name in
-                          object_def['materialCategory']]
-    if materials_list is not None:
-        # need to remember materials for quartets
-        new_object['materials_list'] = materials_list
-        new_object['materials'] = [material_and_color[0] for material_and_color in materials_list]
-        for material_and_color in materials_list:
-            if material_and_color[0] in materials.NOVEL_COLOR_LIST:
-                new_object['novel_color'] = True
-            for color in material_and_color[1]:
-                if color not in colors:
-                    colors.append(color)
+
+    if 'color' not in object_def or 'materials' not in object_def:
+        object_def = random.choice(finalize_object_materials_and_colors(object_def, materials_list))
+
+    new_object['materialCategory'] = object_def['materialCategory']
+    # need the materials list for quartets
+    new_object['materials_list'] = object_def['materials_list']
+    new_object['materials'] = object_def['materials']
+    new_object['color'] = object_def['color']
+    new_object['novel_color'] = (object_def['novel_color'] if 'novel_color' in object_def else False) or \
+            new_object['novel_color']
 
     # The info list contains words that we can use to filter on specific object tags in the UI.
     # Start with this specific ordering of object tags in the info list needed for making the goal_string:
@@ -117,7 +169,7 @@ def instantiate_object(object_def: Dict[str, Any],
         new_object['salientMaterials'] = salient_materials
         new_object['info'] = new_object['info'][:1] + salient_materials + new_object['info'][1:]
 
-    new_object['info'] = new_object['info'][:1] + list(colors) + new_object['info'][1:]
+    new_object['info'] = new_object['info'][:1] + list(new_object['color']) + new_object['info'][1:]
 
     if 'pickupable' in object_def['attributes']:
         weight = 'light'
@@ -138,7 +190,7 @@ def instantiate_object(object_def: Dict[str, Any],
     new_object['size'] = new_object['info'][0]
 
     if new_object['novel_color']:
-        for color in list(colors):
+        for color in list(new_object['color']):
             new_object['info'].append('novel ' + color)
 
     if new_object['novel_shape']:
@@ -149,7 +201,7 @@ def instantiate_object(object_def: Dict[str, Any],
         new_object['novel_combination'] = False
 
     if new_object['novel_combination']:
-        for color in list(colors):
+        for color in list(new_object['color']):
             new_object['info'].append('novel ' + color + ' ' + new_object['shape'])
 
     return new_object
@@ -164,11 +216,11 @@ def get_similar_definition(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) 
     random.shuffle(choices)
     for choice in choices:
         if choice == 1:
-            new_obj = get_def_with_new_type(obj, all_defs)
+            new_obj = get_def_with_new_shape(obj, all_defs)
         elif choice == 2:
-            new_obj = get_def_with_new_material(obj, all_defs)
+            new_obj = get_def_with_new_color(obj, all_defs)
         else:
-            new_obj = get_def_with_new_scale(obj, all_defs)
+            new_obj = get_def_with_new_size(obj, all_defs)
         if new_obj is not None:
             return new_obj
     return None
@@ -181,6 +233,7 @@ def check_same_and_different(a: Dict[str, Any], b: Dict[str, Any],
     different that are in a, they exist in b and are different.
     """
 
+    # TODO MCS-328 Remove
     a['shape'] = a['shape'] if 'shape' in a else a['info'][-1]
     a['size'] = a['size'] if 'size' in a else a['info'][0]
     b['shape'] = b['shape'] if 'shape' in b else b['info'][-1]
@@ -192,6 +245,8 @@ def check_same_and_different(a: Dict[str, Any], b: Dict[str, Any],
             # Look at the dimensions as well as the size tag (tiny/small/medium/large/huge/etc.)
             if b[prop]['x'] > (a[prop]['x'] + MAX_SIZE_DIFFERENCE) or \
                     b[prop]['x'] < (a[prop]['x'] - MAX_SIZE_DIFFERENCE) or \
+                    b[prop]['y'] > (a[prop]['y'] + MAX_SIZE_DIFFERENCE) or \
+                    b[prop]['y'] < (a[prop]['y'] - MAX_SIZE_DIFFERENCE) or \
                     b[prop]['z'] > (a[prop]['z'] + MAX_SIZE_DIFFERENCE) or \
                     b[prop]['z'] < (a[prop]['z'] - MAX_SIZE_DIFFERENCE) or \
                     a['size'] != b['size']:
@@ -210,12 +265,15 @@ def check_same_and_different(a: Dict[str, Any], b: Dict[str, Any],
             # Look at the dimensions as well as the size tag (tiny/small/medium/large/huge/etc.)
             if b[prop]['x'] <= (a[prop]['x'] + MAX_SIZE_DIFFERENCE) and \
                     b[prop]['x'] >= (a[prop]['x'] - MAX_SIZE_DIFFERENCE) and \
+                    b[prop]['y'] <= (a[prop]['y'] + MAX_SIZE_DIFFERENCE) and \
+                    b[prop]['y'] >= (a[prop]['y'] - MAX_SIZE_DIFFERENCE) and \
                     b[prop]['z'] <= (a[prop]['z'] + MAX_SIZE_DIFFERENCE) and \
                     b[prop]['z'] >= (a[prop]['z'] - MAX_SIZE_DIFFERENCE) and \
                     a['size'] == b['size']:
                 diff_ok = False
                 break
-        elif (prop in a and prop in b and a[prop] == b[prop]) or (not prop in a and not prop in b):
+        elif (prop in a and prop in b and a[prop] == b[prop]) or \
+                (not prop in a and not prop in b and a['type'] == b['type']):
             diff_ok = False
             break
     return diff_ok
@@ -226,49 +284,52 @@ def get_similar_defs(obj: Dict[str, Any], all_defs: List[Dict[str, Any]], same: 
     """Return object definitions similar to obj: where properties from
     same are identical and from different are different.
     """
+
     valid_defs = []
     for obj_def in all_defs:
         if 'choose' in obj_def:
-            valid_choices = []
             for choice in obj_def['choose']:
-                possible_obj_def = finalize_object_definition(copy.deepcopy(obj_def), choice)
-                if check_same_and_different(possible_obj_def, obj, same, different):
-                    valid_choices.append(choice)
-            if len(valid_choices) > 0:
-                new_def = copy.deepcopy(obj_def)
-                new_def['choose'] = valid_choices
-                valid_defs.append(new_def)
+                possible_obj_def_template = finalize_object_definition(copy.deepcopy(obj_def), choice)
+                possible_obj_def_list = finalize_object_materials_and_colors(possible_obj_def_template)
+                for possible_obj_def in possible_obj_def_list:
+                    if check_same_and_different(possible_obj_def, obj, same, different):
+                        valid_defs.append(possible_obj_def)
         else:
-            possible_obj_def = finalize_object_definition(copy.deepcopy(obj_def))
-            if check_same_and_different(possible_obj_def, obj, same, different):
-                valid_defs.append(obj_def)
+            possible_obj_def_template = finalize_object_definition(copy.deepcopy(obj_def))
+            possible_obj_def_list = finalize_object_materials_and_colors(possible_obj_def_template)
+            for possible_obj_def in possible_obj_def_list:
+                if check_same_and_different(possible_obj_def, obj, same, different):
+                    valid_defs.append(possible_obj_def)
     return valid_defs
 
 
-def get_def_with_new_type(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, all_defs, ('materialCategory', 'dimensions'), ('shape',))
-    if len(valid_defs) > 0:
-        obj_def = random.choice(valid_defs)
-    else:
-        obj_def = None
+def get_def_with_new_shape(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(obj, all_defs, ('color', 'dimensions'), ('shape',))
+    if len(valid_defs) == 0:
+        return None
+    obj_def = random.choice(valid_defs)
+    # Save the similarity here for debugging
+    obj_def['similarity'] = 'shape'
     return obj_def
 
 
-def get_def_with_new_material(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, all_defs, ('shape', 'dimensions'), ('materialCategory',))
-    if len(valid_defs) > 0:
-        obj_def = random.choice(valid_defs)
-    else:
-        obj_def = None
+def get_def_with_new_color(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(obj, all_defs, ('shape', 'dimensions'), ('color',))
+    if len(valid_defs) == 0:
+        return None
+    obj_def = random.choice(valid_defs)
+    # Save the similarity here for debugging
+    obj_def['similarity'] = 'color'
     return obj_def
 
 
-def get_def_with_new_scale(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, all_defs, ('shape', 'materialCategory'), ('dimensions',))
-    if len(valid_defs) > 0:
-        obj_def = random.choice(valid_defs)
-    else:
-        obj_def = None
+def get_def_with_new_size(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(obj, all_defs, ('shape', 'color'), ('dimensions',))
+    if len(valid_defs) == 0:
+        return None
+    obj_def = random.choice(valid_defs)
+    # Save the similarity here for debugging
+    obj_def['similarity'] = 'size'
     return obj_def
 
 

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -5,7 +5,7 @@ import materials
 import objects
 from goals import *
 from util import finalize_object_definition, instantiate_object, check_same_and_different, get_similar_defs, \
-        random_real, move_to_location
+        random_real, move_to_location, retrieve_full_object_definition_list
 
 
 PACIFIER = {
@@ -406,17 +406,35 @@ def test_check_same_and_different():
         'shape': 'ball',
         'color': 'blue',
         'size': 'tiny',
-        'ignored': 'stuff'
+        'ignore': 'prop'
     }
     b = {
         'shape': 'ball',
-        'color': 'red',
+        'color': 'yellow',
         'size': 'tiny',
-        'ignored': 42
+        'ignore': 42
     }
+    assert check_same_and_different(a, b, [], []) is True
     assert check_same_and_different(a, b, ('shape', 'size'), ('color',)) is True
     assert check_same_and_different(a, b, ('shape', 'color'), ('size',)) is False
     assert check_same_and_different(a, b, ('color', 'size'), ('shape',)) is False
+
+
+def test_check_same_and_different_with_list():
+    a = {
+        'shape': ['ball'],
+        'color': ['blue'],
+        'size': 'tiny',
+        'ignore': 'prop'
+    }
+    b = {
+        'shape': ['ball'],
+        'color': ['yellow'],
+        'size': 'tiny',
+        'ignore': 42
+    }
+    assert check_same_and_different(a, b, ('shape'), ('color',)) is True
+    assert check_same_and_different(a, b, ('color'), ('shape',)) is False
 
 
 def test_check_same_and_different_with_dimensions():
@@ -481,30 +499,30 @@ def test_check_same_and_different_pacifier():
 
 
 def test_get_similar_defs_color():
-    object_list = objects.get_all_object_defs()
-    for object_definition in object_list:
+    object_definition_list = retrieve_full_object_definition_list(objects.get_all_object_defs())
+    for object_definition in object_definition_list:
         object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
-        similar_list = get_similar_defs(object_instance, object_list, ('dimensions', 'shape'), ('color',))
+        similar_list = get_similar_defs(object_instance, object_definition_list, ('dimensions', 'shape'), ('color',))
         for similar_definition in similar_list:
             similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
             assert check_same_and_different(similar_instance, object_instance, ('dimensions', 'shape'), ('color',))
 
 
 def test_get_similar_defs_shape():
-    object_list = objects.get_all_object_defs()
-    for object_definition in object_list:
+    object_definition_list = retrieve_full_object_definition_list(objects.get_all_object_defs())
+    for object_definition in object_definition_list:
         object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
-        similar_list = get_similar_defs(object_instance, object_list, ('color', 'dimensions'), ('shape',))
+        similar_list = get_similar_defs(object_instance, object_definition_list, ('color', 'dimensions'), ('shape',))
         for similar_definition in similar_list:
             similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
             assert check_same_and_different(similar_instance, object_instance, ('color', 'dimensions'), ('shape',))
 
 
 def test_get_similar_defs_size():
-    object_list = objects.get_all_object_defs()
-    for object_definition in object_list:
+    object_definition_list = retrieve_full_object_definition_list(objects.get_all_object_defs())
+    for object_definition in object_definition_list:
         object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
-        similar_list = get_similar_defs(object_instance, object_list, ('color', 'shape'), ('dimensions',))
+        similar_list = get_similar_defs(object_instance, object_definition_list, ('color', 'shape'), ('dimensions',))
         for similar_definition in similar_list:
             similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
             assert check_same_and_different(similar_instance, object_instance, ('color', 'shape'), ('dimensions',))
@@ -621,4 +639,28 @@ def test_move_to_location():
     assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
     assert instance['shows'][0]['bounding_box'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
             {'x': 1, 'z': 3}]
+
+
+def test_retrieve_full_object_definition_list():
+    list_1 = [{ 'type': 'ball', 'mass': 1 }]
+    actual_1 = retrieve_full_object_definition_list(list_1)
+    assert len(actual_1) == 1
+
+    list_2 = [{ 'type': 'ball', 'choose': [{ 'mass': 1 }, { 'mass': 2 }] }]
+    actual_2 = retrieve_full_object_definition_list(list_2)
+    assert len(actual_2) == 2
+
+    list_3 = [
+        { 'type': 'sofa' },
+        { 'type': 'ball', 'choose': [{ 'mass': 1 }, { 'mass': 2 }] }
+    ]
+    actual_3 = retrieve_full_object_definition_list(list_3)
+    assert len(actual_3) == 3
+
+    list_4 = [
+        { 'type': 'sofa', 'choose': [{ 'mass': 1 }, { 'mass': 3 }] },
+        { 'type': 'ball', 'choose': [{ 'mass': 1 }, { 'mass': 2 }] }
+    ]
+    actual_4 = retrieve_full_object_definition_list(list_4)
+    assert len(actual_4) == 4
 

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -4,12 +4,16 @@ import geometry
 import materials
 import objects
 from goals import *
-from util import finalize_object_definition, instantiate_object, check_same_and_different, get_similar_defs, random_real
+from util import finalize_object_definition, instantiate_object, check_same_and_different, get_similar_defs, \
+        random_real, move_to_location
 
 
 PACIFIER = {
     "type": "pacifier",
     "info": ["tiny", "blue", "pacifier"],
+    "color": "blue",
+    "shape": "pacifier",
+    "size": "tiny",
     "mass": 0.125,
     "salientMaterials": ["plastic"],
     "attributes": ["moveable", "pickupable"],
@@ -30,6 +34,7 @@ PACIFIER = {
         "z": 1
     }
 }
+
 
 def test_random_real():
     n = random_real(0, 1, 0.1)
@@ -63,10 +68,11 @@ def test_finalize_object_definition():
 def test_instantiate_object():
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'info': ['huge', 'sofa'],
         'mass': 12.34,
         'attributes': ['foo', 'bar'],
-        'scale': 1.0
+        'scale': {'x': 1, 'y': 1, 'z': 1}
     }
     object_location = {
         'position': {
@@ -83,6 +89,7 @@ def test_instantiate_object():
     obj = instantiate_object(object_def, object_location)
     assert type(obj['id']) is str
     assert obj['type'] == 'sofa_1'
+    assert obj['dimensions'] == object_def['dimensions']
     assert obj['goal_string'] == 'huge massive sofa'
     assert obj['info'] == ['huge', 'massive', 'sofa']
     assert obj['info_string'] == 'huge massive sofa'
@@ -91,19 +98,75 @@ def test_instantiate_object():
     assert obj['novel_combination'] is False
     assert obj['novel_shape'] is False
     assert obj['shape'] == 'sofa'
+    assert obj['size'] == 'huge'
     assert obj['foo'] is True
     assert obj['bar'] is True
+    assert obj['shows'][0]['stepBegin'] == 0
     assert obj['shows'][0]['position'] == object_location['position']
     assert obj['shows'][0]['rotation'] == object_location['rotation']
+    assert obj['shows'][0]['scale'] == object_def['scale']
+
+
+def test_instantiate_object_choose():
+    object_def = {
+        'type': 'sofa_1',
+        'choose': [{
+            'novel_shape': True,
+            'info': ['medium', 'sofa'],
+            'attributes': ['moveable'],
+            'dimensions': {'x': 0.5, 'y': 0.25, 'z': 0.25},
+            'mass': 12.34,
+            'scale': {'x': 0.5, 'y': 0.5, 'z': 0.5}
+        }, {
+            'info': ['huge', 'sofa'],
+            'attributes': [],
+            'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
+            'mass': 56.78,
+            'scale': {'x': 1, 'y': 1, 'z': 1}
+        }]
+    }
+    object_location = {
+        'position': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        },
+        'rotation': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        }
+    }
+    obj = instantiate_object(object_def, object_location)
+    assert obj['size'] == 'medium' or obj['size'] == 'huge'
+    if obj['size'] == 'medium':
+        assert obj['moveable']
+        assert obj['novel_shape']
+        assert obj['info'] == ['medium', 'heavy', 'sofa', 'novel sofa']
+        assert obj['info_string'] == 'medium heavy sofa'
+        assert obj['goal_string'] == 'medium heavy sofa'
+        assert obj['dimensions'] == {'x': 0.5, 'y': 0.25, 'z': 0.25}
+        assert obj['mass'] == 12.34
+        assert obj['shows'][0]['scale'] == {'x': 0.5, 'y': 0.5, 'z': 0.5}
+    if obj['size'] == 'huge':
+        assert 'moveable' not in obj
+        assert not obj['novel_shape']
+        assert obj['info'] == ['huge', 'massive', 'sofa']
+        assert obj['info_string'] == 'huge massive sofa'
+        assert obj['goal_string'] == 'huge massive sofa'
+        assert obj['dimensions'] == {'x': 1, 'y': 0.5, 'z': 0.5}
+        assert obj['mass'] == 56.78
+        assert obj['shows'][0]['scale'] == {'x': 1, 'y': 1, 'z': 1}
 
 
 def test_instantiate_object_heavy_moveable():
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'info': ['huge', 'sofa'],
         'mass': 12.34,
         'attributes': ['moveable'],
-        'scale': 1.0
+        'scale': {'x': 1, 'y': 1, 'z': 1}
     }
     object_location = {
         'position': {
@@ -127,10 +190,11 @@ def test_instantiate_object_heavy_moveable():
 def test_instantiate_object_light_pickupable():
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'info': ['huge', 'sofa'],
         'mass': 12.34,
         'attributes': ['moveable', 'pickupable'],
-        'scale': 1.0
+        'scale': {'x': 1, 'y': 1, 'z': 1}
     }
     object_location = {
         'position': {
@@ -159,9 +223,10 @@ def test_instantiate_object_offset():
     }
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'info': ['huge', 'sofa'],
         'mass': 12.34,
-        'scale': 1.0,
+        'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
         'offset': offset
     }
@@ -185,13 +250,40 @@ def test_instantiate_object_offset():
     assert position['z'] == z - offset['z']
 
 
+def test_instantiate_object_rotation():
+    object_def = {
+        'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
+        'info': ['huge', 'sofa'],
+        'mass': 12.34,
+        'scale': {'x': 1, 'y': 1, 'z': 1},
+        'attributes': [],
+        'rotation': {'x': 1, 'y': 2, 'z': 3}
+    }
+    object_location = {
+        'position': {
+            'x': 0.0,
+            'y': 0.0,
+            'z': 0.0
+        },
+        'rotation': {
+            'x': 30.0,
+            'y': 60.0,
+            'z': 90.0
+        }
+    }
+    obj = instantiate_object(object_def, object_location)
+    assert obj['shows'][0]['rotation'] == {'x': 31.0, 'y': 62.0, 'z': 93.0}
+
+
 def test_instantiate_object_materials():
     materials.TEST_MATERIALS = [('test_material', ['blue', 'yellow'])]
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'info': ['huge', 'sofa'],
         'mass': 12.34,
-        'scale': 1.0,
+        'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
         'materialCategory': ['test']
     }
@@ -209,6 +301,7 @@ def test_instantiate_object_materials():
     }
     obj = instantiate_object(object_def, object_location)
     assert obj['materials'] == ['test_material']
+    assert obj['color'] == ['blue', 'yellow']
     assert obj['goal_string'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa']
     assert obj['info_string'] == 'huge massive blue yellow sofa'
@@ -219,9 +312,10 @@ def test_instantiate_object_multiple_materials():
     materials.TEST2_MATERIALS = [('test_material_2', ['yellow'])]
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'info': ['huge', 'sofa'],
         'mass': 12.34,
-        'scale': 1.0,
+        'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
         'materialCategory': ['test1', 'test2']
     }
@@ -239,6 +333,7 @@ def test_instantiate_object_multiple_materials():
     }
     obj = instantiate_object(object_def, object_location)
     assert obj['materials'] == ['test_material_1', 'test_material_2']
+    assert obj['color'] == ['blue', 'yellow']
     assert obj['goal_string'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa']
     assert obj['info_string'] == 'huge massive blue yellow sofa'
@@ -247,9 +342,10 @@ def test_instantiate_object_multiple_materials():
 def test_instantiate_object_salient_materials():
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'info': ['huge', 'sofa'],
         'mass': 12.34,
-        'scale': 1.0,
+        'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
         'salientMaterials': ['fabric', 'wood']
     }
@@ -275,9 +371,10 @@ def test_instantiate_object_salient_materials():
 def test_instantiate_object_size():
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'info': ['huge', 'sofa'],
         'mass': 12.34,
-        'scale': 1.0,
+        'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
     }
     object_location = {
@@ -322,25 +419,102 @@ def test_check_same_and_different():
     assert check_same_and_different(a, b, ('color', 'size'), ('shape',)) is False
 
 
+def test_check_same_and_different_with_dimensions():
+    object_1 = {
+        'id': 'object_1',
+        'shape': 'ball',
+        'color': 'blue',
+        'dimensions': {'x': 1, 'y': 1, 'z': 1},
+        'size': 'medium'
+    }
+    object_2 = {
+        'id': 'object_2',
+        'shape': 'ball',
+        'color': 'blue',
+        'dimensions': {'x': 1, 'y': 1, 'z': 1},
+        'size': 'medium'
+    }
+    object_3 = {
+        'id': 'object_3',
+        'shape': 'ball',
+        'color': 'blue',
+        'dimensions': {'x': 1.1, 'y': 1.1, 'z': 1.1},
+        'size': 'medium'
+    }
+    object_4 = {
+        'id': 'object_4',
+        'shape': 'ball',
+        'color': 'blue',
+        'dimensions': {'x': 0.9, 'y': 0.9, 'z': 0.9},
+        'size': 'medium'
+    }
+    object_5 = {
+        'id': 'object_5',
+        'shape': 'ball',
+        'color': 'blue',
+        'dimensions': {'x': 1.2, 'y': 1.2, 'z': 1.2},
+        'size': 'medium'
+    }
+    object_6 = {
+        'id': 'object_6',
+        'shape': 'ball',
+        'color': 'blue',
+        'dimensions': {'x': 0.8, 'y': 0.8, 'z': 0.8},
+        'size': 'medium'
+    }
+    assert check_same_and_different(object_1, object_2, ('shape','dimensions'), ('id',)) is True
+    assert check_same_and_different(object_1, object_3, ('shape','dimensions'), ('id',)) is True
+    assert check_same_and_different(object_1, object_4, ('shape','dimensions'), ('id',)) is True
+    assert check_same_and_different(object_1, object_5, ('shape','dimensions'), ('id',)) is False
+    assert check_same_and_different(object_1, object_6, ('shape','dimensions'), ('id',)) is False
+    assert check_same_and_different(object_1, object_2, ('shape',), ('id','dimensions')) is False
+    assert check_same_and_different(object_1, object_3, ('shape',), ('id','dimensions')) is False
+    assert check_same_and_different(object_1, object_4, ('shape',), ('id','dimensions')) is False
+    assert check_same_and_different(object_1, object_5, ('shape',), ('id','dimensions')) is True
+    assert check_same_and_different(object_1, object_6, ('shape',), ('id','dimensions')) is True
+
+
 def test_check_same_and_different_pacifier():
     assert check_same_and_different(PACIFIER, PACIFIER, ('shape', 'dimensions'), ('materialCategory',)) is False
     assert check_same_and_different(PACIFIER, PACIFIER, ('shape', 'materialCategory'), ('dimensions',)) is False
     assert check_same_and_different(PACIFIER, PACIFIER, ('dimensions', 'materialCategory'), ('shape',)) is False
 
 
-def test_get_similar_defs():
-    original_def = objects.OBJECTS_PICKUPABLE_BALLS[0]
-    obj = instantiate_object(original_def, geometry.ORIGIN)
-    similar_defs = get_similar_defs(obj, objects.get_all_object_defs(), ('shape', 'materialCategory'), ('mass',))
-    for obj_def in similar_defs:
-        obj_2 = instantiate_object(obj_def, geometry.ORIGIN)
-        assert check_same_and_different(obj_2, obj, ('shape', 'materialCategory'), ('mass',))
+def test_get_similar_defs_color():
+    object_list = objects.get_all_object_defs()
+    for object_definition in object_list:
+        object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
+        similar_list = get_similar_defs(object_instance, object_list, ('dimensions', 'shape'), ('color',))
+        for similar_definition in similar_list:
+            similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
+            assert check_same_and_different(similar_instance, object_instance, ('dimensions', 'shape'), ('color',))
+
+
+def test_get_similar_defs_shape():
+    object_list = objects.get_all_object_defs()
+    for object_definition in object_list:
+        object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
+        similar_list = get_similar_defs(object_instance, object_list, ('color', 'dimensions'), ('shape',))
+        for similar_definition in similar_list:
+            similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
+            assert check_same_and_different(similar_instance, object_instance, ('color', 'dimensions'), ('shape',))
+
+
+def test_get_similar_defs_size():
+    object_list = objects.get_all_object_defs()
+    for object_definition in object_list:
+        object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
+        similar_list = get_similar_defs(object_instance, object_list, ('color', 'shape'), ('dimensions',))
+        for similar_definition in similar_list:
+            similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
+            assert check_same_and_different(similar_instance, object_instance, ('color', 'shape'), ('dimensions',))
 
 
 def test_instantiate_object_novel_color():
     materials.TEST_MATERIALS = [('test_material', ['blue', 'yellow'])]
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'novel_color': True,
         'info': ['huge', 'sofa'],
         'mass': 12.34,
@@ -370,6 +544,7 @@ def test_instantiate_object_novel_combination():
     materials.TEST_MATERIALS = [('test_material', ['blue', 'yellow'])]
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'novel_combination': True,
         'info': ['huge', 'sofa'],
         'mass': 12.34,
@@ -399,6 +574,7 @@ def test_instantiate_object_novel_shape():
     materials.TEST_MATERIALS = [('test_material', ['blue', 'yellow'])]
     object_def = {
         'type': 'sofa_1',
+        'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'novel_shape': True,
         'info': ['huge', 'sofa'],
         'mass': 12.34,
@@ -423,4 +599,26 @@ def test_instantiate_object_novel_shape():
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel sofa']
     assert obj['info_string'] == 'huge massive blue yellow sofa'
 
+
+def test_move_to_location():
+    instance = {'shows': [{'position': {'x': -1, 'y': 0, 'z': -1}, 'rotation': {'x': 0, 'y': 90, 'z': 0}}]}
+    location = {
+        'position': {'x': 2, 'y': 0, 'z': 2},
+        'rotation': {'x': 0, 'y': 0, 'z': 0},
+        'bounding_box': [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, {'x': 1, 'z': 3}]
+    }
+    actual = move_to_location({}, instance, location)
+    assert actual == instance
+    assert instance['shows'][0]['position'] == {'x': 2, 'y': 0, 'z': 2}
+    assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
+    assert instance['shows'][0]['bounding_box'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
+            {'x': 1, 'z': 3}]
+
+    definition = {'offset': {'x': 0.1, 'z': -0.5}}
+    actual = move_to_location(definition, instance, location)
+    assert actual == instance
+    assert instance['shows'][0]['position'] == {'x': 1.9, 'y': 0, 'z': 2.5}
+    assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
+    assert instance['shows'][0]['bounding_box'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
+            {'x': 1, 'z': 3}]
 


### PR DESCRIPTION
Accomplishments:
- Added a bunch of unit tests for pairs, interactive goals, and geometry/util functions
- Fixed an issue with the geometry function that positions an object adjacent to an existing object
- Fixed an issue with finding similarly colored objects
- Fixed issues with some intermittently broken unit tests
- Removed random choices from unit tests (they will now loop over and validate all possible choices)
- Various cleanup

Outstanding:
- Pair tests sometimes fail due to known issues (usually involving object visibility)
- Some quartet and intphys goal unit tests will intermittently fail (they will be fixed in a future ticket)