### PR TITLE
MCS-321 MCS-322 MCS-327 Minor Scene Generator Tasks

### DIFF
--- a/scene_generator/containers.py
+++ b/scene_generator/containers.py
@@ -10,11 +10,11 @@ import util
 def put_object_in_container(obj_def: Dict[str, Any], obj: Dict[str, Any], container: Dict[str, Any], \
         container_def: Dict[str, Any], area_index: int, rotation: Optional[float] = None) -> None:
 
-    area = container_def['enclosed_areas'][area_index]
+    area = container_def['enclosedAreas'][area_index]
     obj['locationParent'] = container['id']
 
     obj['shows'][0]['position'] = area['position'].copy()
-    obj['shows'][0]['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def.get('position_y', 0)
+    obj['shows'][0]['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def.get('positionY', 0)
 
     if 'rotation' not in obj['shows'][0]:
         obj['shows'][0]['rotation'] = geometry.ORIGIN.copy()
@@ -49,7 +49,7 @@ def put_objects_in_container(obj_def_a: Dict[str, Any], obj_a: Dict[str, Any], o
 
     # TODO This function should probably verify that both objects can fit together inside the container...
 
-    area = container_def['enclosed_areas'][area_index]
+    area = container_def['enclosedAreas'][area_index]
     obj_a['locationParent'] = container['id']
     obj_b['locationParent'] = container['id']
     shows_a = obj_a['shows'][0]
@@ -83,8 +83,8 @@ def put_objects_in_container(obj_def_a: Dict[str, Any], obj_a: Dict[str, Any], o
         shows_b['position'] = area['position'].copy()
         shows_b['position']['z'] += height_b / 2.0
 
-    shows_a['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def_a.get('position_y', 0)
-    shows_b['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def_b.get('position_y', 0)
+    shows_a['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def_a.get('positionY', 0)
+    shows_b['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def_b.get('positionY', 0)
     shows_a['rotation'] = { 'y': rot_a }
     shows_b['rotation'] = { 'y': rot_b }
 
@@ -120,15 +120,15 @@ def can_enclose(area: Dict[str, Any], target: Dict[str, Any]) -> Optional[float]
 
 def how_can_contain(container: Dict[str, Any],
                     *targets: Dict[str, Any]) -> Optional[Tuple[int, List[float]]]:
-    """Return the index of the container's "enclosed_areas" that all
+    """Return the index of the container's "enclosedAreas" that all
      targets fit in, or None if they all do not fit in any of the
-     enclosed_areas (or if the container doesn't have any). Does not
+     enclosedAreas (or if the container doesn't have any). Does not
      try any rotation to see if that makes it possible to fit.
     """
-    if 'enclosed_areas' not in container:
+    if 'enclosedAreas' not in container:
         return None
-    for i in range(len(container['enclosed_areas'])):
-        space = container['enclosed_areas'][i]
+    for i in range(len(container['enclosedAreas'])):
+        space = container['enclosedAreas'][i]
         angles = []
         fits = True
         for target in targets:
@@ -239,7 +239,7 @@ def can_contain_both(container_def: Dict[str, Any], obj_a: Dict[str, Any], obj_b
         -> Optional[Tuple[Dict[str, Any], int, Orientation, float, float]]:
     possible_enclosable_definition_list = util.finalize_each_object_definition_choice(container_def)
     for possible_enclosable_definition in possible_enclosable_definition_list:
-        result = _eas_can_contain_both(possible_enclosable_definition['enclosed_areas'], obj_a, obj_b)
+        result = _eas_can_contain_both(possible_enclosable_definition['enclosedAreas'], obj_a, obj_b)
         if result:
             index, orientation, angle_a, angle_b = result
             new_def = util.finalize_object_definition(container_def)
@@ -257,7 +257,7 @@ def find_suitable_enclosable_list(obj: Dict[str, Any], container_defs: Sequence[
     for obj_def in container_defs:
         possible_enclosable_definition_list = util.finalize_each_object_definition_choice(obj_def)
         for possible_enclosable_definition in possible_enclosable_definition_list:
-            for area in possible_enclosable_definition['enclosed_areas']:
+            for area in possible_enclosable_definition['enclosedAreas']:
                 if (area['dimensions']['x'] >= obj['dimensions']['x'] and \
                         area['dimensions']['y'] >= obj['dimensions']['y'] and \
                         area['dimensions']['z'] >= obj['dimensions']['z']):

--- a/scene_generator/containers.py
+++ b/scene_generator/containers.py
@@ -21,10 +21,10 @@ def put_object_in_container(obj_def: Dict[str, Any], obj: Dict[str, Any], contai
     if rotation is not None:
         obj['shows'][0]['rotation']['y'] = rotation
 
-    # if it had a bounding_box, it's not valid any more
-    obj.pop('bounding_box', None)
+    # if it had a boundingBox, it's not valid any more
+    obj.pop('boundingBox', None)
 
-    obj['shows'][0]['bounding_box'] = geometry.generate_object_bounds(obj_def['dimensions'], \
+    obj['shows'][0]['boundingBox'] = geometry.generate_object_bounds(obj_def['dimensions'], \
             (obj_def['offset'] if 'offset' in obj_def else None), obj['shows'][0]['position'], \
             obj['shows'][0]['rotation'])
 
@@ -88,14 +88,14 @@ def put_objects_in_container(obj_def_a: Dict[str, Any], obj_a: Dict[str, Any], o
     shows_a['rotation'] = { 'y': rot_a }
     shows_b['rotation'] = { 'y': rot_b }
 
-    # any bounding_box they may have had is not valid any more
-    shows_a.pop('bounding_box', None)
-    shows_b.pop('bounding_box', None)
+    # any boundingBox they may have had is not valid any more
+    shows_a.pop('boundingBox', None)
+    shows_b.pop('boundingBox', None)
 
-    shows_a['bounding_box'] = geometry.generate_object_bounds(obj_def_a['dimensions'], \
+    shows_a['boundingBox'] = geometry.generate_object_bounds(obj_def_a['dimensions'], \
             (obj_def_a['offset'] if 'offset' in obj_def_a else None), shows_a['position'], \
             shows_a['rotation'])
-    shows_b['bounding_box'] = geometry.generate_object_bounds(obj_def_b['dimensions'], \
+    shows_b['boundingBox'] = geometry.generate_object_bounds(obj_def_b['dimensions'], \
             (obj_def_b['offset'] if 'offset' in obj_def_b else None), shows_b['position'], \
             shows_b['rotation'])
 

--- a/scene_generator/containers_test.py
+++ b/scene_generator/containers_test.py
@@ -15,7 +15,7 @@ def test_put_object_in_container():
     for obj_def in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
         obj_location = geometry.calc_obj_pos({'x': 1, 'y': 0, 'z': 1}, [], obj_def)
         obj = util.instantiate_object(obj_def, obj_location)
-        obj_bounds = obj['shows'][0]['bounding_box']
+        obj_bounds = obj['shows'][0]['boundingBox']
 
         containments = get_enclosable_containments([obj_def])
         if len(containments) == 0 and obj_def['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS:
@@ -37,20 +37,20 @@ def test_put_object_in_container():
             assert obj['shows'][0]['position']['y'] == pytest.approx(expected_position_y)
             assert obj['shows'][0]['position']['z'] == container_def['enclosedAreas'][0]['position']['z']
             assert obj['shows'][0]['rotation']
-            assert obj['shows'][0]['bounding_box']
-            assert obj['shows'][0]['bounding_box'] != obj_bounds
+            assert obj['shows'][0]['boundingBox']
+            assert obj['shows'][0]['boundingBox'] != obj_bounds
 
 
 def test_put_objects_in_container():
     for obj_a_def in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
         obj_a_location = geometry.calc_obj_pos(geometry.ORIGIN, [], obj_a_def)
         obj_a = util.instantiate_object(obj_a_def, obj_a_location)
-        obj_a_bounds = obj_a['shows'][0]['bounding_box']
+        obj_a_bounds = obj_a['shows'][0]['boundingBox']
 
         for obj_b_def in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
             obj_b_location = geometry.calc_obj_pos(geometry.ORIGIN, [], obj_b_def)
             obj_b = util.instantiate_object(obj_b_def, obj_b_location)
-            obj_b_bounds = obj_b['shows'][0]['bounding_box']
+            obj_b_bounds = obj_b['shows'][0]['boundingBox']
 
             containments = get_enclosable_containments([obj_a_def, obj_b_def])
             if len(containments) == 0 and obj_a_def['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS and \
@@ -67,10 +67,10 @@ def test_put_objects_in_container():
                                          Orientation.SIDE_BY_SIDE, rotations[0], rotations[1])
                 assert obj_a['locationParent'] == container['id']
                 assert obj_b['locationParent'] == container['id']
-                assert obj_a['shows'][0]['bounding_box']
-                assert obj_b['shows'][0]['bounding_box']
-                assert obj_a['shows'][0]['bounding_box'] != obj_a_bounds
-                assert obj_b['shows'][0]['bounding_box'] != obj_b_bounds
+                assert obj_a['shows'][0]['boundingBox']
+                assert obj_b['shows'][0]['boundingBox']
+                assert obj_a['shows'][0]['boundingBox'] != obj_a_bounds
+                assert obj_b['shows'][0]['boundingBox'] != obj_b_bounds
                 assert are_adjacent(obj_a, obj_b)
 
 

--- a/scene_generator/containers_test.py
+++ b/scene_generator/containers_test.py
@@ -30,12 +30,12 @@ def test_put_object_in_container():
             put_object_in_container(obj_def, obj, container, container_def, area_index, rotations[0])
 
             assert obj['locationParent'] == container['id']
-            assert obj['shows'][0]['position']['x'] == container_def['enclosed_areas'][0]['position']['x']
-            expected_position_y = container_def['enclosed_areas'][0]['position']['y'] - \
-                    (container_def['enclosed_areas'][area_index]['dimensions']['y'] / 2.0) + \
-                    obj_def.get('position_y', 0)
+            assert obj['shows'][0]['position']['x'] == container_def['enclosedAreas'][0]['position']['x']
+            expected_position_y = container_def['enclosedAreas'][0]['position']['y'] - \
+                    (container_def['enclosedAreas'][area_index]['dimensions']['y'] / 2.0) + \
+                    obj_def.get('positionY', 0)
             assert obj['shows'][0]['position']['y'] == pytest.approx(expected_position_y)
-            assert obj['shows'][0]['position']['z'] == container_def['enclosed_areas'][0]['position']['z']
+            assert obj['shows'][0]['position']['z'] == container_def['enclosedAreas'][0]['position']['z']
             assert obj['shows'][0]['rotation']
             assert obj['shows'][0]['bounding_box']
             assert obj['shows'][0]['bounding_box'] != obj_bounds

--- a/scene_generator/geometry.py
+++ b/scene_generator/geometry.py
@@ -159,7 +159,7 @@ def calc_obj_pos(performer_position: Dict[str, float],
         new_object = {
             'rotation': {'x': rotation_x, 'y': rotation_y, 'z': rotation_z},
             'position':  {'x': new_x, 'y': obj_def.get('positionY', 0), 'z': new_z},
-            'bounding_box': rect
+            'boundingBox': rect
         }
         other_rects.append(rect)
         return new_object
@@ -348,7 +348,7 @@ def get_adjacent_location_on_side(object_definition: Dict[str, Any], target_defi
                 'y': target_location['rotation']['y'],
                 'z': 0
             },
-            'bounding_box': rect
+            'boundingBox': rect
         }
     else:
         location = None
@@ -381,13 +381,13 @@ def get_wider_and_taller_defs(obj_def: Dict[str, Any], obstruct_vision: bool) ->
 
 
 def get_bounding_polygon(object_or_location: Dict[str, Any]) -> shapely.geometry.Polygon:
-    if 'bounding_box' in object_or_location:
-        bounding_box: List[Dict[str, float]] = object_or_location['bounding_box']
+    if 'boundingBox' in object_or_location:
+        bounding_box: List[Dict[str, float]] = object_or_location['boundingBox']
         poly = rect_to_poly(bounding_box)
     else:
         show = object_or_location['shows'][0]
-        if 'bounding_box' in show:
-            bounding_box: List[Dict[str, float]] = show['bounding_box']
+        if 'boundingBox' in show:
+            bounding_box: List[Dict[str, float]] = show['boundingBox']
             poly = rect_to_poly(bounding_box)
         else:
             # TODO I think we need to consider the affect of the object's offsets on its poly here
@@ -429,7 +429,7 @@ def set_location_rotation(definition: Dict[str, Any], location: Dict[str, float]
         Dict[str, float]:
     """Updates the Y rotation and the bounding box of the given location and returns the location."""
     location['rotation']['y'] = rotation_y
-    location['bounding_box'] = generate_object_bounds(definition['dimensions'], \
+    location['boundingBox'] = generate_object_bounds(definition['dimensions'], \
             (definition['offset'] if 'offset' in definition else None), location['position'], location['rotation'])
     return location
 
@@ -467,8 +467,8 @@ def _does_obstruct_target_helper(performer_start_position: Dict[str, float], tar
 
     obstructing_corners = 0
     performer_start_coordinates = (performer_start_position['x'], performer_start_position['z'])
-    bounds = target_or_location['bounding_box'] if 'bounding_box' in target_or_location else \
-            (target_or_location['shows'][0]['bounding_box'] if 'shows' in target_or_location else [])
+    bounds = target_or_location['boundingBox'] if 'boundingBox' in target_or_location else \
+            (target_or_location['shows'][0]['boundingBox'] if 'shows' in target_or_location else [])
     for corner in bounds:
         target_corner_coordinates = (corner['x'], corner['z'])
         line_to_target = shapely.geometry.LineString([performer_start_coordinates, target_corner_coordinates])

--- a/scene_generator/geometry.py
+++ b/scene_generator/geometry.py
@@ -158,7 +158,7 @@ def calc_obj_pos(performer_position: Dict[str, float],
     if tries < util.MAX_TRIES:
         new_object = {
             'rotation': {'x': rotation_x, 'y': rotation_y, 'z': rotation_z},
-            'position':  {'x': new_x, 'y': obj_def.get('position_y', 0), 'z': new_z},
+            'position':  {'x': new_x, 'y': obj_def.get('positionY', 0), 'z': new_z},
             'bounding_box': rect
         }
         other_rects.append(rect)
@@ -309,9 +309,9 @@ def get_adjacent_location_on_side(object_definition: Dict[str, Any], target_defi
     """
     object_dimensions = object_definition['dimensions']
     object_offset = object_definition['offset'] if 'offset' in object_definition else {'x': 0, 'z': 0}
-    if obstruct and 'closed_dimensions' in object_definition:
-        object_dimensions = object_definition['closed_dimensions']
-        object_offset = object_definition['closed_offset'] if 'closed_offset' in object_definition else object_offset
+    if obstruct and 'closedDimensions' in object_definition:
+        object_dimensions = object_definition['closedDimensions']
+        object_offset = object_definition['closedOffset'] if 'closedOffset' in object_definition else object_offset
     target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
 
     distance_prop = 'x' if side in (0, 2) else 'z'
@@ -340,7 +340,7 @@ def get_adjacent_location_on_side(object_definition: Dict[str, Any], target_defi
         location = {
             'position': {
                 'x': x,
-                'y': object_definition.get('position_y', 0),
+                'y': object_definition.get('positionY', 0),
                 'z': z
             },
             'rotation': {
@@ -368,8 +368,8 @@ def get_wider_and_taller_defs(obj_def: Dict[str, Any], obstruct_vision: bool) ->
     for big_def in possible_defs:
         # Only look at definitions with the obstruct property.
         if 'obstruct' in big_def and big_def['obstruct'] == ('vision' if obstruct_vision else 'navigation'):
-            obj_dimensions = obj_def['closed_dimensions'] if 'closed_dimensions' in obj_def else obj_def['dimensions']
-            big_dimensions = big_def['closed_dimensions'] if 'closed_dimensions' in big_def else big_def['dimensions']
+            obj_dimensions = obj_def['closedDimensions'] if 'closedDimensions' in obj_def else obj_def['dimensions']
+            big_dimensions = big_def['closedDimensions'] if 'closedDimensions' in big_def else big_def['dimensions']
             cannot_walk_over = big_dimensions['y'] >= (PERFORMER_CAMERA_Y / 2.0)
             # Only need a bigger Y dimension if the object must obstruct vision.
             if cannot_walk_over and (not obstruct_vision or big_dimensions['y'] >= obj_dimensions['y']):

--- a/scene_generator/geometry.py
+++ b/scene_generator/geometry.py
@@ -361,16 +361,10 @@ def get_wider_and_taller_defs(obj_def: Dict[str, Any], obstruct_vision: bool) ->
     (z-axis), 90 degrees is returned. Objects returned may be equal in
     dimensions, not just strictly greater.
     """
-    defs = copy.deepcopy(objects.get_all_object_defs())
-    random.shuffle(defs)
     possible_defs = []
-    for new_def in defs:
-        if 'choose' in new_def:
-            for choice in new_def['choose']:
-                possible_defs.append(util.finalize_object_definition(copy.deepcopy(new_def), choice))
-        else:
-            possible_defs.append(util.finalize_object_definition(copy.deepcopy(new_def)))
     bigger_defs = []
+    for new_def in objects.get_all_object_defs():
+        possible_defs = possible_defs + util.finalize_each_object_definition_choice(new_def)
     for big_def in possible_defs:
         # Only look at definitions with the obstruct property.
         if 'obstruct' in big_def and big_def['obstruct'] == ('vision' if obstruct_vision else 'navigation'):

--- a/scene_generator/geometry_test.py
+++ b/scene_generator/geometry_test.py
@@ -479,70 +479,70 @@ def test_are_adjacent():
     dimensions = {'x': 2, 'y': 2, 'z': 2}
 
     center = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    center['bounding_box'] = generate_object_bounds(dimensions, None, center['position'], center['rotation'])
+    center['boundingBox'] = generate_object_bounds(dimensions, None, center['position'], center['rotation'])
 
     good_1 = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_1['bounding_box'] = generate_object_bounds(dimensions, None, good_1['position'], good_1['rotation'])
+    good_1['boundingBox'] = generate_object_bounds(dimensions, None, good_1['position'], good_1['rotation'])
     assert are_adjacent(center, good_1)
 
     good_2 = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_2['bounding_box'] = generate_object_bounds(dimensions, None, good_2['position'], good_2['rotation'])
+    good_2['boundingBox'] = generate_object_bounds(dimensions, None, good_2['position'], good_2['rotation'])
     assert are_adjacent(center, good_2)
 
     good_3 = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_3['bounding_box'] = generate_object_bounds(dimensions, None, good_3['position'], good_3['rotation'])
+    good_3['boundingBox'] = generate_object_bounds(dimensions, None, good_3['position'], good_3['rotation'])
     assert are_adjacent(center, good_3)
 
     good_4 = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_4['bounding_box'] = generate_object_bounds(dimensions, None, good_4['position'], good_4['rotation'])
+    good_4['boundingBox'] = generate_object_bounds(dimensions, None, good_4['position'], good_4['rotation'])
     assert are_adjacent(center, good_4)
 
     good_5 = {'position': {'x': 2, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_5['bounding_box'] = generate_object_bounds(dimensions, None, good_5['position'], good_5['rotation'])
+    good_5['boundingBox'] = generate_object_bounds(dimensions, None, good_5['position'], good_5['rotation'])
     assert are_adjacent(center, good_5)
 
     good_6 = {'position': {'x': 2, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_6['bounding_box'] = generate_object_bounds(dimensions, None, good_6['position'], good_6['rotation'])
+    good_6['boundingBox'] = generate_object_bounds(dimensions, None, good_6['position'], good_6['rotation'])
     assert are_adjacent(center, good_6)
 
     good_7 = {'position': {'x': -2, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_7['bounding_box'] = generate_object_bounds(dimensions, None, good_7['position'], good_7['rotation'])
+    good_7['boundingBox'] = generate_object_bounds(dimensions, None, good_7['position'], good_7['rotation'])
     assert are_adjacent(center, good_7)
 
     good_8 = {'position': {'x': -2, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_8['bounding_box'] = generate_object_bounds(dimensions, None, good_8['position'], good_8['rotation'])
+    good_8['boundingBox'] = generate_object_bounds(dimensions, None, good_8['position'], good_8['rotation'])
     assert are_adjacent(center, good_8)
 
     bad_1 = {'position': {'x': 3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_1['bounding_box'] = generate_object_bounds(dimensions, None, bad_1['position'], bad_1['rotation'])
+    bad_1['boundingBox'] = generate_object_bounds(dimensions, None, bad_1['position'], bad_1['rotation'])
     assert not are_adjacent(center, bad_1)
 
     bad_2 = {'position': {'x': -3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_2['bounding_box'] = generate_object_bounds(dimensions, None, bad_2['position'], bad_2['rotation'])
+    bad_2['boundingBox'] = generate_object_bounds(dimensions, None, bad_2['position'], bad_2['rotation'])
     assert not are_adjacent(center, bad_2)
 
     bad_3 = {'position': {'x': 0, 'y': 0, 'z': 3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_3['bounding_box'] = generate_object_bounds(dimensions, None, bad_3['position'], bad_3['rotation'])
+    bad_3['boundingBox'] = generate_object_bounds(dimensions, None, bad_3['position'], bad_3['rotation'])
     assert not are_adjacent(center, bad_3)
 
     bad_4 = {'position': {'x': 0, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_4['bounding_box'] = generate_object_bounds(dimensions, None, bad_4['position'], bad_4['rotation'])
+    bad_4['boundingBox'] = generate_object_bounds(dimensions, None, bad_4['position'], bad_4['rotation'])
     assert not are_adjacent(center, bad_4)
 
     bad_5 = {'position': {'x': 2.5, 'y': 0, 'z': 2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_5['bounding_box'] = generate_object_bounds(dimensions, None, bad_5['position'], bad_5['rotation'])
+    bad_5['boundingBox'] = generate_object_bounds(dimensions, None, bad_5['position'], bad_5['rotation'])
     assert not are_adjacent(center, bad_5)
 
     bad_6 = {'position': {'x': 2.5, 'y': 0, 'z': -2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_6['bounding_box'] = generate_object_bounds(dimensions, None, bad_6['position'], bad_6['rotation'])
+    bad_6['boundingBox'] = generate_object_bounds(dimensions, None, bad_6['position'], bad_6['rotation'])
     assert not are_adjacent(center, bad_6)
 
     bad_7 = {'position': {'x': -2.5, 'y': 0, 'z': 2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_7['bounding_box'] = generate_object_bounds(dimensions, None, bad_7['position'], bad_7['rotation'])
+    bad_7['boundingBox'] = generate_object_bounds(dimensions, None, bad_7['position'], bad_7['rotation'])
     assert not are_adjacent(center, bad_7)
 
     bad_8 = {'position': {'x': -2.5, 'y': 0, 'z': -2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_8['bounding_box'] = generate_object_bounds(dimensions, None, bad_8['position'], bad_8['rotation'])
+    bad_8['boundingBox'] = generate_object_bounds(dimensions, None, bad_8['position'], bad_8['rotation'])
     assert not are_adjacent(center, bad_8)
 
 
@@ -551,70 +551,70 @@ def test_are_adjacent_with_offset():
     offset = {'x': -1, 'y': 0, 'z': 1}
 
     center = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    center['bounding_box'] = generate_object_bounds(dimensions, None, center['position'], center['rotation'])
+    center['boundingBox'] = generate_object_bounds(dimensions, None, center['position'], center['rotation'])
 
     good_1 = {'position': {'x': 3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_1['bounding_box'] = generate_object_bounds(dimensions, offset, good_1['position'], good_1['rotation'])
+    good_1['boundingBox'] = generate_object_bounds(dimensions, offset, good_1['position'], good_1['rotation'])
     assert are_adjacent(center, good_1)
 
     good_2 = {'position': {'x': -1, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_2['bounding_box'] = generate_object_bounds(dimensions, offset, good_2['position'], good_2['rotation'])
+    good_2['boundingBox'] = generate_object_bounds(dimensions, offset, good_2['position'], good_2['rotation'])
     assert are_adjacent(center, good_2)
 
     good_3 = {'position': {'x': 0, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_3['bounding_box'] = generate_object_bounds(dimensions, offset, good_3['position'], good_3['rotation'])
+    good_3['boundingBox'] = generate_object_bounds(dimensions, offset, good_3['position'], good_3['rotation'])
     assert are_adjacent(center, good_3)
 
     good_4 = {'position': {'x': 0, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_4['bounding_box'] = generate_object_bounds(dimensions, offset, good_4['position'], good_4['rotation'])
+    good_4['boundingBox'] = generate_object_bounds(dimensions, offset, good_4['position'], good_4['rotation'])
     assert are_adjacent(center, good_4)
 
     good_5 = {'position': {'x': 3, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_5['bounding_box'] = generate_object_bounds(dimensions, offset, good_5['position'], good_5['rotation'])
+    good_5['boundingBox'] = generate_object_bounds(dimensions, offset, good_5['position'], good_5['rotation'])
     assert are_adjacent(center, good_5)
 
     good_6 = {'position': {'x': 3, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_6['bounding_box'] = generate_object_bounds(dimensions, offset, good_6['position'], good_6['rotation'])
+    good_6['boundingBox'] = generate_object_bounds(dimensions, offset, good_6['position'], good_6['rotation'])
     assert are_adjacent(center, good_6)
 
     good_7 = {'position': {'x': -1, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_7['bounding_box'] = generate_object_bounds(dimensions, offset, good_7['position'], good_7['rotation'])
+    good_7['boundingBox'] = generate_object_bounds(dimensions, offset, good_7['position'], good_7['rotation'])
     assert are_adjacent(center, good_7)
 
     good_8 = {'position': {'x': -1, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_8['bounding_box'] = generate_object_bounds(dimensions, offset, good_8['position'], good_8['rotation'])
+    good_8['boundingBox'] = generate_object_bounds(dimensions, offset, good_8['position'], good_8['rotation'])
     assert are_adjacent(center, good_8)
 
     bad_1 = {'position': {'x': 4, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_1['bounding_box'] = generate_object_bounds(dimensions, offset, bad_1['position'], bad_1['rotation'])
+    bad_1['boundingBox'] = generate_object_bounds(dimensions, offset, bad_1['position'], bad_1['rotation'])
     assert not are_adjacent(center, bad_1)
 
     bad_2 = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_2['bounding_box'] = generate_object_bounds(dimensions, offset, bad_2['position'], bad_2['rotation'])
+    bad_2['boundingBox'] = generate_object_bounds(dimensions, offset, bad_2['position'], bad_2['rotation'])
     assert not are_adjacent(center, bad_2)
 
     bad_3 = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_3['bounding_box'] = generate_object_bounds(dimensions, offset, bad_3['position'], bad_3['rotation'])
+    bad_3['boundingBox'] = generate_object_bounds(dimensions, offset, bad_3['position'], bad_3['rotation'])
     assert not are_adjacent(center, bad_3)
 
     bad_4 = {'position': {'x': 0, 'y': 0, 'z': -4}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_4['bounding_box'] = generate_object_bounds(dimensions, offset, bad_4['position'], bad_4['rotation'])
+    bad_4['boundingBox'] = generate_object_bounds(dimensions, offset, bad_4['position'], bad_4['rotation'])
     assert not are_adjacent(center, bad_4)
 
     bad_5 = {'position': {'x': 3.5, 'y': 0, 'z': 1.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_5['bounding_box'] = generate_object_bounds(dimensions, offset, bad_5['position'], bad_5['rotation'])
+    bad_5['boundingBox'] = generate_object_bounds(dimensions, offset, bad_5['position'], bad_5['rotation'])
     assert not are_adjacent(center, bad_5)
 
     bad_6 = {'position': {'x': 3.5, 'y': 0, 'z': -3.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_6['bounding_box'] = generate_object_bounds(dimensions, offset, bad_6['position'], bad_6['rotation'])
+    bad_6['boundingBox'] = generate_object_bounds(dimensions, offset, bad_6['position'], bad_6['rotation'])
     assert not are_adjacent(center, bad_6)
 
     bad_7 = {'position': {'x': -1.5, 'y': 0, 'z': 1.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_7['bounding_box'] = generate_object_bounds(dimensions, offset, bad_7['position'], bad_7['rotation'])
+    bad_7['boundingBox'] = generate_object_bounds(dimensions, offset, bad_7['position'], bad_7['rotation'])
     assert not are_adjacent(center, bad_7)
 
     bad_8 = {'position': {'x': -1.5, 'y': 0, 'z': -3.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_8['bounding_box'] = generate_object_bounds(dimensions, offset, bad_8['position'], bad_8['rotation'])
+    bad_8['boundingBox'] = generate_object_bounds(dimensions, offset, bad_8['position'], bad_8['rotation'])
     assert not are_adjacent(center, bad_8)
 
 
@@ -624,7 +624,7 @@ def test_get_adjacent_location():
 
     for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
         target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-        target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], \
+        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], \
                 (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
                 target_location['rotation'])
         target_poly = get_bounding_polygon(target_location)
@@ -646,7 +646,7 @@ def test_get_adjacent_location_with_obstruct():
 
     for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
         target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-        target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], \
+        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], \
                 (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
                 target_location['rotation'])
         target_poly = get_bounding_polygon(target_location)
@@ -669,12 +669,12 @@ def test_get_adjacent_location_on_side():
     for target_definition in util.retrieve_full_object_definition_list(objects.OBJECTS_PICKUPABLE):
         target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
         target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-        target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
+        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
                 target_location['position'], target_location['rotation'])
         target_poly = get_bounding_polygon(target_location)
 
         target_x_min, target_x_max, target_z_min, target_z_max = get_min_and_max_in_bounds( \
-                target_location['bounding_box'])
+                target_location['boundingBox'])
 
         for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
             object_offset = object_definition['offset'] if 'offset' in object_definition else {'x': 0, 'z': 0}
@@ -682,7 +682,7 @@ def test_get_adjacent_location_on_side():
             location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
                     performer_start, Side.RIGHT, False)
             assert location
-            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['boundingBox'])
             assert target_x_max <= x_min <= ROOM_X_MAX
             assert target_x_max <= x_max <= ROOM_X_MAX
             assert target_location['position']['z'] + target_offset['z'] == \
@@ -693,7 +693,7 @@ def test_get_adjacent_location_on_side():
             location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
                     performer_start, Side.LEFT, False)
             assert location
-            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['boundingBox'])
             assert ROOM_X_MIN <= x_min <= target_x_min
             assert ROOM_X_MIN <= x_max <= target_x_min
             assert target_location['position']['z'] + target_offset['z'] == \
@@ -704,7 +704,7 @@ def test_get_adjacent_location_on_side():
             location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
                     performer_start, Side.FRONT, False)
             assert location
-            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['boundingBox'])
             assert target_z_max <= z_min <= ROOM_Z_MAX
             assert target_z_max <= z_max <= ROOM_Z_MAX
             assert target_location['position']['x'] + target_offset['x'] == \
@@ -715,7 +715,7 @@ def test_get_adjacent_location_on_side():
             location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
                     performer_start, Side.BACK, False)
             assert location
-            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['bounding_box'])
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['boundingBox'])
             assert ROOM_Z_MIN <= z_min <= target_z_min
             assert ROOM_Z_MIN <= z_max <= target_z_min
             assert target_location['position']['x'] + target_offset['x'] == \
@@ -731,7 +731,7 @@ def test_get_adjacent_location_on_side_next_to_room_wall():
     for target_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
         target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
         target_location = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-        target_location['bounding_box'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
+        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
                 target_location['position'], target_location['rotation'])
 
         for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
@@ -807,77 +807,77 @@ def test_set_location_rotation():
         location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
         location = set_location_rotation(definition, location, 0)
         assert location['rotation']['y'] == 0
-        assert location['bounding_box'][0]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['bounding_box'][0]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['bounding_box'][1]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['bounding_box'][1]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['bounding_box'][2]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['bounding_box'][2]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['bounding_box'][3]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['bounding_box'][3]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][0]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][0]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][1]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][1]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][2]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][2]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][3]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][3]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
 
         location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
         location = set_location_rotation(definition, location, 90)
         assert location['rotation']['y'] == 90
-        assert location['bounding_box'][0]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['bounding_box'][0]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['bounding_box'][1]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['bounding_box'][1]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['bounding_box'][2]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['bounding_box'][2]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['bounding_box'][3]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['bounding_box'][3]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][0]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][0]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][1]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][1]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][2]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][2]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][3]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][3]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
 
         location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
         location = set_location_rotation(definition, location, 180)
         assert location['rotation']['y'] == 180
-        assert location['bounding_box'][0]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['bounding_box'][0]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['bounding_box'][1]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['bounding_box'][1]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['bounding_box'][2]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['bounding_box'][2]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['bounding_box'][3]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['bounding_box'][3]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][0]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][0]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][1]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][1]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][2]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][2]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][3]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][3]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
 
         location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
         location = set_location_rotation(definition, location, 270)
         assert location['rotation']['y'] == 270
-        assert location['bounding_box'][0]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['bounding_box'][0]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['bounding_box'][1]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['bounding_box'][1]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['bounding_box'][2]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['bounding_box'][2]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['bounding_box'][3]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['bounding_box'][3]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][0]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][0]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][1]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][1]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][2]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][2]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][3]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][3]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
 
 
 def test_does_fully_obstruct_target():
     target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['bounding_box'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
+    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
             target_location['position'], target_location['rotation'])
 
     obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
@@ -885,29 +885,29 @@ def test_does_fully_obstruct_target():
 
 def test_does_fully_obstruct_target_returns_false_too_small():
     target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['bounding_box'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
+    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
             target_location['position'], target_location['rotation'])
 
     obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
@@ -915,11 +915,11 @@ def test_does_fully_obstruct_target_returns_false_too_small():
 
 def test_does_fully_obstruct_target_returns_false_performer_start():
     target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['bounding_box'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
+    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
             target_location['position'], target_location['rotation'])
 
     obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
@@ -929,7 +929,7 @@ def test_does_fully_obstruct_target_returns_false_performer_start():
     assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
@@ -939,7 +939,7 @@ def test_does_fully_obstruct_target_returns_false_performer_start():
     assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
@@ -949,7 +949,7 @@ def test_does_fully_obstruct_target_returns_false_performer_start():
     assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
@@ -961,53 +961,53 @@ def test_does_fully_obstruct_target_returns_false_performer_start():
 
 def test_does_fully_obstruct_target_returns_false_visible_corners():
     target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['bounding_box'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
+    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
             target_location['position'], target_location['rotation'])
 
     obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': -2, 'y': 0, 'z': -1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 2, 'y': 0, 'z': -1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 1, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': -1, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': 1, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
     obstructor_location = {'position': {'x': -1, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['bounding_box'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
             obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
     assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)

--- a/scene_generator/geometry_test.py
+++ b/scene_generator/geometry_test.py
@@ -742,13 +742,13 @@ def test_get_adjacent_location_on_side_next_to_room_wall():
 
 def test_get_wider_and_taller_defs():
     for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
-        object_dimensions = object_definition['closed_dimensions'] if 'closed_dimensions' in object_definition else \
+        object_dimensions = object_definition['closedDimensions'] if 'closedDimensions' in object_definition else \
                 object_definition['dimensions']
         bigger_definition_list = get_wider_and_taller_defs(object_definition, False)
         for bigger_definition_result in bigger_definition_list:
             bigger_definition, angle = bigger_definition_result
             bigger_definition = util.finalize_object_definition(bigger_definition)
-            bigger_dimensions = bigger_definition['closed_dimensions'] if 'closed_dimensions' in bigger_definition \
+            bigger_dimensions = bigger_definition['closedDimensions'] if 'closedDimensions' in bigger_definition \
                     else bigger_definition['dimensions']
             assert bigger_definition['obstruct'] == 'navigation'
             assert bigger_dimensions['y'] >= 0.2
@@ -761,13 +761,13 @@ def test_get_wider_and_taller_defs():
 
 def test_get_wider_and_taller_defs_obstruct_vision():
     for object_definition in util.retrieve_full_object_definition_list(objects.get_all_object_defs()):
-        object_dimensions = object_definition['closed_dimensions'] if 'closed_dimensions' in object_definition else \
+        object_dimensions = object_definition['closedDimensions'] if 'closedDimensions' in object_definition else \
                 object_definition['dimensions']
         bigger_definition_list = get_wider_and_taller_defs(object_definition, True)
         for bigger_definition_result in bigger_definition_list:
             bigger_definition, angle = bigger_definition_result
             bigger_definition = util.finalize_object_definition(bigger_definition)
-            bigger_dimensions = bigger_definition['closed_dimensions'] if 'closed_dimensions' in bigger_definition \
+            bigger_dimensions = bigger_definition['closedDimensions'] if 'closedDimensions' in bigger_definition \
                     else bigger_definition['dimensions']
             assert bigger_definition['obstruct'] == 'vision'
             assert bigger_dimensions['y'] >= object_dimensions['y']

--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -67,8 +67,7 @@ def generate_wall(wall_material: str, wall_colors: List[str], performer_position
             'kinematic': 'true',
             'structure': 'true',
             'mass': 200,
-            'info': wall_colors,
-            'info_string': ' '.join(wall_colors)
+            'info': wall_colors
         }
         shows_object = {
             'stepBegin': 0,
@@ -152,8 +151,8 @@ class Goal(ABC):
         for key, value in tag_to_objects.items():
             for obj in value:
                 info_list = obj.get('info', []).copy()
-                if 'info_string' in obj:
-                    info_list.append(obj['info_string'])
+                if 'goal_string' in obj:
+                    info_list.append(obj['goal_string'])
                 info_set |= set([(key + ' ' + info) for info in info_list])
         return list(info_set)
 

--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -74,7 +74,7 @@ def generate_wall(wall_material: str, wall_colors: List[str], performer_position
             'scale': {'x': new_x_size, 'y': WALL_HEIGHT, 'z': WALL_DEPTH},
             'rotation': {'x': 0, 'y': rotation, 'z': 0},
             'position': {'x': new_x, 'y': WALL_Y_POS, 'z': new_z},
-            'bounding_box': rect
+            'boundingBox': rect
         }
         shows = [shows_object]
         new_object['shows'] = shows
@@ -151,8 +151,8 @@ class Goal(ABC):
         for key, value in tag_to_objects.items():
             for obj in value:
                 info_list = obj.get('info', []).copy()
-                if 'goal_string' in obj:
-                    info_list.append(obj['goal_string'])
+                if 'goalString' in obj:
+                    info_list.append(obj['goalString'])
                 info_set |= set([(key + ' ' + info) for info in info_list])
         return list(info_set)
 

--- a/scene_generator/goal_test.py
+++ b/scene_generator/goal_test.py
@@ -16,15 +16,15 @@ def create_tags_test_object_1():
             'z': 0.1
         },
         'info': ['tiny', 'light', 'blue', 'plastic', 'ball'],
-        'info_string': 'tiny light blue plastic ball',
+        'goal_string': 'tiny light blue plastic ball',
         'mass': 0.5,
         'materials': ['test_material'],
         'materialCategory': ['plastic'],
         'salientMaterials': ['plastic'],
         'moveable': True,
-        'novel_color': False,
-        'novel_combination': False,
-        'novel_shape': False,
+        'novelColor': False,
+        'novelCombination': False,
+        'novelShape': False,
         'pickupable': True,
         'shows': [{
             'stepBegin': 0,
@@ -47,15 +47,15 @@ def create_tags_test_object_2():
             'z': 0.5
         },
         'info': ['medium', 'light', 'yellow', 'plastic', 'cube'],
-        'info_string': 'medium light yellow plastic cube',
+        'goal_string': 'medium light yellow plastic cube',
         'mass': 2.5,
         'materials': ['test_material'],
         'materialCategory': ['plastic'],
         'salientMaterials': ['plastic'],
         'moveable': True,
-        'novel_color': False,
-        'novel_combination': False,
-        'novel_shape': False,
+        'novelColor': False,
+        'novelCombination': False,
+        'novelShape': False,
         'pickupable': True,
         'shows': [{
             'stepBegin': 0,
@@ -79,7 +79,6 @@ def test_generate_wall():
     assert wall['structure'] == 'true'
     assert wall['mass'] == 200
     assert wall['info'] == ['test_color_1', 'test_color_2']
-    assert wall['info_string'] == 'test_color_1 test_color_2'
 
     assert len(wall['shows']) == 1
     assert wall['shows'][0]['stepBegin'] == 0
@@ -389,7 +388,7 @@ def test_Goal_tags_target_enclosed():
 def test_Goal_tags_target_novel_color():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    target['novel_color'] = True
+    target['novelColor'] = True
     goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -409,7 +408,7 @@ def test_Goal_tags_target_novel_color():
 def test_Goal_tags_target_novel_combination():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    target['novel_combination'] = True
+    target['novelCombination'] = True
     goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -429,7 +428,7 @@ def test_Goal_tags_target_novel_combination():
 def test_Goal_tags_target_novel_shape():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    target['novel_shape'] = True
+    target['novelShape'] = True
     goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -450,8 +449,8 @@ def test_Goal_tags_target_enclosed_novel_color_novel_shape():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['locationParent'] = 'parent'
-    target['novel_color'] = True
-    target['novel_shape'] = True
+    target['novelColor'] = True
+    target['novelShape'] = True
     goal = goal_object._get_config({ 'target': [target] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -504,7 +503,7 @@ def test_Goal_tags_distractor_novel_color():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
-    distractor['novel_color'] = True
+    distractor['novelColor'] = True
     goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -536,7 +535,7 @@ def test_Goal_tags_distractor_novel_combination():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
-    distractor['novel_combination'] = True
+    distractor['novelCombination'] = True
     goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -568,7 +567,7 @@ def test_Goal_tags_distractor_novel_shape():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
-    distractor['novel_shape'] = True
+    distractor['novelShape'] = True
     goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -601,8 +600,8 @@ def test_Goal_tags_distractor_enclosed_novel_color_novel_shape():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['locationParent'] = 'parent'
-    distractor['novel_color'] = True
-    distractor['novel_shape'] = True
+    distractor['novelColor'] = True
+    distractor['novelShape'] = True
     goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',
@@ -634,12 +633,12 @@ def test_Goal_tags_target_distractor_enclosed_novel_color_novel_shape():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['locationParent'] = 'parent'
-    target['novel_color'] = True
-    target['novel_shape'] = True
+    target['novelColor'] = True
+    target['novelShape'] = True
     distractor = create_tags_test_object_2()
     distractor['locationParent'] = 'parent'
-    distractor['novel_color'] = True
-    distractor['novel_shape'] = True
+    distractor['novelColor'] = True
+    distractor['novelShape'] = True
     goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
     assert set(goal['info_list']) == {
         'target tiny',

--- a/scene_generator/goal_test.py
+++ b/scene_generator/goal_test.py
@@ -16,7 +16,7 @@ def create_tags_test_object_1():
             'z': 0.1
         },
         'info': ['tiny', 'light', 'blue', 'plastic', 'ball'],
-        'goal_string': 'tiny light blue plastic ball',
+        'goalString': 'tiny light blue plastic ball',
         'mass': 0.5,
         'materials': ['test_material'],
         'materialCategory': ['plastic'],
@@ -47,7 +47,7 @@ def create_tags_test_object_2():
             'z': 0.5
         },
         'info': ['medium', 'light', 'yellow', 'plastic', 'cube'],
-        'goal_string': 'medium light yellow plastic cube',
+        'goalString': 'medium light yellow plastic cube',
         'mass': 2.5,
         'materials': ['test_material'],
         'materialCategory': ['plastic'],
@@ -91,7 +91,7 @@ def test_generate_wall():
     assert wall['shows'][0]['position']['x'] is not None
     assert wall['shows'][0]['position']['y'] == WALL_Y_POS
     assert wall['shows'][0]['position']['z'] is not None
-    assert wall['shows'][0]['bounding_box'] is not None
+    assert wall['shows'][0]['boundingBox'] is not None
 
     assert not 'hides' in wall
     assert not 'moves' in wall
@@ -100,16 +100,16 @@ def test_generate_wall():
 
     player_rect = geometry.find_performer_rect(geometry.ORIGIN)
     player_poly = geometry.rect_to_poly(player_rect)
-    wall_poly = geometry.rect_to_poly(wall['shows'][0]['bounding_box'])
+    wall_poly = geometry.rect_to_poly(wall['shows'][0]['boundingBox'])
     assert not wall_poly.intersects(player_poly)
-    assert geometry.rect_within_room(wall['shows'][0]['bounding_box'])
+    assert geometry.rect_within_room(wall['shows'][0]['boundingBox'])
 
 
 def test_generate_wall_multiple():
     wall_1 = generate_wall('test_material', [], geometry.ORIGIN, [])
-    wall_2 = generate_wall('test_material', [], geometry.ORIGIN, [wall_1['shows'][0]['bounding_box']])
-    wall_1_poly = geometry.rect_to_poly(wall_1['shows'][0]['bounding_box'])
-    wall_2_poly = geometry.rect_to_poly(wall_2['shows'][0]['bounding_box'])
+    wall_2 = generate_wall('test_material', [], geometry.ORIGIN, [wall_1['shows'][0]['boundingBox']])
+    wall_1_poly = geometry.rect_to_poly(wall_1['shows'][0]['boundingBox'])
+    wall_2_poly = geometry.rect_to_poly(wall_2['shows'][0]['boundingBox'])
     assert not wall_1_poly.intersects(wall_2_poly)
 
 
@@ -117,15 +117,15 @@ def test_generate_wall_with_bounds_list():
     bounds = [{'x': 4, 'y': 0, 'z': 4}, {'x': 4, 'y': 0, 'z': 1}, {'x': 1, 'y': 0, 'z': 1}, {'x': 1, 'y': 0, 'z': 4}]
     wall = generate_wall('test_material', [], geometry.ORIGIN, [bounds])
     poly = geometry.rect_to_poly(bounds)
-    wall_poly = geometry.rect_to_poly(wall['shows'][0]['bounding_box'])
+    wall_poly = geometry.rect_to_poly(wall['shows'][0]['boundingBox'])
     assert not wall_poly.intersects(poly)
 
 
 def test_generate_wall_with_target_list():
     bounds = [{'x': 4, 'y': 0, 'z': 4}, {'x': 4, 'y': 0, 'z': 3}, {'x': 3, 'y': 0, 'z': 3}, {'x': 3, 'y': 0, 'z': 4}]
-    target = {'shows': [{'bounding_box': bounds}]}
+    target = {'shows': [{'boundingBox': bounds}]}
     wall = generate_wall('test_material', [], geometry.ORIGIN, [bounds], [target])
-    wall_poly = geometry.rect_to_poly(wall['shows'][0]['bounding_box'])
+    wall_poly = geometry.rect_to_poly(wall['shows'][0]['boundingBox'])
     assert not geometry.does_fully_obstruct_target(geometry.ORIGIN, target, wall_poly)
 
 

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -130,7 +130,7 @@ def get_navigation_actions(start_location: Dict[str, Any],
     goal = (goal_object['shows'][0]['position']['x'], goal_object['shows'][0]['position']['z'])
     hole_rects = []
 
-    hole_rects.extend(object['shows'][0]['bounding_box'] for object
+    hole_rects.extend(object['shows'][0]['boundingBox'] for object
                       in all_objects if object['id'] != goal_object['id']
                       and 'locationParent' not in object)
     path = generatepath(performer, goal, hole_rects)
@@ -138,7 +138,7 @@ def get_navigation_actions(start_location: Dict[str, Any],
         raise PathfindingException(f'could not find path to target {goal_object["id"]}')
     for object in all_objects:
         if object['id'] == goal_object['id']:
-            goal_boundary = object['shows'][0]['bounding_box']
+            goal_boundary = object['shows'][0]['boundingBox']
             break
     actions = []
     current_heading = 90 - start_location['rotation']['y']
@@ -429,7 +429,7 @@ class InteractionGoal(Goal, ABC):
                         self._bounds_list, self._wall_target_list)
                 if wall:
                     self._wall_list.append(wall)
-                    self._bounds_list.append(wall['shows'][0]['bounding_box'])
+                    self._bounds_list.append(wall['shows'][0]['boundingBox'])
                 else:
                     logging.warning('cannot generate a dynamic wall object')
         return self._wall_list
@@ -575,7 +575,7 @@ class RetrievalGoal(InteractionGoal):
                 'image_name': image_name
             }
         }
-        goal['description'] = f'Find and pick up the {target["goal_string"]}.'
+        goal['description'] = f'Find and pick up the {target["goalString"]}.'
         return goal
 
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
@@ -681,8 +681,8 @@ class TransferralGoal(InteractionGoal):
             },
             'relationship': ['target_1', relationship.value, 'target_2']
         }
-        goal['description'] = f'Find and pick up the {target1["goal_string"]} and move it {relationship.value} ' \
-            f'the {target2["goal_string"]}.'
+        goal['description'] = f'Find and pick up the {target1["goalString"]} and move it {relationship.value} ' \
+            f'the {target2["goalString"]}.'
         return goal
 
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
@@ -736,7 +736,7 @@ class TransferralGoal(InteractionGoal):
             goal = (goal_objects[1]['shows'][0]['position']['x'], goal_objects[1]['shows'][0]['position']['z'])
 
         hole_rects = []
-        hole_rects.extend(object['shows'][0]['bounding_box'] for object
+        hole_rects.extend(object['shows'][0]['boundingBox'] for object
                           in all_objects if (object['id'] not in ignore_object_ids and 'locationParent' not in object))
 
         logging.debug(f'TransferralGoal.f_o_p: target = {target}\tgoal = {goal}\tholes = {hole_rects}')
@@ -746,7 +746,7 @@ class TransferralGoal(InteractionGoal):
         logging.debug(f'TransferralGoal.f_o_p: got path = {path}')
         for object in all_objects:
             if object['id'] == goal_objects[1]['id']:
-                goal_boundary = object['shows'][0]['bounding_box']
+                goal_boundary = object['shows'][0]['boundingBox']
                 break
         current_heading = heading
         for indx in range(len(path)-1):
@@ -811,7 +811,7 @@ class TraversalGoal(InteractionGoal):
                 'image_name': image_name
             }
         }
-        goal['description'] = f'Find the {target["goal_string"]} and move near it.'
+        goal['description'] = f'Find the {target["goalString"]} and move near it.'
         return goal
 
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -574,7 +574,7 @@ class RetrievalGoal(InteractionGoal):
                 'image_name': image_name
             }
         }
-        goal['description'] = f'Find and pick up the {target["info_string"]}.'
+        goal['description'] = f'Find and pick up the {target["goal_string"]}.'
         return goal
 
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
@@ -680,8 +680,8 @@ class TransferralGoal(InteractionGoal):
             },
             'relationship': ['target_1', relationship.value, 'target_2']
         }
-        goal['description'] = f'Find and pick up the {target1["info_string"]} and move it {relationship.value} ' \
-            f'the {target2["info_string"]}.'
+        goal['description'] = f'Find and pick up the {target1["goal_string"]} and move it {relationship.value} ' \
+            f'the {target2["goal_string"]}.'
         return goal
 
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
@@ -810,7 +810,7 @@ class TraversalGoal(InteractionGoal):
                 'image_name': image_name
             }
         }
-        goal['description'] = f'Find the {target["info_string"]} and move near it.'
+        goal['description'] = f'Find the {target["goal_string"]} and move near it.'
         return goal
 
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -305,10 +305,11 @@ class DistractorObjectRule(ObjectRule):
         self._target_list = target_list
 
     def choose_definition(self) -> Dict[str, Any]:
-        target_shape_list = [target['info'][-1] for target in self._target_list]
+        target_shape_list = [target['shape'][-1] for target in self._target_list]
         for _ in range(util.MAX_TRIES):
             distractor_definition = super(DistractorObjectRule, self).choose_definition()
-            distractor_shape = distractor_definition['info'][-1]
+            distractor_shape = distractor_definition['shape'][-1] if isinstance(distractor_definition['shape'], list) \
+                    else distractor_definition['shape']
             # Cannot have the same shape as a target object, so we don't unintentionally generate a confusor.
             if distractor_shape not in target_shape_list:
                 break

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -530,7 +530,7 @@ def test_RetrievalGoal_get_config():
     obj = {
         'id': str(uuid.uuid4()),
         'info': ['blue', 'rubber', 'ball'],
-        'info_string': 'blue rubber ball',
+        'goal_string': 'blue rubber ball',
         'pickupable': True,
         'type': 'sphere'
     }
@@ -570,7 +570,7 @@ def test_TraversalGoal_get_config():
     obj = {
         'id': str(uuid.uuid4()),
         'info': ['blue', 'rubber', 'ball'],
-        'info_string': 'blue rubber ball',
+        'goal_string': 'blue rubber ball',
         'type': 'sphere'
     }
     goal = goal_obj._get_config({ 'target': [obj] })
@@ -628,7 +628,7 @@ def test_TransferralGoal_get_config():
     pickupable_obj = {
         'id': pickupable_id,
         'info': ['blue', 'rubber', 'ball'],
-        'info_string': 'blue rubber ball',
+        'goal_string': 'blue rubber ball',
         'pickupable': True,
         'type': 'sphere'
     }
@@ -636,7 +636,7 @@ def test_TransferralGoal_get_config():
     other_obj = {
         'id': other_id,
         'info': ['yellow', 'wood', 'changing table'],
-        'info_string': 'yellow wood changing table',
+        'goal_string': 'yellow wood changing table',
         'attributes': [],
         'type': 'changing_table',
         'stackTarget': True

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -24,7 +24,7 @@ def test_move_to_container():
     # find a tiny object so we know it will fit in *something*
     for obj_def in objects.OBJECTS_PICKUPABLE:
         obj_def = finalize_object_definition(obj_def)
-        if 'tiny' in obj_def['info']:
+        if obj_def['size'] == 'tiny':
             obj = instantiate_object(obj_def, geometry.ORIGIN_LOCATION)
             tries = 0
             while tries < 100:
@@ -429,7 +429,7 @@ def test_DistractorObjectRule_choose_definition():
     rule = DistractorObjectRule([target])
     definition = rule.choose_definition()
     assert definition
-    assert definition['info'][-1] != target['info'][-1]
+    assert definition['shape'] != target['shape']
 
 
 def test_ConfusorObjectRule_choose_definition():

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -122,7 +122,7 @@ def test_get_navigation_action():
                 'y': 0.5,
                 'z': 0.1
             },
-            'bounding_box': [
+            'boundingBox': [
                 {
                     'x': 0.11,
                     'y': 0.5,
@@ -181,7 +181,7 @@ def test_get_navigation_action_with_locationParent():
                 'y': 0,
                 'z': 0.1
             },
-            'bounding_box': [
+            'boundingBox': [
                 {
                     'x': 0.11,
                     'y': 0,
@@ -251,7 +251,7 @@ def test_get_navigation_action_with_turning():
                 'y': 0,
                 'z': 3
             },
-            'bounding_box': [
+            'boundingBox': [
                 {
                     'x': 0.1,
                     'y': 0,
@@ -283,7 +283,7 @@ def test_get_navigation_action_with_turning():
                 'y': 0,
                 'z': 1.5
             },
-            'bounding_box': [
+            'boundingBox': [
                 {
                     'x': 2,
                     'y': 0,
@@ -522,7 +522,7 @@ def test_RetrievalGoal_update_body():
     target = body['objects'][0]
     assert target['pickupable']
     assert target['id'] == body['goal']['metadata']['target']['id']
-    assert body['goal']['description'] == ('Find and pick up the ' + target['goal_string'] + '.')
+    assert body['goal']['description'] == ('Find and pick up the ' + target['goalString'] + '.')
 
 
 def test_RetrievalGoal_get_config():
@@ -530,7 +530,7 @@ def test_RetrievalGoal_get_config():
     obj = {
         'id': str(uuid.uuid4()),
         'info': ['blue', 'rubber', 'ball'],
-        'goal_string': 'blue rubber ball',
+        'goalString': 'blue rubber ball',
         'pickupable': True,
         'type': 'sphere'
     }
@@ -562,7 +562,7 @@ def test_TraversalGoal_update_body():
 
     target = body['objects'][0]
     assert target['id'] == body['goal']['metadata']['target']['id']
-    assert body['goal']['description'] == ('Find the ' + target['goal_string'] + ' and move near it.')
+    assert body['goal']['description'] == ('Find the ' + target['goalString'] + ' and move near it.')
 
 
 def test_TraversalGoal_get_config():
@@ -570,7 +570,7 @@ def test_TraversalGoal_get_config():
     obj = {
         'id': str(uuid.uuid4()),
         'info': ['blue', 'rubber', 'ball'],
-        'goal_string': 'blue rubber ball',
+        'goalString': 'blue rubber ball',
         'type': 'sphere'
     }
     goal = goal_obj._get_config({ 'target': [obj] })
@@ -600,8 +600,8 @@ def test_TransferralGoal_update_body():
     assert target_2['stackTarget']
     assert target_1['id'] == body['goal']['metadata']['target_1']['id']
     assert target_2['id'] == body['goal']['metadata']['target_2']['id']
-    assert body['goal']['description'] == ('Find and pick up the ' + target_1['goal_string'] + ' and move it ' + \
-            body['goal']['metadata']['relationship'][1] + ' the ' + target_2['goal_string'] + '.')
+    assert body['goal']['description'] == ('Find and pick up the ' + target_1['goalString'] + ' and move it ' + \
+            body['goal']['metadata']['relationship'][1] + ' the ' + target_2['goalString'] + '.')
 
 
 def test_TransferralGoal_get_config_arg_count():
@@ -628,7 +628,7 @@ def test_TransferralGoal_get_config():
     pickupable_obj = {
         'id': pickupable_id,
         'info': ['blue', 'rubber', 'ball'],
-        'goal_string': 'blue rubber ball',
+        'goalString': 'blue rubber ball',
         'pickupable': True,
         'type': 'sphere'
     }
@@ -636,7 +636,7 @@ def test_TransferralGoal_get_config():
     other_obj = {
         'id': other_id,
         'info': ['yellow', 'wood', 'changing table'],
-        'goal_string': 'yellow wood changing table',
+        'goalString': 'yellow wood changing table',
         'attributes': [],
         'type': 'changing_table',
         'stackTarget': True
@@ -770,7 +770,7 @@ def test_add_RotateLook_to_action_list_before_Pickup_or_Put_Object():
                     'y': 0.02,
                     'z': 0.02
                 },
-                'bounding_box': [
+                'boundingBox': [
                     {
                         'x': 0.01,
                         'y': 0,

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -175,7 +175,7 @@ class IntPhysGoal(Goal, ABC):
                                                  random_x, random_z)
                 if location is not None:
                     # check that the bounds are valid
-                    for point in location['bounding_box']:
+                    for point in location['boundingBox']:
                         x = point['x']
                         z = point['z']
                         if x < MIN_VISIBLE_X or x > MAX_VISIBLE_X or \

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -204,7 +204,7 @@ class IntPhysGoal(Goal, ABC):
                             IntPhysGoal.MAX_OCCLUDER_SCALE)
             # object could be a cube on its corner, so use the diagonal distance
             x_scale = util.random_real(min_scale, IntPhysGoal.MAX_OCCLUDER_SCALE, util.MIN_RANDOM_INTERVAL)
-            position_by_step = paired_obj['intphys_option']['position_by_step']
+            position_by_step = paired_obj['intphysOption']['position_by_step']
             paired_z = paired_obj['shows'][0]['position']['z']
             min_paired_x_position = -3 + x_scale / 2
             max_paired_x_position = 3 - x_scale / 2
@@ -227,9 +227,9 @@ class IntPhysGoal(Goal, ABC):
                     break
             if not found_collision:
                 # occluder_indices are needed by quartets
-                occluder_indices = paired_obj['intphys_option'].get('occluder_indices', [])
+                occluder_indices = paired_obj['intphysOption'].get('occluder_indices', [])
                 occluder_indices.append(position_index)
-                paired_obj['intphys_option']['occluder_indices'] = occluder_indices
+                paired_obj['intphysOption']['occluder_indices'] = occluder_indices
                 occluder_fits = True
                 break
         if occluder_fits:
@@ -348,7 +348,7 @@ class IntPhysGoal(Goal, ABC):
             for loc in exclusions[location]:
                 available_locations.discard(loc)
             obj_def = finalize_object_definition(random.choice(valid_defs))
-            remaining_intphys_options = obj_def['intphys_options'].copy()
+            remaining_intphys_options = obj_def['intphysOptions'].copy()
             while len(remaining_intphys_options) > 0:
                 intphys_option = random.choice(remaining_intphys_options)
                 if location in acceleration_ordering and \
@@ -356,7 +356,7 @@ class IntPhysGoal(Goal, ABC):
                     # ensure the objects won't collide
                     acceleration = abs(intphys_option['force']['x'] / obj_def['mass'])
                     other_obj = location_assignments[acceleration_ordering[location]]
-                    other_acceleration = abs(other_obj['intphys_option']['force']['x'] / other_obj['mass'])
+                    other_acceleration = abs(other_obj['intphysOption']['force']['x'] / other_obj['mass'])
 
                     collision = acceleration > other_acceleration
                     if not collision:
@@ -374,7 +374,7 @@ class IntPhysGoal(Goal, ABC):
             object_location = {
                 'position': {
                     'x': IntPhysGoal.OBJECT_POSITIONS[location][0],
-                    'y': intphys_option['y'] + obj_def['position_y'],
+                    'y': intphys_option['y'] + obj_def['positionY'],
                     'z': IntPhysGoal.OBJECT_POSITIONS[location][1]
                 }
             }
@@ -417,8 +417,8 @@ class IntPhysGoal(Goal, ABC):
             }]
             if location in (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR, IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR):
                 obj['forces'][0]['vector']['x'] *= -1
-            intphys_option['position_y'] = obj_def['position_y']
-            obj['intphys_option'] = intphys_option
+            intphys_option['positionY'] = obj_def['positionY']
+            obj['intphysOption'] = intphys_option
             new_objects.append(obj)
             if positions is not None:
                 positions.append(location)
@@ -474,8 +474,8 @@ class IntPhysGoal(Goal, ABC):
             obj = instantiate_object(obj_def, location)
             obj['shows'][0]['stepBegin'] = random.randint(IntPhysGoal.EARLIEST_ACTION_START_STEP,
                                                           IntPhysGoal.LATEST_ACTION_FALL_DOWN_START_STEP)
-            obj['intphys_option'] = {
-                'position_y': obj_def['position_y']
+            obj['intphysOption'] = {
+                'positionY': obj_def['positionY']
             }
             object_list.append(obj)
         # place required occluders, then (maybe) some random ones
@@ -511,9 +511,9 @@ class IntPhysGoal(Goal, ABC):
                                                     random.choice(materials.METAL_MATERIALS),
                                                     adjusted_x, x_scale, True)
             # occluded_id needed by SpatioTemporalContinuityQuartet
-            if 'intphys_option' not in occluder_pair[0]:
-                occluder_pair[0]['intphys_option'] = {}
-            occluder_pair[0]['intphys_option']['occluded_id'] = paired_obj['id']
+            if 'intphysOption' not in occluder_pair[0]:
+                occluder_pair[0]['intphysOption'] = {}
+            occluder_pair[0]['intphysOption']['occluded_id'] = paired_obj['id']
             occluders.extend(occluder_pair)
         self._add_occluders(occluders, num_occluders - num_objects, non_room_wall_materials, True)
 
@@ -599,14 +599,14 @@ class GravityGoal(IntPhysGoal):
             # Want to avoid cubes in the gravity tests at this time MCS-269
             if obj_def['type'] != 'cube':
                 new_od = obj_def.copy()
-                valid_intphys = [intphys for intphys in obj_def['intphys_options'] if intphys['y'] == 0]
+                valid_intphys = [intphys for intphys in obj_def['intphysOptions'] if intphys['y'] == 0]
                 if len(valid_intphys) != 0:
                     new_od['saved_intphys_options'] = copy.deepcopy(valid_intphys)
                     if self.is_ramp_steep() and self._use_fastest:
                         # use the intphys with the highest force.x for each object
                         sorted_intphys = sorted(valid_intphys, key=lambda intphys: intphys['force']['x'])
                         valid_intphys = [sorted_intphys[-1]]
-                    new_od['intphys_options'] = valid_intphys
+                    new_od['intphysOptions'] = valid_intphys
                     valid_defs.append(new_od)
         if self.is_ramp_steep():
             # Don't put objects in places where they'd have to roll up
@@ -636,8 +636,8 @@ class GravityGoal(IntPhysGoal):
         # adjust height to be on top of ramp if necessary
         for i in range(len(objs)):
             obj = objs[i]
-            obj['intphys_option']['moving_object'] = True
-            obj['intphys_option']['ramp_x_term'] = x_term
+            obj['intphysOption']['moving_object'] = True
+            obj['intphysOption']['ramp_x_term'] = x_term
             position = positions[i]
             # Add a downward force to all objects moving down the
             # ramps so that they will move more realistically.

--- a/scene_generator/intphys_goals_test.py
+++ b/scene_generator/intphys_goals_test.py
@@ -209,7 +209,7 @@ def test_IntPhysGoal__compute_scenery():
         assert 0 <= len(scenery_list) <= 5
         scenery_generated = len(scenery_list) > 0
         for scenery in scenery_list:
-            for point in scenery['shows'][0]['bounding_box']:
+            for point in scenery['shows'][0]['boundingBox']:
                 assert -6.5 <= point['x'] <= 6.5
                 assert 3.25 <= point['z'] <= 4.95
 

--- a/scene_generator/intphys_goals_test.py
+++ b/scene_generator/intphys_goals_test.py
@@ -148,7 +148,7 @@ def test_GravityGoal__get_ramp_and_objects():
     ramp_type, left_to_right, ramp_objs, object_list = goal._get_ramp_and_objects('dummy')
     assert len(ramp_objs) >= 1
     for obj in object_list:
-        assert obj['intphys_option']['y'] == 0
+        assert obj['intphysOption']['y'] == 0
         assert obj['type'] != 'cube'
 
 
@@ -167,7 +167,7 @@ def test_IntPhysGoal__get_objects_and_occluders_moving_across():
     first_obj = objs[0]
     found = False
     multiplier = 0.9 if first_obj['shows'][0]['position']['z'] == 1.6 else 0.8
-    for position in first_obj['intphys_option']['position_by_step']:
+    for position in first_obj['intphysOption']['position_by_step']:
         adjusted_x = position * multiplier
         if adjusted_x == occluder_x:
             found = True
@@ -194,8 +194,8 @@ def test_IntPhysGoal__get_objects_moving_across_collisions():
             other_z = other['shows'][0]['position']['z']
             # could other catch up to obj?
             if other_z == z and abs(other_x) > abs(x):
-                obj_a = obj['intphys_option']['force']['x'] / obj['mass']
-                other_a = other['intphys_option']['force']['x'] / obj['mass']
+                obj_a = obj['intphysOption']['force']['x'] / obj['mass']
+                other_a = other['intphysOption']['force']['x'] / obj['mass']
                 assert abs(other_a) <= abs(obj_a)
 
     

--- a/scene_generator/objects.py
+++ b/scene_generator/objects.py
@@ -21,7 +21,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
         "materialCategory": ["metal"],
         "salientMaterials": ["metal"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }],
@@ -32,7 +32,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
             "z": 0.025
         },
         "mass": 0.125,
-        "position_y": 0.0125,
+        "positionY": 0.0125,
         "scale": {
             "x": 0.025,
             "y": 0.025,
@@ -45,7 +45,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
             "z": 0.05,
         },
         "mass": 0.25,
-        "position_y": 0.025,
+        "positionY": 0.025,
         "scale": {
             "x": 0.05,
             "y": 0.05,
@@ -58,7 +58,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
             "z": 0.1
         },
         "mass": 0.5,
-        "position_y": 0.05,
+        "positionY": 0.05,
         "scale": {
             "x": 0.1,
             "y": 0.1,
@@ -72,7 +72,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
             "z": 0.25
         },
         "mass": 2,
-        "position_y": 0.125,
+        "positionY": 0.125,
         "scale": {
             "x": 0.25,
             "y": 0.25,
@@ -90,7 +90,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
@@ -106,7 +106,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "y": 0.05,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -124,7 +124,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "y": 0.1,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 2,
@@ -142,7 +142,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "y": 0.05,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 1,
@@ -158,7 +158,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
@@ -174,7 +174,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "y": 0.05,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -192,7 +192,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "y": 0.1,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 2,
@@ -210,7 +210,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "y": 0.05,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 1,
@@ -236,7 +236,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
         "y": 0.05,
         "z": 0
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -261,7 +261,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
         "y": 0.05,
         "z": 0
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -276,7 +276,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
@@ -293,7 +293,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.0425,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -312,7 +312,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.085,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 1,
             "y": 1,
@@ -331,7 +331,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.17,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 2,
             "y": 2,
@@ -345,7 +345,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
@@ -362,7 +362,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.0225,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 0.75,
             "y": 0.75,
@@ -381,7 +381,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.045,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 1.5,
             "y": 1.5,
@@ -400,7 +400,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.09,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 3,
             "y": 3,
@@ -423,7 +423,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "y": 0.02,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -448,7 +448,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "y": 0.0425,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -457,7 +457,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
 }, {
     "type": "turtle_on_wheels",
     "attributes": ["moveable", "pickupable"],
-    "novel_shape": True,
+    "novelShape": True,
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
@@ -478,7 +478,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.07 * 0.5,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -497,7 +497,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.07,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 1,
             "y": 1,
@@ -516,7 +516,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.07 * 2,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 2,
             "y": 2,
@@ -526,7 +526,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
 }, {
     "type": "car_1",
     "attributes": ["moveable", "pickupable"],
-    "novel_shape": True,
+    "novelShape": True,
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
@@ -547,7 +547,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.03 * 0.75,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 0.75,
             "y": 0.75,
@@ -566,7 +566,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.03 * 1.5,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 1.5,
             "y": 1.5,
@@ -585,7 +585,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "y": 0.03 * 3,
             "z": 0
         },
-        "position_y": 0.01,
+        "positionY": 0.01,
         "scale": {
             "x": 3,
             "y": 3,
@@ -610,7 +610,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.005,
         "z": 0
     },
-    "position_y": 0.03,
+    "positionY": 0.03,
     "scale": {
         "x": 1,
         "y": 1,
@@ -632,7 +632,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.002,
         "z": 0
     },
-    "position_y": 0.03,
+    "positionY": 0.03,
     "scale": {
         "x": 1,
         "y": 1,
@@ -646,7 +646,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -662,7 +662,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.055,
         "z": -0.002
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -676,7 +676,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -692,7 +692,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.027,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -701,7 +701,7 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "bowl_6",
     "info": ["tiny", "bowl"],
-    "novel_shape": True,
+    "novelShape": True,
     "chooseMaterial": [{
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
@@ -722,7 +722,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.052,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -736,7 +736,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -752,7 +752,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.064,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -761,7 +761,7 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "cup_3",
     "info": ["tiny", "cup"],
-    "novel_shape": True,
+    "novelShape": True,
     "chooseMaterial": [{
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
@@ -782,7 +782,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.072,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -796,7 +796,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -812,7 +812,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.046,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -826,7 +826,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -842,7 +842,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.057,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -856,7 +856,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -872,7 +872,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.098,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -881,7 +881,7 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "plate_4",
     "info": ["tiny", "plate"],
-    "novel_shape": True,
+    "novelShape": True,
     "chooseMaterial": [{
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
@@ -902,7 +902,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.053,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -915,7 +915,7 @@ OBJECTS_PICKUPABLE_MISC = [{
     "mass": 0.5,
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
-    "enclosed_areas": [{
+    "enclosedAreas": [{
         "id": "",
         "position": {
             "x": 0 * 1.25,
@@ -938,17 +938,17 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0 * 0.75,
         "z": -0.144 * 1.25
     },
-    "closed_dimensions": {
+    "closedDimensions": {
         "x": 0.31 * 1.25,
         "y": 0.21 * 0.75,
         "z": 0.36 * 1.25
     },
-    "closed_offset": {
+    "closedOffset": {
         "x": 0,
         "y": -0.08 * 0.75,
         "z": -0.145 * 1.25
     },
-    "position_y": 0.2 * 0.75,
+    "positionY": 0.2 * 0.75,
     "scale": {
         "x": 1.25,
         "y": 0.75,
@@ -961,7 +961,7 @@ OBJECTS_PICKUPABLE_MISC = [{
     "mass": 0.25,
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
-    "enclosed_areas": [{
+    "enclosedAreas": [{
         "id": "",
         "position": {
             "x": 0 * 0.75,
@@ -984,17 +984,17 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0 * 0.75,
         "z": -0.144 * 0.75
     },
-    "closed_dimensions": {
+    "closedDimensions": {
         "x": 0.31 * 0.75,
         "y": 0.21 * 0.75,
         "z": 0.36 * 0.75
     },
-    "closed_offset": {
+    "closedOffset": {
         "x": 0,
         "y": -0.08 * 0.75,
         "z": -0.145 * 0.75
     },
-    "position_y": 0.2 * 0.75,
+    "positionY": 0.2 * 0.75,
     "scale": {
         "x": 0.75,
         "y": 0.75,
@@ -1007,7 +1007,7 @@ OBJECTS_PICKUPABLE_MISC = [{
     "mass": 0.5,
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
-    "enclosed_areas": [{
+    "enclosedAreas": [{
         "id": "",
         "position": {
             "x": 0,
@@ -1030,17 +1030,17 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": -0.038 * 0.5,
         "z": -0.115
     },
-    "closed_dimensions": {
+    "closedDimensions": {
         "x": 0.41,
         "y": 0.31 * 0.5,
         "z": 0.34
     },
-    "closed_offset": {
+    "closedOffset": {
         "x": 0,
         "y": -0.125 * 0.5,
         "z": -0.13
     },
-    "position_y": 0.15,
+    "positionY": 0.15,
     "scale": {
         "x": 1,
         "y": 0.5,
@@ -1053,7 +1053,7 @@ OBJECTS_PICKUPABLE_MISC = [{
     "mass": 0.25,
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
-    "enclosed_areas": [{
+    "enclosedAreas": [{
         "id": "",
         "position": {
             "x": 0,
@@ -1076,17 +1076,17 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": -0.038 * 0.5,
         "z": -0.115 * 0.5
     },
-    "closed_dimensions": {
+    "closedDimensions": {
         "x": 0.41 * 0.5,
         "y": 0.31 * 0.5,
         "z": 0.34 * 0.5
     },
-    "closed_offset": {
+    "closedOffset": {
         "x": 0,
         "y": -0.125 * 0.5,
         "z": -0.13 * 0.5
     },
-    "position_y": 0.15,
+    "positionY": 0.15,
     "scale": {
         "x": 0.5,
         "y": 0.5,
@@ -1097,11 +1097,11 @@ OBJECTS_PICKUPABLE_MISC = [{
     "obstruct": "vision",
     "info": ["small", "grey", "box"],
     "mass": 0.5,
-    "novel_color": True,
-    "novel_shape": True,
+    "novelColor": True,
+    "novelShape": True,
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
-    "enclosed_areas": [{
+    "enclosedAreas": [{
         "id": "",
         "position": {
             "x": 0,
@@ -1124,17 +1124,17 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": -0.046 * 0.5,
         "z": -0.136
     },
-    "closed_dimensions": {
+    "closedDimensions": {
         "x": 0.3,
         "y": 0.32 * 0.5,
         "z": 0.34
     },
-    "closed_offset": {
+    "closedOffset": {
         "x": 0,
         "y": -0.125 * 0.5,
         "z": -0.13
     },
-    "position_y": 0.15,
+    "positionY": 0.15,
     "scale": {
         "x": 1,
         "y": 0.5,
@@ -1145,11 +1145,11 @@ OBJECTS_PICKUPABLE_MISC = [{
     "obstruct": "vision",
     "info": ["tiny", "grey", "box"],
     "mass": 0.25,
-    "novel_color": True,
-    "novel_shape": True,
+    "novelColor": True,
+    "novelShape": True,
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
-    "enclosed_areas": [{
+    "enclosedAreas": [{
         "id": "",
         "position": {
             "x": 0,
@@ -1172,17 +1172,17 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": -0.046 * 0.5,
         "z": -0.136 * 0.5
     },
-    "closed_dimensions": {
+    "closedDimensions": {
         "x": 0.3 * 0.5,
         "y": 0.32 * 0.5,
         "z": 0.34 * 0.5
     },
-    "closed_offset": {
+    "closedOffset": {
         "x": 0,
         "y": -0.125 * 0.5,
         "z": -0.13 * 0.5
     },
-    "position_y": 0.15,
+    "positionY": 0.15,
     "scale": {
         "x": 0.5,
         "y": 0.5,
@@ -1202,18 +1202,18 @@ OBJECTS_MOVEABLE = [{
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "massMultiplier": 2,
         "materialCategory": ["metal"],
         "salientMaterials": ["metal"]
     }],
     "chooseSize": [{
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": 0.01,
@@ -1237,7 +1237,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.51,
             "z": -0.02
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1245,7 +1245,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "info": ["small", "chair"],
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": 0.01 * 0.5,
@@ -1269,7 +1269,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.51 * 0.5,
             "z": -0.02 * 0.5
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -1286,17 +1286,17 @@ OBJECTS_MOVEABLE = [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "massMultiplier": 2,
         "materialCategory": ["metal"],
         "salientMaterials": ["metal"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -1320,7 +1320,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.375,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1328,7 +1328,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "info": ["small", "stool"],
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -1352,7 +1352,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.375 * 0.5,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -1367,7 +1367,7 @@ OBJECTS_MOVEABLE = [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
@@ -1383,7 +1383,7 @@ OBJECTS_MOVEABLE = [{
         "y": 0.125,
         "z": 0
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 2.5,
         "y": 2.5,
@@ -1397,7 +1397,7 @@ OBJECTS_MOVEABLE = [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
@@ -1413,7 +1413,7 @@ OBJECTS_MOVEABLE = [{
         "y": 0.125,
         "z": 0
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 2.5,
         "y": 2.5,
@@ -1427,7 +1427,7 @@ OBJECTS_MOVEABLE = [{
         "info": ["small", "brown", "box"],
         "mass": 1,
         "salientMaterials": ["paper"],
-        "enclosed_areas": [{
+        "enclosedAreas": [{
             "id": "",
             "position": {
                 "x": 0 * 1.25,
@@ -1450,17 +1450,17 @@ OBJECTS_MOVEABLE = [{
             "y": 0 * 1.25,
             "z": -0.144 * 1.25
         },
-        "closed_dimensions": {
+        "closedDimensions": {
             "x": 0.31 * 1.25,
             "y": 0.21 * 1.25,
             "z": 0.36 * 1.25
         },
-        "closed_offset": {
+        "closedOffset": {
             "x": 0,
             "y": -0.08 * 1.25,
             "z": -0.145 * 1.25
         },
-        "position_y": 0.2 * 1.25,
+        "positionY": 0.2 * 1.25,
         "scale": {
             "x": 1.25,
             "y": 1.25,
@@ -1470,7 +1470,7 @@ OBJECTS_MOVEABLE = [{
         "info": ["medium", "brown", "box"],
         "mass": 3,
         "salientMaterials": ["paper"],
-        "enclosed_areas": [{
+        "enclosedAreas": [{
             "id": "",
             "position": {
                 "x": 0 * 1.75,
@@ -1493,17 +1493,17 @@ OBJECTS_MOVEABLE = [{
             "y": 0 * 1.75,
             "z": -0.144 * 1.75
         },
-        "closed_dimensions": {
+        "closedDimensions": {
             "x": 0.31 * 1.75,
             "y": 0.21 * 1.75,
             "z": 0.36 * 1.75
         },
-        "closed_offset": {
+        "closedOffset": {
             "x": 0,
             "y": -0.08 * 1.75,
             "z": -0.145 * 1.75
         },
-        "position_y": 0.2 * 1.75,
+        "positionY": 0.2 * 1.75,
         "scale": {
             "x": 1.75,
             "y": 1.75,
@@ -1518,7 +1518,7 @@ OBJECTS_MOVEABLE = [{
         "info": ["small", "brown", "box"],
         "mass": 1,
         "salientMaterials": ["paper"],
-        "enclosed_areas": [{
+        "enclosedAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -1541,17 +1541,17 @@ OBJECTS_MOVEABLE = [{
             "y": -0.038,
             "z": -0.115
         },
-        "closed_dimensions": {
+        "closedDimensions": {
             "x": 0.41,
             "y": 0.31,
             "z": 0.34
         },
-        "closed_offset": {
+        "closedOffset": {
             "x": 0,
             "y": -0.125,
             "z": -0.13
         },
-        "position_y": 0.3,
+        "positionY": 0.3,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1561,7 +1561,7 @@ OBJECTS_MOVEABLE = [{
         "info": ["medium", "brown", "box"],
         "mass": 3,
         "salientMaterials": ["paper"],
-        "enclosed_areas": [{
+        "enclosedAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -1584,17 +1584,17 @@ OBJECTS_MOVEABLE = [{
             "y": -0.038,
             "z": -0.115 * 1.5
         },
-        "closed_dimensions": {
+        "closedDimensions": {
             "x": 0.41 * 1.5,
             "y": 0.31,
             "z": 0.34 * 1.5
         },
-        "closed_offset": {
+        "closedOffset": {
             "x": 0,
             "y": -0.125,
             "z": -0.13 * 1.5
         },
-        "position_y": 0.3,
+        "positionY": 0.3,
         "scale": {
             "x": 1.5,
             "y": 1,
@@ -1605,13 +1605,13 @@ OBJECTS_MOVEABLE = [{
     "type": "box_4",
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
-    "novel_color": True,
-    "novel_shape": True,
+    "novelColor": True,
+    "novelShape": True,
     "chooseSize": [{
         "info": ["small", "grey", "box"],
         "mass": 1,
         "salientMaterials": ["paper"],
-        "enclosed_areas": [{
+        "enclosedAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -1634,17 +1634,17 @@ OBJECTS_MOVEABLE = [{
             "y": -0.046,
             "z": -0.136
         },
-        "closed_dimensions": {
+        "closedDimensions": {
             "x": 0.3,
             "y": 0.32,
             "z": 0.34
         },
-        "closed_offset": {
+        "closedOffset": {
             "x": 0,
             "y": -0.125,
             "z": -0.13
         },
-        "position_y": 0.3,
+        "positionY": 0.3,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1654,7 +1654,7 @@ OBJECTS_MOVEABLE = [{
         "info": ["tiny", "grey", "box"],
         "mass": 0.25,
         "salientMaterials": ["paper"],
-        "enclosed_areas": [{
+        "enclosedAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -1677,17 +1677,17 @@ OBJECTS_MOVEABLE = [{
             "y": -0.046,
             "z": -0.136 * 1.5
         },
-        "closed_dimensions": {
+        "closedDimensions": {
             "x": 0.3 * 1.5,
             "y": 0.32,
             "z": 0.34 * 1.5
         },
-        "closed_offset": {
+        "closedOffset": {
             "x": 0,
             "y": -0.125,
             "z": -0.13 * 1.5
         },
-        "position_y": 0.3,
+        "positionY": 0.3,
         "scale": {
             "x": 1.5,
             "y": 1,
@@ -1711,7 +1711,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.399,
             "z": -0.118
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1729,7 +1729,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.32,
             "z": -0.018
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1747,7 +1747,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.546,
             "z": -0.017
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1765,7 +1765,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.41,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1783,7 +1783,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.383,
             "z": 0.033
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1801,7 +1801,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.629,
             "z": -0.012
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1825,7 +1825,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.399 / 0.5,
             "z": -0.118 / 0.5
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -1843,7 +1843,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.32 / 0.5,
             "z": -0.018 / 0.5
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -1861,7 +1861,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.546 / 0.5,
             "z": -0.017 / 0.5
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -1879,7 +1879,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.41 / 0.5,
             "z": 0 / 0.5
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -1897,7 +1897,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.383 / 0.5,
             "z": 0.033 / 0.5
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -1915,7 +1915,7 @@ OBJECTS_MOVEABLE = [{
             "y": 0.629 / 0.5,
             "z": -0.012 / 0.5
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -1932,7 +1932,7 @@ OBJECTS_IMMOBILE = [{
     "materialCategory": ["wood"],
     "salientMaterials": ["wood"],
     "attributes": ["receptacle", "openable"],
-    "enclosed_areas": [{
+    "enclosedAreas": [{
 # Remove the top drawer for now.
 #        "id": "_drawer_top",
 #        "position": {
@@ -1958,7 +1958,7 @@ OBJECTS_IMMOBILE = [{
             "z": 0.41
         }
     }],
-    "open_areas": [{
+    "openAreas": [{
 # Remove the top shelves for now.
 #        "id": "",
 #        "position": {
@@ -2018,17 +2018,17 @@ OBJECTS_IMMOBILE = [{
         "y": 0.48,
         "z": 0.155
     },
-    "closed_dimensions": {
+    "closedDimensions": {
         "x": 1.1,
         "y": 0.96,
         "z": 0.58
     },
-    "closed_offset": {
+    "closedOffset": {
         "x": -0.01,
         "y": 0.48,
         "z": 0
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -2050,7 +2050,7 @@ OBJECTS_IMMOBILE = [{
         "y": 0.45,
         "z": 0
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -2063,7 +2063,7 @@ OBJECTS_IMMOBILE = [{
         "materialCategory": ["wood", "wood"],
         "salientMaterials": ["wood"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "massMultiplier": 2,
         "materialCategory": ["metal", "metal"],
         "salientMaterials": ["metal"],
@@ -2071,7 +2071,7 @@ OBJECTS_IMMOBILE = [{
     "chooseSize": [{
         "info": ["huge", "table"],
 # Remove for now because it's too high up.
-#        "open_areas": [{
+#        "openAreas": [{
 #            "id": "",
 #            "position": {
 #                "x": 0.065 * 1.175,
@@ -2095,7 +2095,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.44,
             "z": -0.07
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1.175,
             "y": 1,
@@ -2104,7 +2104,7 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["large", "table"],
 # Remove for now because it's too high up.
-#        "open_areas": [{
+#        "openAreas": [{
 #            "id": "",
 #            "position": {
 #                "x": 0.065 * 2.35,
@@ -2128,7 +2128,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.44,
             "z": -0.07
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2.35,
             "y": 1,
@@ -2137,7 +2137,7 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["medium", "table"],
         "obstruct": "navigation",
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": 0.065 * 0.5875,
@@ -2161,7 +2161,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.44 * 0.5,
             "z": -0.07 * 0.25
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5875,
             "y": 0.5,
@@ -2171,12 +2171,12 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "table_3",
     "obstruct": "navigation",
-    "novel_shape": True,
+    "novelShape": True,
     "chooseMaterial": [{
         "materialCategory": ["wood", "wood"],
         "salientMaterials": ["wood"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "massMultiplier": 2,
         "materialCategory": ["metal", "metal"],
         "salientMaterials": ["metal"],
@@ -2185,7 +2185,7 @@ OBJECTS_IMMOBILE = [{
         "info": ["large", "table"],
         "attributes": ["moveable", "receptacle"],
 # Remove for now because it's too high up.
-#        "open_areas": [{
+#        "openAreas": [{
 #            "id": "",
 #            "position": {
 #                "x": 0,
@@ -2209,7 +2209,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.509,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -2218,7 +2218,7 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["medium", "table"],
         "attributes": ["moveable", "receptacle", "stackTarget"],
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -2242,7 +2242,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.509 * 0.5,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 0.5,
@@ -2256,7 +2256,7 @@ OBJECTS_IMMOBILE = [{
         "materialCategory": ["wood", "wood"],
         "salientMaterials": ["wood"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "massMultiplier": 2,
         "materialCategory": ["metal", "metal"],
         "salientMaterials": ["metal"],
@@ -2265,7 +2265,7 @@ OBJECTS_IMMOBILE = [{
         "attributes": ["receptacle"],
         "info": ["large", "table"],
 # Remove for now because it's too high up.
-#        "open_areas": [{
+#        "openAreas": [{
 #            "id": "",
 #            "position": {
 #                "x": -0.18 * 0.5,
@@ -2289,7 +2289,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.35,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 1,
@@ -2299,7 +2299,7 @@ OBJECTS_IMMOBILE = [{
         "attributes": ["receptacle", "stackTarget"],
         "info": ["huge", "table"],
 # Remove for now because it's too high up.
-#        "open_areas": [{
+#        "openAreas": [{
 #            "id": "",
 #            "position": {
 #                "x": -0.18,
@@ -2323,7 +2323,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.35,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
@@ -2332,7 +2332,7 @@ OBJECTS_IMMOBILE = [{
     }, {
         "attributes": ["receptacle", "stackTarget"],
         "info": ["large", "table"],
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": -0.18,
@@ -2356,7 +2356,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.35 * 0.5,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 0.5,
@@ -2370,7 +2370,7 @@ OBJECTS_IMMOBILE = [{
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "massMultiplier": 2,
         "materialCategory": ["metal"],
         "salientMaterials": ["metal"],
@@ -2378,7 +2378,7 @@ OBJECTS_IMMOBILE = [{
     "chooseSize": [{
         "info": ["small", "shelf"],
         "attributes": ["receptacle", "stackTarget"],
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -2426,7 +2426,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.355,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 1,
@@ -2435,7 +2435,7 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["medium", "shelf"],
         "attributes": ["receptacle"],
-        "open_areas": [{
+        "openAreas": [{
 # Remove for now because it's too high up.
 #            "id": "",
 #            "position": {
@@ -2484,7 +2484,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.355 * 1.5,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1.5,
             "y": 1.5,
@@ -2493,7 +2493,7 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["huge", "shelf"],
         "attributes": ["receptacle"],
-        "open_areas": [{
+        "openAreas": [{
 # Remove for now because it's too high up.
 #            "id": "",
 #            "position": {
@@ -2542,7 +2542,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.355 * 3,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 3,
             "y": 3,
@@ -2555,7 +2555,7 @@ OBJECTS_IMMOBILE = [{
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "massMultiplier": 2,
         "materialCategory": ["metal"],
         "salientMaterials": ["metal"],
@@ -2563,7 +2563,7 @@ OBJECTS_IMMOBILE = [{
     "chooseSize": [{
         "info": ["small", "shelf"],
         "attributes": ["receptacle", "stackTarget"],
-        "open_areas": [{
+        "openAreas": [{
             "id": "",
             "position": {
                 "x": 0,
@@ -2635,7 +2635,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.385 * 0.5,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -2644,7 +2644,7 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["medium", "shelf"],
         "attributes": ["receptacle"],
-        "open_areas": [{
+        "openAreas": [{
 # Remove for now because it's too high up.
 #            "id": "",
 #            "position": {
@@ -2717,17 +2717,17 @@ OBJECTS_IMMOBILE = [{
             "y": 0.385,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 1,
             "y": 1,
             "z": 1
         }
     }, {
-        "novel_combination": True,
+        "novelCombination": True,
         "info": ["huge", "shelf"],
         "attributes": ["receptacle"],
-        "open_areas": [{
+        "openAreas": [{
 # Remove for now because it's too high up.
 #            "id": "",
 #            "position": {
@@ -2800,7 +2800,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.385 * 2,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 2,
@@ -2813,7 +2813,7 @@ OBJECTS_IMMOBILE = [{
     "info": ["huge", "brown", "sofa"],
     "mass": 100,
     "attributes": ["receptacle", "stackTarget"],
-    "open_areas": [{
+    "openAreas": [{
         "id": "",
         "position": {
             "x": 0,
@@ -2836,7 +2836,7 @@ OBJECTS_IMMOBILE = [{
         "y": 0.55,
         "z": -0.025
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -2848,7 +2848,7 @@ OBJECTS_IMMOBILE = [{
     "info": ["huge", "grey", "sofa"],
     "mass": 100,
     "attributes": ["receptacle", "stackTarget"],
-    "open_areas": [{
+    "openAreas": [{
         "id": "",
         "position": {
             "x": 0,
@@ -2871,7 +2871,7 @@ OBJECTS_IMMOBILE = [{
         "y": 0.55,
         "z": -0.025
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -2883,7 +2883,7 @@ OBJECTS_IMMOBILE = [{
     "info": ["huge", "black", "sofa chair"],
     "mass": 50,
     "attributes": ["receptacle", "stackTarget"],
-    "open_areas": [{
+    "openAreas": [{
         "id": "",
         "position": {
             "x": -0.03,
@@ -2906,7 +2906,7 @@ OBJECTS_IMMOBILE = [{
         "y": 0.55,
         "z": -0.025
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -2918,7 +2918,7 @@ OBJECTS_IMMOBILE = [{
     "info": ["huge", "grey", "sofa chair"],
     "mass": 50,
     "attributes": ["receptacle", "stackTarget"],
-    "open_areas": [{
+    "openAreas": [{
         "id": "",
         "position": {
             "x": 0.005,
@@ -2941,7 +2941,7 @@ OBJECTS_IMMOBILE = [{
         "y": 0.55,
         "z": -0.025
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -2955,8 +2955,8 @@ OBJECTS_IMMOBILE = [{
     "materialCategory": ["wood"],
     "salientMaterials": ["wood"],
     "attributes": ["receptacle", "openable"],
-    "novel_shape": True,
-    "enclosed_areas": [{
+    "novelShape": True,
+    "enclosedAreas": [{
 # Remove the top drawers and shelves for now.
 #        "id": "_middle_shelf_right",
 #        "position": {
@@ -3052,17 +3052,17 @@ OBJECTS_IMMOBILE = [{
         "y": 1.05,
         "z": -0.09
     },
-    "closed_dimensions": {
+    "closedDimensions": {
         "x": 1.07,
         "y": 2.1,
         "z": 1
     },
-    "closed_offset": {
+    "closedOffset": {
         "x": 0,
         "y": 1.05,
         "z": 0.17
     },
-    "position_y": 0,
+    "positionY": 0,
     "scale": {
         "x": 1,
         "y": 1,
@@ -3085,7 +3085,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.399 * 2,
             "z": -0.118
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 2,
@@ -3103,7 +3103,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.32 * 2,
             "z": -0.018
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 2,
@@ -3121,7 +3121,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.546 * 2,
             "z": -0.017
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 2,
@@ -3139,7 +3139,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.41 * 2,
             "z": 0
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 2,
@@ -3157,7 +3157,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.383 * 2,
             "z": 0.033
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 2,
@@ -3175,7 +3175,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.629 * 2,
             "z": -0.012
         },
-        "position_y": 0,
+        "positionY": 0,
         "scale": {
             "x": 2,
             "y": 2,
@@ -3188,7 +3188,6 @@ OBJECTS_IMMOBILE = [{
 OCCLUDER_INSTANCE_NORMAL = [{
     "id": "occluder_wall_",
     "info": [],
-    "info_string": "",
     "type": "cube",
     "kinematic": True,
     "structure": True,
@@ -3260,7 +3259,6 @@ OCCLUDER_INSTANCE_NORMAL = [{
 }, {
     "id": "occluder_pole_",
     "info": [],
-    "info_string": "",
     "type": "cylinder",
     "kinematic": True,
     "structure": True,
@@ -3310,7 +3308,6 @@ OCCLUDER_INSTANCE_NORMAL = [{
 OCCLUDER_INSTANCE_SIDEWAYS = [{
     "id": "occluder_wall_",
     "info": [],
-    "info_string": "",
     "type": "cube",
     "kinematic": True,
     "structure": True,
@@ -3382,7 +3379,6 @@ OCCLUDER_INSTANCE_SIDEWAYS = [{
 }, {
     "id": "occluder_pole_",
     "info": [],
-    "info_string": "",
     "type": "cylinder",
     "kinematic": True,
     "structure": True,
@@ -3457,13 +3453,13 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.75,
         "z": 0.75
     },
-    "position_y": 0.375,
+    "positionY": 0.375,
     "scale": {
         "x": 0.75,
         "y": 0.75,
         "z": 0.75
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.75,
@@ -3654,13 +3650,13 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.5,
         "z": 0.5
     },
-    "position_y": 0.25,
+    "positionY": 0.25,
     "scale": {
         "x": 0.5,
         "y": 0.5,
         "z": 0.5
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.5,
@@ -3850,13 +3846,13 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.25,
         "z": 0.25
     },
-    "position_y": 0.125,
+    "positionY": 0.125,
     "scale": {
         "x": 0.25,
         "y": 0.25,
         "z": 0.25
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.25,
@@ -4044,13 +4040,13 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.75,
         "z": 0.75
     },
-    "position_y": 0.375,
+    "positionY": 0.375,
     "scale": {
         "x": 0.75,
         "y": 0.75,
         "z": 0.75
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.75,
@@ -4257,13 +4253,13 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.5,
         "z": 0.5
     },
-    "position_y": 0.25,
+    "positionY": 0.25,
     "scale": {
         "x": 0.5,
         "y": 0.5,
         "z": 0.5
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.5,
@@ -4468,13 +4464,13 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.25,
         "z": 0.25
     },
-    "position_y": 0.125,
+    "positionY": 0.125,
     "scale": {
         "x": 0.25,
         "y": 0.25,
         "z": 0.25
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.25,
@@ -4677,7 +4673,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.75,
         "z": 0.75
     },
-    "position_y": 0.375,
+    "positionY": 0.375,
     "rotation": {
         "x": 90,
         "y": 0,
@@ -4688,7 +4684,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.375, # Must be half
         "z": 0.75
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.75,
@@ -4881,7 +4877,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.5,
         "z": 0.5
     },
-    "position_y": 0.25,
+    "positionY": 0.25,
     "rotation": {
         "x": 90,
         "y": 0,
@@ -4892,7 +4888,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.25, # Must be half
         "z": 0.5
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.5,
@@ -5083,7 +5079,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.25,
         "z": 0.25
     },
-    "position_y": 0.125,
+    "positionY": 0.125,
     "rotation": {
         "x": 90,
         "y": 0,
@@ -5094,7 +5090,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
         "y": 0.125, # Must be half
         "z": 0.25
     },
-    "intphys_options": [{
+    "intphysOptions": [{
         "y": 0,
         "force": {
             "x": 300 * 0.25,
@@ -5266,7 +5262,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
 
 OBJECTS_INTPHYS_NOVEL = [{
     "type": "duck_on_wheels",
-    "novel_shape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "info": ["tiny", "duck"],
     "mass": 2,
@@ -5287,7 +5283,7 @@ OBJECTS_INTPHYS_NOVEL = [{
         "y": 0.085,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -5295,7 +5291,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     }
 }, {
     "type": "duck_on_wheels",
-    "novel_shape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "info": ["small", "duck"],
     "mass": 4,
@@ -5316,7 +5312,7 @@ OBJECTS_INTPHYS_NOVEL = [{
         "y": 0.085 * 2.5,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 2.5,
         "y": 2.5,
@@ -5324,7 +5320,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     }
 }, {
     "type": "duck_on_wheels",
-    "novel_shape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "info": ["medium", "duck"],
     "mass": 8,
@@ -5345,7 +5341,7 @@ OBJECTS_INTPHYS_NOVEL = [{
         "y": 0.085 * 4,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 4,
         "y": 4,
@@ -5353,7 +5349,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     }
 }, {
     "type": "racecar_red",
-    "novel_shape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "info": ["tiny", "car"],
     "mass": 2,
@@ -5380,7 +5376,7 @@ OBJECTS_INTPHYS_NOVEL = [{
         "y": 90,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 2,
         "y": 2,
@@ -5388,7 +5384,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     }
 }, {
     "type": "racecar_red",
-    "novel_shape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "info": ["small", "car"],
     "mass": 4,
@@ -5415,7 +5411,7 @@ OBJECTS_INTPHYS_NOVEL = [{
         "y": 90,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 3.5,
         "y": 3.5,
@@ -5423,7 +5419,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     }
 }, {
     "type": "racecar_red",
-    "novel_shape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "info": ["medium", "car"],
     "mass": 4,
@@ -5450,7 +5446,7 @@ OBJECTS_INTPHYS_NOVEL = [{
         "y": 90,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 5,
         "y": 5,
@@ -5481,16 +5477,13 @@ def create_occluder(wall_material: Tuple[str, List[str]], pole_material: Tuple[s
     occluder[WALL]['info'] = wall_material[1]
     occluder[POLE]['info'] = pole_material[1]
 
-    occluder[WALL]['info_string'] = ' '.join(occluder[WALL]['info'])
-    occluder[POLE]['info_string'] = ' '.join(occluder[POLE]['info'])
-
     occluder[WALL]['shows'][0]['position']['x'] = x_position
     occluder[POLE]['shows'][0]['position']['x'] = x_position
 
     occluder[WALL]['shows'][0]['scale']['x'] = x_scale
 
     # is_occluder is needed by SpatioTemporalContinuityQuartet
-    occluder[WALL]['intphys_option'] = {
+    occluder[WALL]['intphysOption'] = {
         'is_occluder': True
     }
 
@@ -5521,15 +5514,15 @@ _ENCLOSED_CONTAINERS = None
 
 
 def get_enclosed_containers() -> List[Dict[str, Any]]:
-    """Return all object definitions that have 'enclosed_areas' whose value is a non-empty list."""
+    """Return all object definitions that have 'enclosedAreas' whose value is a non-empty list."""
     global _ENCLOSED_CONTAINERS
     if _ENCLOSED_CONTAINERS is None:
         all_defs = get_all_object_defs()
         _ENCLOSED_CONTAINERS = [
             obj_def for obj_def in all_defs
-            if ('enclosed_areas' in obj_def and len(obj_def['enclosed_areas']) > 0)
-            or (('chooseSize' in obj_def) and ('enclosed_areas' in obj_def['chooseSize'][0])
-                and (len(obj_def['chooseSize'][0]['enclosed_areas']) > 0))
+            if ('enclosedAreas' in obj_def and len(obj_def['enclosedAreas']) > 0)
+            or (('chooseSize' in obj_def) and ('enclosedAreas' in obj_def['chooseSize'][0])
+                and (len(obj_def['chooseSize'][0]['enclosedAreas']) > 0))
         ]
     return _ENCLOSED_CONTAINERS
 
@@ -5538,9 +5531,9 @@ _INTPHYS_OBJECTS = None
 
 
 def get_intphys_objects() -> List[Dict[str, Any]]:
-    """Return all object definitions that have 'intphys_options'."""
+    """Return all object definitions that have 'intphysOptions'."""
     global _INTPHYS_OBJECTS
     if _INTPHYS_OBJECTS is None:
         all_defs = get_all_object_defs()
-        _INTPHYS_OBJECTS = [obj_def for obj_def in all_defs if 'intphys_options' in obj_def]
+        _INTPHYS_OBJECTS = [obj_def for obj_def in all_defs if 'intphysOptions' in obj_def]
     return _INTPHYS_OBJECTS

--- a/scene_generator/objects.py
+++ b/scene_generator/objects.py
@@ -5,339 +5,218 @@ from typing import Tuple, Dict, Any, List
 OBJECTS_PICKUPABLE_BALLS = [{
     "type": "sphere",
     "info": ["tiny", "ball"],
-    "choose": [{
-        "mass": 0.0625,
+    "attributes": ["moveable", "pickupable"],
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
-        "mass": 0.125,
         "materialCategory": ["rubber"],
         "salientMaterials": ["rubber"]
     }, {
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"]
+    }, {
+        "massMultiplier": 2,
+        "materialCategory": ["metal"],
+        "salientMaterials": ["metal"]
+    }, {
+        "novel_combination": True,
+        "materialCategory": ["block_blank"],
+        "salientMaterials": ["wood"]
+    }],
+    "chooseSize": [{
+        "dimensions": {
+            "x": 0.025,
+            "y": 0.025,
+            "z": 0.025
+        },
         "mass": 0.125,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
+        "position_y": 0.0125,
+        "scale": {
+            "x": 0.025,
+            "y": 0.025,
+            "z": 0.025
+        }
     }, {
+        "dimensions": {
+            "x": 0.05,
+            "y": 0.05,
+            "z": 0.05,
+        },
         "mass": 0.25,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"]
+        "position_y": 0.025,
+        "scale": {
+            "x": 0.05,
+            "y": 0.05,
+            "z": 0.05
+        }
     }, {
-        "novel_combination": True,
-        "mass": 0.125,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable"],
-    "dimensions": {
-        "x": 0.025,
-        "y": 0.025,
-        "z": 0.025
-    },
-    "position_y": 0.0125,
-    "scale": {
-        "x": 0.025,
-        "y": 0.025,
-        "z": 0.025
-    }
-}, {
-    "type": "sphere",
-    "info": ["tiny", "ball"],
-    "choose": [{
-        "mass": 0.125,
-        "materialCategory": ["plastic"],
-        "salientMaterials": ["plastic", "hollow"]
-    }, {
-        "mass": 0.25,
-        "materialCategory": ["rubber"],
-        "salientMaterials": ["rubber"]
-    }, {
-        "mass": 0.25,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }, {
+        "dimensions": {
+            "x": 0.1,
+            "y": 0.1,
+            "z": 0.1
+        },
         "mass": 0.5,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"]
+        "position_y": 0.05,
+        "scale": {
+            "x": 0.1,
+            "y": 0.1,
+            "z": 0.1
+        }
     }, {
-        "novel_combination": True,
-        "mass": 0.25,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable"],
-    "dimensions": {
-        "x": 0.05,
-        "y": 0.05,
-        "z": 0.05,
-    },
-    "position_y": 0.025,
-    "scale": {
-        "x": 0.05,
-        "y": 0.05,
-        "z": 0.05
-    }
-}, {
-    "type": "sphere",
-    "info": ["tiny", "ball"],
-    "choose": [{
-        "mass": 0.25,
-        "materialCategory": ["plastic"],
-        "salientMaterials": ["plastic", "hollow"]
-    }, {
-        "mass": 0.5,
-        "materialCategory": ["rubber"],
-        "salientMaterials": ["rubber"]
-    }, {
-        "mass": 0.5,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }, {
-        "mass": 1,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"]
-    }, {
-        "novel_combination": True,
-        "mass": 0.5,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable"],
-    "dimensions": {
-        "x": 0.1,
-        "y": 0.1,
-        "z": 0.1
-    },
-    "position_y": 0.05,
-    "scale": {
-        "x": 0.1,
-        "y": 0.1,
-        "z": 0.1
-    }
-}, {
-    "type": "sphere",
-    "info": ["small", "ball"],
-    "choose": [{
-        "mass": 1,
-        "materialCategory": ["plastic"],
-        "salientMaterials": ["plastic", "hollow"]
-    }, {
+        "info": ["small", "ball"],
+        "dimensions": {
+            "x": 0.25,
+            "y": 0.25,
+            "z": 0.25
+        },
         "mass": 2,
-        "materialCategory": ["rubber"],
-        "salientMaterials": ["rubber"],
-    }, {
-        "mass": 2,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }, {
-        "mass": 4,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"]
-    }, {
-        "novel_combination": True,
-        "mass": 2,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable"],
-    "dimensions": {
-        "x": 0.25,
-        "y": 0.25,
-        "z": 0.25
-    },
-    "position_y": 0.125,
-    "scale": {
-        "x": 0.25,
-        "y": 0.25,
-        "z": 0.25
-    }
+        "position_y": 0.125,
+        "scale": {
+            "x": 0.25,
+            "y": 0.25,
+            "z": 0.25
+        }
+    }]
 }]
 
 OBJECTS_PICKUPABLE_BLOCKS = [{
     "type": "block_blank_wood_cube",
     "obstruct": "vision",
     "info": ["tiny", "blank block", "cube"],
-    "choose": [{
+    "attributes": ["moveable", "pickupable", "stackTarget"],
+    "chooseMaterial": [{
+        "materialCategory": ["block_blank"],
+        "salientMaterials": ["wood"]
+    }, {
+        "novel_combination": True,
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"]
+    }],
+    "chooseSize": [{
+        "dimensions": {
+            "x": 0.1,
+            "y": 0.1,
+            "z": 0.1
+        },
         "mass": 0.66,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
+        "offset": {
+            "x": 0,
+            "y": 0.05,
+            "z": 0
+        },
+        "position_y": 0,
+        "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+        }
     }, {
-        "novel_combination": True,
-        "mass": 0.66,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable", "stackTarget"],
-    "dimensions": {
-        "x": 0.1,
-        "y": 0.1,
-        "z": 0.1
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.05,
-        "z": 0
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 1,
-        "y": 1,
-        "z": 1
-    }
-}, {
-    "type": "block_blank_wood_cube",
-    "obstruct": "vision",
-    "info": ["tiny", "blank block", "cube"],
-    "choose": [{
+        "dimensions": {
+            "x": 0.1,
+            "y": 0.2,
+            "z": 0.1
+        },
         "mass": 1.33,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
+        "offset": {
+            "x": 0,
+            "y": 0.1,
+            "z": 0
+        },
+        "position_y": 0,
+        "scale": {
+            "x": 1,
+            "y": 2,
+            "z": 1
+        }
     }, {
-        "novel_combination": True,
-        "mass": 1.33,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable", "stackTarget"],
-    "dimensions": {
-        "x": 0.1,
-        "y": 0.2,
-        "z": 0.1
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.1,
-        "z": 0
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 1,
-        "y": 2,
-        "z": 1
-    }
-}, {
-    "type": "block_blank_wood_cube",
-    "obstruct": "vision",
-    "info": ["tiny", "blank block", "cube"],
-    "choose": [{
+        "dimensions": {
+            "x": 0.2,
+            "y": 0.1,
+            "z": 0.2
+        },
         "mass": 2.66,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
-    }, {
-        "novel_combination": True,
-        "mass": 2.66,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable", "stackTarget"],
-    "dimensions": {
-        "x": 0.2,
-        "y": 0.1,
-        "z": 0.2
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.05,
-        "z": 0
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 2,
-        "y": 1,
-        "z": 2
-    }
+        "offset": {
+            "x": 0,
+            "y": 0.05,
+            "z": 0
+        },
+        "position_y": 0,
+        "scale": {
+            "x": 2,
+            "y": 1,
+            "z": 2
+        }
+    }]
 }, {
     "type": "block_blank_wood_cylinder",
     "obstruct": "vision",
     "info": ["tiny", "blank block", "cylinder"],
-    "choose": [{
+    "attributes": ["moveable", "pickupable"],
+    "chooseMaterial": [{
+        "materialCategory": ["block_blank"],
+        "salientMaterials": ["wood"]
+    }, {
+        "novel_combination": True,
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"]
+    }],
+    "chooseSize": [{
+        "dimensions": {
+            "x": 0.1,
+            "y": 0.1,
+            "z": 0.1
+        },
         "mass": 0.66,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
+        "offset": {
+            "x": 0,
+            "y": 0.05,
+            "z": 0
+        },
+        "position_y": 0,
+        "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+        }
     }, {
-        "novel_combination": True,
-        "mass": 0.66,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable"],
-    "dimensions": {
-        "x": 0.1,
-        "y": 0.1,
-        "z": 0.1
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.05,
-        "z": 0
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 1,
-        "y": 1,
-        "z": 1
-    }
-}, {
-    "type": "block_blank_wood_cylinder",
-    "obstruct": "vision",
-    "info": ["tiny", "blank block", "cylinder"],
-    "choose": [{
+        "dimensions": {
+            "x": 0.1,
+            "y": 0.2,
+            "z": 0.1
+        },
         "mass": 1.33,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
+        "offset": {
+            "x": 0,
+            "y": 0.1,
+            "z": 0
+        },
+        "position_y": 0,
+        "scale": {
+            "x": 1,
+            "y": 2,
+            "z": 1
+        }
     }, {
-        "novel_combination": True,
-        "mass": 1.33,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable"],
-    "dimensions": {
-        "x": 0.1,
-        "y": 0.2,
-        "z": 0.1
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.1,
-        "z": 0
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 1,
-        "y": 2,
-        "z": 1
-    }
-}, {
-    "type": "block_blank_wood_cylinder",
-    "obstruct": "vision",
-    "info": ["tiny", "blank block", "cylinder"],
-    "choose": [{
+        "dimensions": {
+            "x": 0.2,
+            "y": 0.1,
+            "z": 0.2
+        },
         "mass": 2.66,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"]
-    }, {
-        "novel_combination": True,
-        "mass": 2.66,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "pickupable"],
-    "dimensions": {
-        "x": 0.2,
-        "y": 0.1,
-        "z": 0.2
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.05,
-        "z": 0
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 2,
-        "y": 1,
-        "z": 2
-    }
+        "offset": {
+            "x": 0,
+            "y": 0.05,
+            "z": 0
+        },
+        "position_y": 0,
+        "scale": {
+            "x": 2,
+            "y": 1,
+            "z": 2
+        }
+    }]
 }, {
     # Readers, please ignore the "blue letter c" in the type: the object's chosen material will change this design.
     "type": "block_blue_letter_c",
@@ -393,16 +272,22 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
 OBJECTS_PICKUPABLE_TOYS = [{
     "type": "duck_on_wheels",
     "attributes": ["moveable", "pickupable"],
-    "choose": [{
-        "info": ["tiny", "duck"],
-        "mass": 1,
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
+        "salientMaterials": ["wood"]
+    }, {
+        "novel_combination": True,
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"]
+    }],
+    "chooseSize": [{
+        "info": ["tiny", "duck"],
         "dimensions": {
             "x": 0.105,
             "y": 0.085,
             "z": 0.0325
         },
+        "mass": 1,
         "offset": {
             "x": 0,
             "y": 0.0425,
@@ -416,14 +301,12 @@ OBJECTS_PICKUPABLE_TOYS = [{
         }
     }, {
         "info": ["tiny", "duck"],
-        "mass": 2,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
         "dimensions": {
             "x": 0.21,
             "y": 0.17,
             "z": 0.065
         },
+        "mass": 2,
         "offset": {
             "x": 0,
             "y": 0.085,
@@ -437,80 +320,12 @@ OBJECTS_PICKUPABLE_TOYS = [{
         }
     }, {
         "info": ["small", "duck"],
-        "mass": 4,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
         "dimensions": {
             "x": 0.42,
             "y": 0.34,
             "z": 0.13
         },
-        "offset": {
-            "x": 0,
-            "y": 0.17,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 2,
-            "y": 2,
-            "z": 2
-        }
-    }, {
-        "info": ["tiny", "duck"],
-        "mass": 1,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.105,
-            "y": 0.085,
-            "z": 0.0325
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.0425,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 0.5,
-            "y": 0.5,
-            "z": 0.5
-        }
-    }, {
-        "info": ["tiny", "duck"],
-        "mass": 2,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.21,
-            "y": 0.17,
-            "z": 0.065
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.085,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
-        }
-    }, {
-        "info": ["small", "duck"],
         "mass": 4,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.42,
-            "y": 0.34,
-            "z": 0.13
-        },
         "offset": {
             "x": 0,
             "y": 0.17,
@@ -526,16 +341,22 @@ OBJECTS_PICKUPABLE_TOYS = [{
 }, {
     "type": "racecar_red",
     "attributes": ["moveable", "pickupable"],
-    "choose": [{
-        "info": ["tiny", "car"],
-        "mass": 1,
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
+        "salientMaterials": ["wood"]
+    }, {
+        "novel_combination": True,
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"]
+    }],
+    "chooseSize": [{
+        "info": ["tiny", "car"],
         "dimensions": {
             "x": 0.0525,
             "y": 0.045,
             "z": 0.1125
         },
+        "mass": 1,
         "offset": {
             "x": 0,
             "y": 0.0225,
@@ -549,14 +370,12 @@ OBJECTS_PICKUPABLE_TOYS = [{
         }
     }, {
         "info": ["tiny", "car"],
-        "mass": 2,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
         "dimensions": {
             "x": 0.105,
             "y": 0.09,
             "z": 0.225
         },
+        "mass": 2,
         "offset": {
             "x": 0,
             "y": 0.045,
@@ -570,80 +389,12 @@ OBJECTS_PICKUPABLE_TOYS = [{
         }
     }, {
         "info": ["small", "car"],
-        "mass": 4,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
         "dimensions": {
             "x": 0.21,
             "y": 0.18,
             "z": 0.45
         },
-        "offset": {
-            "x": 0,
-            "y": 0.09,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 3,
-            "y": 3,
-            "z": 3
-        }
-    }, {
-        "info": ["tiny", "car"],
-        "mass": 1,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.0525,
-            "y": 0.045,
-            "z": 0.1125
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.0225,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 0.75,
-            "y": 0.75,
-            "z": 0.75
-        }
-    }, {
-        "info": ["tiny", "car"],
-        "mass": 2,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.105,
-            "y": 0.09,
-            "z": 0.225
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.045,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
-        }
-    }, {
-        "info": ["small", "car"],
         "mass": 4,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.21,
-            "y": 0.18,
-            "z": 0.45
-        },
         "offset": {
             "x": 0,
             "y": 0.09,
@@ -679,7 +430,8 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "z": 1
     }
 }, {
-    "choose": [{
+    "chooseMaterial": [{
+        # TODO
         "type": "crayon_blue",
         "info": ["tiny", "blue", "crayon"]
     }],
@@ -706,16 +458,21 @@ OBJECTS_PICKUPABLE_TOYS = [{
     "type": "turtle_on_wheels",
     "attributes": ["moveable", "pickupable"],
     "novel_shape": True,
-    "choose": [{
-        "info": ["tiny", "turtle"],
-        "mass": 1,
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
+        "salientMaterials": ["wood"]
+    }, {
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"]
+    }],
+    "chooseSize": [{
+        "info": ["tiny", "turtle"],
         "dimensions": {
             "x": 0.24 * 0.5,
             "y": 0.14 * 0.5,
             "z": 0.085 * 0.5
         },
+        "mass": 1,
         "offset": {
             "x": 0,
             "y": 0.07 * 0.5,
@@ -729,14 +486,12 @@ OBJECTS_PICKUPABLE_TOYS = [{
         }
     }, {
         "info": ["tiny", "turtle"],
-        "mass": 2,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
         "dimensions": {
             "x": 0.24,
             "y": 0.14,
             "z": 0.085
         },
+        "mass": 2,
         "offset": {
             "x": 0,
             "y": 0.07,
@@ -750,77 +505,12 @@ OBJECTS_PICKUPABLE_TOYS = [{
         }
     }, {
         "info": ["small", "turtle"],
-        "mass": 4,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
         "dimensions": {
             "x": 0.24 * 2,
             "y": 0.14 * 2,
             "z": 0.085 * 2
         },
-        "offset": {
-            "x": 0,
-            "y": 0.07 * 2,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 2,
-            "y": 2,
-            "z": 2
-        }
-    }, {
-        "info": ["tiny", "turtle"],
-        "mass": 1,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.24 * 0.5,
-            "y": 0.14 * 0.5,
-            "z": 0.085 * 0.5
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.07 * 0.5,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 0.5,
-            "y": 0.5,
-            "z": 0.5
-        }
-    }, {
-        "info": ["tiny", "turtle"],
-        "mass": 2,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.24,
-            "y": 0.14,
-            "z": 0.085
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.07,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
-        }
-    }, {
-        "info": ["small", "turtle"],
         "mass": 4,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.24 * 2,
-            "y": 0.14 * 2,
-            "z": 0.085 * 2
-        },
         "offset": {
             "x": 0,
             "y": 0.07 * 2,
@@ -836,16 +526,22 @@ OBJECTS_PICKUPABLE_TOYS = [{
 }, {
     "type": "car_1",
     "attributes": ["moveable", "pickupable"],
-    "choose": [{
-        "info": ["tiny", "car"],
-        "mass": 1,
+    "novel_shape": True,
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
+        "salientMaterials": ["wood"]
+    }, {
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"]
+    }],
+    "chooseSize": [{
+        "info": ["tiny", "car"],
         "dimensions": {
             "x": 0.075 * 0.75,
             "y": 0.065 * 0.75,
             "z": 0.14 * 0.75
         },
+        "mass": 1,
         "offset": {
             "x": 0,
             "y": 0.03 * 0.75,
@@ -859,14 +555,12 @@ OBJECTS_PICKUPABLE_TOYS = [{
         }
     }, {
         "info": ["tiny", "car"],
-        "mass": 2,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
         "dimensions": {
             "x": 0.075 * 1.5,
             "y": 0.065 * 1.5,
             "z": 0.14 * 1.5
         },
+        "mass": 2,
         "offset": {
             "x": 0,
             "y": 0.03 * 1.5,
@@ -880,80 +574,12 @@ OBJECTS_PICKUPABLE_TOYS = [{
         }
     }, {
         "info": ["small", "car"],
-        "mass": 4,
-        "materialCategory": ["block_blank"],
-        "salientMaterials": ["wood"],
         "dimensions": {
             "x": 0.075 * 3,
             "y": 0.065 * 3,
             "z": 0.14 * 3
         },
-        "offset": {
-            "x": 0,
-            "y": 0.03 * 3,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 3,
-            "y": 3,
-            "z": 3
-        }
-    }, {
-        "info": ["tiny", "car"],
-        "mass": 1,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.075 * 0.75,
-            "y": 0.065 * 0.75,
-            "z": 0.14 * 0.75
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.03 * 0.75,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 0.75,
-            "y": 0.75,
-            "z": 0.75
-        }
-    }, {
-        "info": ["tiny", "car"],
-        "mass": 2,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.075 * 1.5,
-            "y": 0.065 * 1.5,
-            "z": 0.14 * 1.5
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.03 * 1.5,
-            "z": 0
-        },
-        "position_y": 0.01,
-        "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
-        }
-    }, {
-        "info": ["small", "car"],
         "mass": 4,
-        "novel_combination": True,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "dimensions": {
-            "x": 0.075 * 3,
-            "y": 0.065 * 3,
-            "z": 0.14 * 3
-        },
         "offset": {
             "x": 0,
             "y": 0.03 * 3,
@@ -1015,13 +641,12 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "bowl_3",
     "info": ["tiny", "bowl"],
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
         "novel_combination": True,
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1031,6 +656,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.116,
         "z": 0.171
     },
+    "mass": 0.5,
     "offset": {
         "x": 0,
         "y": 0.055,
@@ -1045,13 +671,12 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "bowl_4",
     "info": ["tiny", "bowl"],
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
         "novel_combination": True,
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1061,6 +686,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.059,
         "z": 0.206
     },
+    "mass": 0.5,
     "offset": {
         "x": 0.001,
         "y": 0.027,
@@ -1076,12 +702,11 @@ OBJECTS_PICKUPABLE_MISC = [{
     "type": "bowl_6",
     "info": ["tiny", "bowl"],
     "novel_shape": True,
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1091,6 +716,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.109,
         "z": 0.201
     },
+    "mass": 0.5,
     "offset": {
         "x": 0,
         "y": 0.052,
@@ -1105,13 +731,12 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "cup_2",
     "info": ["tiny", "cup"],
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.25,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
         "novel_combination": True,
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1121,6 +746,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.135,
         "z": 0.104
     },
+    "mass": 0.5,
     "offset": {
         "x": 0,
         "y": 0.064,
@@ -1136,12 +762,11 @@ OBJECTS_PICKUPABLE_MISC = [{
     "type": "cup_3",
     "info": ["tiny", "cup"],
     "novel_shape": True,
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1151,6 +776,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.149,
         "z": 0.126
     },
+    "mass": 0.5,
     "offset": {
         "x": 0,
         "y": 0.072,
@@ -1165,13 +791,12 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "cup_6",
     "info": ["tiny", "cup"],
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
         "novel_combination": True,
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1181,6 +806,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.098,
         "z": 0.106
     },
+    "mass": 0.5,
     "offset": {
         "x": 0,
         "y": 0.046,
@@ -1195,13 +821,12 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "plate_1",
     "info": ["tiny", "plate"],
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
         "novel_combination": True,
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1211,6 +836,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.117,
         "z": 0.222
     },
+    "mass": 0.5,
     "offset": {
         "x": 0,
         "y": 0.057,
@@ -1225,13 +851,12 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "plate_3",
     "info": ["tiny", "plate"],
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
         "novel_combination": True,
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1241,6 +866,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.208,
         "z": 0.305
     },
+    "mass": 0.5,
     "offset": {
         "x": 0,
         "y": 0.098,
@@ -1256,12 +882,11 @@ OBJECTS_PICKUPABLE_MISC = [{
     "type": "plate_4",
     "info": ["tiny", "plate"],
     "novel_shape": True,
-    "choose": [{
-        "mass": 0.25,
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"],
     }, {
-        "mass": 0.5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
     }],
@@ -1271,6 +896,7 @@ OBJECTS_PICKUPABLE_MISC = [{
         "y": 0.113,
         "z": 0.206
     },
+    "mass": 0.5,
     "offset": {
         "x": 0,
         "y": 0.053,
@@ -1571,209 +1197,177 @@ OBJECTS_PICKUPABLE = [item for sublist in OBJECTS_PICKUPABLE_LISTS for item in s
 OBJECTS_MOVEABLE = [{
     "type": "chair_1",
     "info": ["medium", "chair"],
-    "choose": [{
-        "mass": 5,
+    "attributes": ["moveable", "receptacle", "stackTarget"],
+    "chooseMaterial": [{
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }, {
         "novel_combination": True,
-        "mass": 2.5,
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"]
     }, {
         "novel_combination": True,
-        "mass": 10,
+        "massMultiplier": 2,
         "materialCategory": ["metal"],
         "salientMaterials": ["metal"]
     }],
-    "attributes": ["moveable", "receptacle", "stackTarget"],
-    "open_areas": [{
-        "id": "",
-        "position": {
-            "x": 0.01,
-            "y": 0.5,
+    "chooseSize": [{
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": 0.01,
+                "y": 0.5,
+                "z": -0.02
+            },
+            "dimensions": {
+                "x": 0.38,
+                "y": 0,
+                "z": 0.38
+            }
+        }],
+        "dimensions": {
+            "x": 0.54,
+            "y": 1.04,
+            "z": 0.46
+        },
+        "mass": 5,
+        "offset": {
+            "x": 0,
+            "y": 0.51,
             "z": -0.02
         },
-        "dimensions": {
-            "x": 0.38,
-            "y": 0,
-            "z": 0.38
+        "position_y": 0,
+        "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
         }
-    }],
-    "dimensions": {
-        "x": 0.54,
-        "y": 1.04,
-        "z": 0.46
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.51,
-        "z": -0.02
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 1,
-        "y": 1,
-        "z": 1
-    }
-}, {
-    "type": "chair_1",
-    "obstruct": "navigation",
-    "info": ["small", "chair"],
-    "choose": [{
+    }, {
+        "info": ["small", "chair"],
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": 0.01 * 0.5,
+                "y": 0.5 * 0.5,
+                "z": -0.02 * 0.5
+            },
+            "dimensions": {
+                "x": 0.38 * 0.5,
+                "y": 0,
+                "z": 0.38 * 0.5
+            }
+        }],
+        "dimensions": {
+            "x": 0.54 * 0.5,
+            "y": 1.04 * 0.5,
+            "z": 0.46 * 0.5
+        },
         "mass": 2.5,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }, {
-        "novel_combination": True,
-        "mass": 1.25,
-        "materialCategory": ["plastic"],
-        "salientMaterials": ["plastic"]
-    }, {
-        "novel_combination": True,
-        "mass": 5,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"]
-    }],
-    "attributes": ["moveable", "receptacle", "stackTarget"],
-    "open_areas": [{
-        "id": "",
-        "position": {
-            "x": 0.01 * 0.5,
-            "y": 0.5 * 0.5,
+        "offset": {
+            "x": 0,
+            "y": 0.51 * 0.5,
             "z": -0.02 * 0.5
         },
-        "dimensions": {
-            "x": 0.38 * 0.5,
-            "y": 0,
-            "z": 0.38 * 0.5
+        "position_y": 0,
+        "scale": {
+            "x": 0.5,
+            "y": 0.5,
+            "z": 0.5
         }
-    }],
-    "dimensions": {
-        "x": 0.54 * 0.5,
-        "y": 1.04 * 0.5,
-        "z": 0.46 * 0.5
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.51 * 0.5,
-        "z": -0.02 * 0.5
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 0.5,
-        "y": 0.5,
-        "z": 0.5
-    }
+    }]
 }, {
     "type": "chair_2",
     "obstruct": "navigation",
     "info": ["medium", "stool"],
-    "choose": [{
-        "mass": 2.5,
+    "attributes": ["moveable", "receptacle", "stackTarget"],
+    "chooseMaterial": [{
+        "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic"]
     }, {
         "novel_combination": True,
-        "mass": 10,
+        "massMultiplier": 2,
         "materialCategory": ["metal"],
         "salientMaterials": ["metal"]
     }, {
         "novel_combination": True,
-        "mass": 5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
-    "attributes": ["moveable", "receptacle", "stackTarget"],
-    "open_areas": [{
-        "id": "",
-        "position": {
-            "x": 0,
+    "chooseSize": [{
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": 0,
+                "y": 0.75,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.2,
+                "y": 0,
+                "z": 0.2
+            }
+        }],
+        "dimensions": {
+            "x": 0.3,
             "y": 0.75,
-            "z": 0
+            "z": 0.3
         },
-        "dimensions": {
-            "x": 0.2,
-            "y": 0,
-            "z": 0.2
-        }
-    }],
-    "dimensions": {
-        "x": 0.3,
-        "y": 0.75,
-        "z": 0.3
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.375,
-        "z": 0
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 1,
-        "y": 1,
-        "z": 1
-    }
-}, {
-    "type": "chair_2",
-    "obstruct": "navigation",
-    "info": ["medium", "stool"],
-    "choose": [{
-        "mass": 1.25,
-        "materialCategory": ["plastic"],
-        "salientMaterials": ["plastic"]
-    }, {
-        "novel_combination": True,
         "mass": 5,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"]
-    }, {
-        "novel_combination": True,
-        "mass": 2.5,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"]
-    }],
-    "attributes": ["moveable", "receptacle", "stackTarget"],
-    "open_areas": [{
-        "id": "",
-        "position": {
+        "offset": {
             "x": 0,
-            "y": 0.75 * 0.5,
+            "y": 0.375,
             "z": 0
         },
-        "dimensions": {
-            "x": 0.2 * 0.5,
-            "y": 0,
-            "z": 0.2 * 0.5
+        "position_y": 0,
+        "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
         }
-    }],
-    "dimensions": {
-        "x": 0.3 * 0.5,
-        "y": 0.75 * 0.5,
-        "z": 0.3 * 0.5
-    },
-    "offset": {
-        "x": 0,
-        "y": 0.375 * 0.5,
-        "z": 0
-    },
-    "position_y": 0,
-    "scale": {
-        "x": 0.5,
-        "y": 0.5,
-        "z": 0.5
-    }
+    }, {
+        "info": ["small", "stool"],
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": 0,
+                "y": 0.75 * 0.5,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.2 * 0.5,
+                "y": 0,
+                "z": 0.2 * 0.5
+            }
+        }],
+        "mass": 2.5,
+        "dimensions": {
+            "x": 0.3 * 0.5,
+            "y": 0.75 * 0.5,
+            "z": 0.3 * 0.5
+        },
+        "offset": {
+            "x": 0,
+            "y": 0.375 * 0.5,
+            "z": 0
+        },
+        "position_y": 0,
+        "scale": {
+            "x": 0.5,
+            "y": 0.5,
+            "z": 0.5
+        }
+    }]
 }, {
     "type": "block_blank_wood_cube",
     "obstruct": "vision",
     "info": ["small", "blank block", "cube"],
-    "choose": [{
-        "mass": 5,
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
         "novel_combination": True,
-        "mass": 5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
@@ -1783,6 +1377,7 @@ OBJECTS_MOVEABLE = [{
         "y": 0.25,
         "z": 0.25
     },
+    "mass": 5,
     "offset": {
         "x": 0,
         "y": 0.125,
@@ -1798,13 +1393,11 @@ OBJECTS_MOVEABLE = [{
     "type": "block_blank_wood_cylinder",
     "obstruct": "vision",
     "info": ["small", "blank block", "cylinder"],
-    "choose": [{
-        "mass": 5,
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
         "novel_combination": True,
-        "mass": 5,
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"]
     }],
@@ -1814,6 +1407,7 @@ OBJECTS_MOVEABLE = [{
         "y": 0.25,
         "z": 0.25
     },
+    "mass": 5,
     "offset": {
         "x": 0,
         "y": 0.125,
@@ -1829,7 +1423,7 @@ OBJECTS_MOVEABLE = [{
     "type": "box_2",
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
-    "choose": [{
+    "chooseSize": [{
         "info": ["small", "brown", "box"],
         "mass": 1,
         "salientMaterials": ["paper"],
@@ -1920,7 +1514,7 @@ OBJECTS_MOVEABLE = [{
     "type": "box_3",
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
-    "choose": [{
+    "chooseSize": [{
         "info": ["small", "brown", "box"],
         "mass": 1,
         "salientMaterials": ["paper"],
@@ -2013,7 +1607,7 @@ OBJECTS_MOVEABLE = [{
     "attributes": ["moveable", "receptacle", "openable"],
     "novel_color": True,
     "novel_shape": True,
-    "choose": [{
+    "chooseSize": [{
         "info": ["small", "grey", "box"],
         "mass": 1,
         "salientMaterials": ["paper"],
@@ -2105,7 +1699,7 @@ OBJECTS_MOVEABLE = [{
     "mass": 2.5,
     "salientMaterials": ["organic", "ceramic"],
     "attributes": ["moveable"],
-    "choose": [{
+    "chooseType": [{
         "type": "plant_1",
         "dimensions": {
             "x": 0.931,
@@ -2219,7 +1813,7 @@ OBJECTS_MOVEABLE = [{
     "mass": 1,
     "salientMaterials": ["organic", "ceramic"],
     "attributes": ["moveable"],
-    "choose": [{
+    "chooseType": [{
         "type": "plant_1",
         "dimensions": {
             "x": 0.931 / 0.5,
@@ -2364,7 +1958,7 @@ OBJECTS_IMMOBILE = [{
             "z": 0.41
         }
     }],
-    "open_areas": [
+    "open_areas": [{
 # Remove the top shelves for now.
 #        "id": "",
 #        "position": {
@@ -2413,7 +2007,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.25,
             "z": 0.44
         }
-    ],
+    }],
     "dimensions": {
         "x": 1.1,
         "y": 0.96,
@@ -2464,12 +2058,18 @@ OBJECTS_IMMOBILE = [{
     }
 }, {
     "type": "table_1",
-    "info": ["huge", "table"],
     "attributes": ["receptacle"],
-    "choose": [{
-        "mass": 5,
+    "chooseMaterial": [{
         "materialCategory": ["wood", "wood"],
         "salientMaterials": ["wood"],
+    }, {
+        "novel_combination": True,
+        "massMultiplier": 2,
+        "materialCategory": ["metal", "metal"],
+        "salientMaterials": ["metal"],
+    }],
+    "chooseSize": [{
+        "info": ["huge", "table"],
 # Remove for now because it's too high up.
 #        "open_areas": [{
 #            "id": "",
@@ -2489,6 +2089,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.88,
             "z": 1.63
         },
+        "mass": 5,
         "offset": {
             "x": 0.067 * 1.175,
             "y": 0.44,
@@ -2501,9 +2102,7 @@ OBJECTS_IMMOBILE = [{
             "z": 1
         }
     }, {
-        "mass": 10,
-        "materialCategory": ["wood", "wood"],
-        "salientMaterials": ["wood"],
+        "info": ["large", "table"],
 # Remove for now because it's too high up.
 #        "open_areas": [{
 #            "id": "",
@@ -2523,6 +2122,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.88,
             "z": 1.63
         },
+        "mass": 10,
         "offset": {
             "x": 0.067 * 2.35,
             "y": 0.44,
@@ -2535,133 +2135,27 @@ OBJECTS_IMMOBILE = [{
             "z": 1
         }
     }, {
+        "info": ["medium", "table"],
         "obstruct": "navigation",
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": 0.065 * 0.5875,
+                "y": 0.88 * 0.5,
+                "z": -0.07 * 0.25
+            },
+            "dimensions": {
+                "x": 0.68 * 0.5875,
+                "y": 0,
+                "z": 1.62 * 0.25
+            }
+        }],
+        "dimensions": {
+            "x": 0.69 * 0.5875,
+            "y": 0.88 * 0.5,
+            "z": 1.63 * 0.25
+        },
         "mass": 2.5,
-        "materialCategory": ["wood", "wood"],
-        "salientMaterials": ["wood"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": 0.065 * 0.5875,
-                "y": 0.88 * 0.5,
-                "z": -0.07 * 0.25
-            },
-            "dimensions": {
-                "x": 0.68 * 0.5875,
-                "y": 0,
-                "z": 1.62 * 0.25
-            }
-        }],
-        "dimensions": {
-            "x": 0.69 * 0.5875,
-            "y": 0.88 * 0.5,
-            "z": 1.63 * 0.25
-        },
-        "offset": {
-            "x": 0.067 * 0.5875,
-            "y": 0.44 * 0.5,
-            "z": -0.07 * 0.25
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 0.5875,
-            "y": 0.5,
-            "z": 0.25
-        }
-    }, {
-        "novel_combination": True,
-        "mass": 10,
-        "materialCategory": ["metal", "metal"],
-        "salientMaterials": ["metal"],
-# Remove for now because it's too high up.
-#        "open_areas": [{
-#            "id": "",
-#            "position": {
-#                "x": 0.065 * 1.175,
-#                "y": 0.88,
-#                "z": -0.07
-#            },
-#            "dimensions": {
-#                "x": 0.68 * 1.175,
-#                "y": 0,
-#                "z": 1.62
-#            }
-#        }],
-        "dimensions": {
-            "x": 0.69 * 1.175,
-            "y": 0.88,
-            "z": 1.63
-        },
-        "offset": {
-            "x": 0.067 * 1.175,
-            "y": 0.44,
-            "z": -0.07
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 1.175,
-            "y": 1,
-            "z": 1
-        }
-    }, {
-        "novel_combination": True,
-        "mass": 20,
-        "materialCategory": ["metal", "metal"],
-        "salientMaterials": ["metal"],
-# Remove for now because it's too high up.
-#        "open_areas": [{
-#            "id": "",
-#            "position": {
-#                "x": 0.065 * 2.35,
-#                "y": 0.88,
-#                "z": -0.07
-#            },
-#            "dimensions": {
-#                "x": 0.68 * 2.35,
-#                "y": 0,
-#                "z": 1.62
-#            }
-#        }],
-        "dimensions": {
-            "x": 0.69 * 2.35,
-            "y": 0.88,
-            "z": 1.63
-        },
-        "offset": {
-            "x": 0.067 * 2.35,
-            "y": 0.44,
-            "z": -0.07
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 2.35,
-            "y": 1,
-            "z": 1
-        }
-    }, {
-        "novel_combination": True,
-        "obstruct": "navigation",
-        "mass": 5,
-        "materialCategory": ["metal", "metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": 0.065 * 0.5875,
-                "y": 0.88 * 0.5,
-                "z": -0.07 * 0.25
-            },
-            "dimensions": {
-                "x": 0.68 * 0.5875,
-                "y": 0,
-                "z": 1.62 * 0.25
-            }
-        }],
-        "dimensions": {
-            "x": 0.69 * 0.5875,
-            "y": 0.88 * 0.5,
-            "z": 1.63 * 0.25
-        },
         "offset": {
             "x": 0.067 * 0.5875,
             "y": 0.44 * 0.5,
@@ -2677,13 +2171,19 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "table_3",
     "obstruct": "navigation",
-    "info": ["large", "table"],
     "novel_shape": True,
-    "choose": [{
-        "attributes": ["moveable", "receptacle"],
-        "mass": 2,
-        "materialCategory": ["wood"],
+    "chooseMaterial": [{
+        "materialCategory": ["wood", "wood"],
         "salientMaterials": ["wood"],
+    }, {
+        "novel_combination": True,
+        "massMultiplier": 2,
+        "materialCategory": ["metal", "metal"],
+        "salientMaterials": ["metal"],
+    }],
+    "chooseSize": [{
+        "info": ["large", "table"],
+        "attributes": ["moveable", "receptacle"],
 # Remove for now because it's too high up.
 #        "open_areas": [{
 #            "id": "",
@@ -2703,6 +2203,7 @@ OBJECTS_IMMOBILE = [{
             "y": 1.018,
             "z": 0.557
         },
+        "mass": 2,
         "offset": {
             "x": 0,
             "y": 0.509,
@@ -2715,97 +2216,27 @@ OBJECTS_IMMOBILE = [{
             "z": 1
         }
     }, {
+        "info": ["medium", "table"],
         "attributes": ["moveable", "receptacle", "stackTarget"],
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": 0,
+                "y": 0.84 * 0.5,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.4,
+                "y": 0,
+                "z": 0.4
+            }
+        }],
+        "dimensions": {
+            "x": 0.573,
+            "y": 1.018 * 0.5,
+            "z": 0.557
+        },
         "mass": 1,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": 0,
-                "y": 0.84 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.4,
-                "y": 0,
-                "z": 0.4
-            }
-        }],
-        "dimensions": {
-            "x": 0.573,
-            "y": 1.018 * 0.5,
-            "z": 0.557
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.509 * 0.5,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 1,
-            "y": 0.5,
-            "z": 1
-        }
-    }, {
-        "attributes": ["moveable", "receptacle"],
-        "mass": 4,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"],
-# Remove for now because it's too high up.
-#        "open_areas": [{
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.84,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.4,
-#                "y": 0,
-#                "z": 0.4
-#            }
-#        }],
-        "dimensions": {
-            "x": 0.573,
-            "y": 1.018,
-            "z": 0.557
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.509,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
-        }
-    }, {
-        "attributes": ["moveable", "receptacle", "stackTarget"],
-        "mass": 2,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": 0,
-                "y": 0.84 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.4,
-                "y": 0,
-                "z": 0.4
-            }
-        }],
-        "dimensions": {
-            "x": 0.573,
-            "y": 1.018 * 0.5,
-            "z": 0.557
-        },
         "offset": {
             "x": 0,
             "y": 0.509 * 0.5,
@@ -2821,12 +2252,18 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "table_5",
     "obstruct": "navigation",
-    "info": ["huge", "table"],
-    "choose": [{
-        "attributes": ["receptacle"],
-        "mass": 20,
+    "chooseMaterial": [{
         "materialCategory": ["wood", "wood"],
         "salientMaterials": ["wood"],
+    }, {
+        "novel_combination": True,
+        "massMultiplier": 2,
+        "materialCategory": ["metal", "metal"],
+        "salientMaterials": ["metal"],
+    }],
+    "chooseSize": [{
+        "attributes": ["receptacle"],
+        "info": ["large", "table"],
 # Remove for now because it's too high up.
 #        "open_areas": [{
 #            "id": "",
@@ -2846,6 +2283,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.7,
             "z": 0.9 * 0.667
         },
+        "mass": 10,
         "offset": {
             "x": -0.18 * 0.5,
             "y": 0.35,
@@ -2859,9 +2297,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "attributes": ["receptacle", "stackTarget"],
-        "mass": 10,
-        "materialCategory": ["wood", "wood"],
-        "salientMaterials": ["wood"],
+        "info": ["huge", "table"],
 # Remove for now because it's too high up.
 #        "open_areas": [{
 #            "id": "",
@@ -2881,6 +2317,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.7,
             "z": 0.9 * 0.667
         },
+        "mass": 20,
         "offset": {
             "x": -0.18,
             "y": 0.35,
@@ -2894,129 +2331,21 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "attributes": ["receptacle", "stackTarget"],
+        "info": ["large", "table"],
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": -0.18,
+                "y": 0.7 * 0.5,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 1.2,
+                "y": 0,
+                "z": 0.9 * 0.667
+            }
+        }],
         "mass": 10,
-        "materialCategory": ["wood", "wood"],
-        "salientMaterials": ["wood"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": -0.18,
-                "y": 0.7 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 1.2,
-                "y": 0,
-                "z": 0.9 * 0.667
-            }
-        }],
-        "dimensions": {
-            "x": 1.2,
-            "y": 0.7 * 0.5,
-            "z": 0.9 * 0.667
-        },
-        "offset": {
-            "x": -0.18,
-            "y": 0.35 * 0.5,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 1,
-            "y": 0.5,
-            "z": 0.667
-        }
-    }, {
-        "novel_combination": True,
-        "attributes": ["receptacle"],
-        "mass": 40,
-        "materialCategory": ["metal", "metal"],
-        "salientMaterials": ["metal"],
-# Remove for now because it's too high up.
-#        "open_areas": [{
-#            "id": "",
-#            "position": {
-#                "x": -0.18 * 0.5,
-#                "y": 0.7,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 1.2 * 0.5,
-#                "y": 0,
-#                "z": 0.9 * 0.667
-#            }
-#        }],
-        "dimensions": {
-            "x": 1.2 * 0.5,
-            "y": 0.7,
-            "z": 0.9 * 0.667
-        },
-        "offset": {
-            "x": -0.18 * 0.5,
-            "y": 0.35,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 0.5,
-            "y": 1,
-            "z": 0.667
-        }
-    }, {
-        "novel_combination": True,
-        "attributes": ["receptacle", "stackTarget"],
-        "mass": 20,
-        "materialCategory": ["metal", "metal"],
-        "salientMaterials": ["metal"],
-# Remove for now because it's too high up.
-#        "open_areas": [{
-#            "id": "",
-#            "position": {
-#                "x": -0.18,
-#                "y": 0.7,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 1.2,
-#                "y": 0,
-#                "z": 0.9 * 0.667
-#            }
-#        }],
-        "dimensions": {
-            "x": 1.2,
-            "y": 0.7,
-            "z": 0.9 * 0.667
-        },
-        "offset": {
-            "x": -0.18,
-            "y": 0.35,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 0.667
-        }
-    }, {
-        "novel_combination": True,
-        "attributes": ["receptacle", "stackTarget"],
-        "mass": 20,
-        "materialCategory": ["metal", "metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": -0.18,
-                "y": 0.7 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 1.2,
-                "y": 0,
-                "z": 0.9 * 0.667
-            }
-        }],
         "dimensions": {
             "x": 1.2,
             "y": 0.7 * 0.5,
@@ -3037,54 +2366,61 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "shelf_2",
     "obstruct": "navigation",
-    "choose": [{
+    "chooseMaterial": [{
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"],
+    }, {
+        "novel_combination": True,
+        "massMultiplier": 2,
+        "materialCategory": ["metal"],
+        "salientMaterials": ["metal"],
+    }],
+    "chooseSize": [{
         "info": ["small", "shelf"],
         "attributes": ["receptacle", "stackTarget"],
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": 0,
+                "y": 0.73,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.92 * 0.5,
+                "y": 0,
+                "z": 1.01 * 0.5
+            }
+        }, {
+            "id": "_middle_shelf",
+            "position": {
+                "x": 0,
+                "y": 0.52,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.65 * 0.5,
+                "y": 0.22,
+                "z": 0.87 * 0.5
+            }
+        }, {
+            "id": "_lower_shelf",
+            "position": {
+                "x": 0,
+                "y": 0.225,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.8 * 0.5,
+                "y": 0.235,
+                "z": 0.95 * 0.5
+            }
+        }],
+        "dimensions": {
+            "x": 0.93 * 0.5,
+            "y": 0.73,
+            "z": 1.02 * 0.5
+        },
         "mass": 5,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": 0,
-                "y": 0.73,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.92 * 0.5,
-                "y": 0,
-                "z": 1.01 * 0.5
-            }
-        }, {
-            "id": "_middle_shelf",
-            "position": {
-                "x": 0,
-                "y": 0.52,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.65 * 0.5,
-                "y": 0.22,
-                "z": 0.87 * 0.5
-            }
-        }, {
-            "id": "_lower_shelf",
-            "position": {
-                "x": 0,
-                "y": 0.225,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.8 * 0.5,
-                "y": 0.235,
-                "z": 0.95 * 0.5
-            }
-        }],
-        "dimensions": {
-            "x": 0.93 * 0.5,
-            "y": 0.73,
-            "z": 1.02 * 0.5
-        },
         "offset": {
             "x": 0,
             "y": 0.355,
@@ -3099,9 +2435,6 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["medium", "shelf"],
         "attributes": ["receptacle"],
-        "mass": 10,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
         "open_areas": [{
 # Remove for now because it's too high up.
 #            "id": "",
@@ -3145,6 +2478,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.73 * 1.5,
             "z": 1.02 * 0.5
         },
+        "mass": 10,
         "offset": {
             "x": 0,
             "y": 0.355 * 1.5,
@@ -3159,234 +2493,50 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["huge", "shelf"],
         "attributes": ["receptacle"],
+        "open_areas": [{
+# Remove for now because it's too high up.
+#            "id": "",
+#            "position": {
+#                "x": 0,
+#                "y": 0.73 * 3,
+#                "z": 0
+#            },
+#            "dimensions": {
+#                "x": 0.92 * 3,
+#                "y": 0,
+#                "z": 1.01 * 0.5
+#            }
+#        }, {
+#            "id": "_middle_shelf",
+#            "position": {
+#                "x": 0,
+#                "y": 0.52 * 3,
+#                "z": 0
+#            },
+#            "dimensions": {
+#                "x": 0.65 * 3,
+#                "y": 0.22 * 3,
+#                "z": 0.87 * 0.5
+#            }
+#        }, {
+            "id": "_lower_shelf",
+            "position": {
+                "x": 0,
+                "y": 0.225 * 3,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.8 * 3,
+                "y": 0.235 * 3,
+                "z": 0.95 * 0.5
+            }
+        }],
+        "dimensions": {
+            "x": 0.93 * 3,
+            "y": 0.73 * 3,
+            "z": 1.02 * 0.5
+        },
         "mass": 15,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "open_areas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.73 * 3,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.92 * 3,
-#                "y": 0,
-#                "z": 1.01 * 0.5
-#            }
-#        }, {
-#            "id": "_middle_shelf",
-#            "position": {
-#                "x": 0,
-#                "y": 0.52 * 3,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.65 * 3,
-#                "y": 0.22 * 3,
-#                "z": 0.87 * 0.5
-#            }
-#        }, {
-            "id": "_lower_shelf",
-            "position": {
-                "x": 0,
-                "y": 0.225 * 3,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.8 * 3,
-                "y": 0.235 * 3,
-                "z": 0.95 * 0.5
-            }
-        }],
-        "dimensions": {
-            "x": 0.93 * 3,
-            "y": 0.73 * 3,
-            "z": 1.02 * 0.5
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.355 * 3,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 3,
-            "y": 3,
-            "z": 0.5
-        }
-    }, {
-        "novel_combination": True,
-        "info": ["small", "shelf"],
-        "attributes": ["receptacle", "stackTarget"],
-        "mass": 10,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": 0,
-                "y": 0.73,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.92 * 0.5,
-                "y": 0,
-                "z": 1.01 * 0.5
-            }
-        }, {
-            "id": "_middle_shelf",
-            "position": {
-                "x": 0,
-                "y": 0.52,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.65 * 0.5,
-                "y": 0.22,
-                "z": 0.87 * 0.5
-            }
-        }, {
-            "id": "_lower_shelf",
-            "position": {
-                "x": 0,
-                "y": 0.225,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.8 * 0.5,
-                "y": 0.235,
-                "z": 0.95 * 0.5
-            }
-        }],
-        "dimensions": {
-            "x": 0.93 * 0.5,
-            "y": 0.73,
-            "z": 1.02 * 0.5
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.355,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 0.5,
-            "y": 1,
-            "z": 0.5
-        }
-    }, {
-        "novel_combination": True,
-        "info": ["medium", "shelf"],
-        "attributes": ["receptacle"],
-        "mass": 20,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.73 * 1.5,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.92 * 1.5,
-#                "y": 0,
-#                "z": 1.01 * 0.5
-#            }
-#        }, {
-            "id": "_middle_shelf",
-            "position": {
-                "x": 0,
-                "y": 0.52 * 1.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.65 * 1.5,
-                "y": 0.22 * 1.5,
-                "z": 0.87 * 0.5
-            }
-        }, {
-            "id": "_lower_shelf",
-            "position": {
-                "x": 0,
-                "y": 0.225 * 1.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.8 * 1.5,
-                "y": 0.235 * 1.5,
-                "z": 0.95 * 0.5
-            }
-        }],
-        "dimensions": {
-            "x": 0.93 * 1.5,
-            "y": 0.73 * 1.5,
-            "z": 1.02 * 0.5
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.355 * 1.5,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 1.5,
-            "y": 1.5,
-            "z": 0.5
-        }
-    }, {
-        "novel_combination": True,
-        "info": ["huge", "shelf"],
-        "attributes": ["receptacle"],
-        "mass": 30,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.73 * 3,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.92 * 3,
-#                "y": 0,
-#                "z": 1.01 * 0.5
-#            }
-#        }, {
-#            "id": "_middle_shelf",
-#            "position": {
-#                "x": 0,
-#                "y": 0.52 * 3,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.65 * 3,
-#                "y": 0.22 * 3,
-#                "z": 0.87 * 0.5
-#            }
-#        }, {
-            "id": "_lower_shelf",
-            "position": {
-                "x": 0,
-                "y": 0.225 * 3,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.8 * 3,
-                "y": 0.235 * 3,
-                "z": 0.95 * 0.5
-            }
-        }],
-        "dimensions": {
-            "x": 0.93 * 3,
-            "y": 0.73 * 3,
-            "z": 1.02 * 0.5
-        },
         "offset": {
             "x": 0,
             "y": 0.355 * 3,
@@ -3401,78 +2551,85 @@ OBJECTS_IMMOBILE = [{
     }]
 }, {
     "type": "shelf_1",
-    "choose": [{
+    "chooseMaterial": [{
+        "materialCategory": ["wood"],
+        "salientMaterials": ["wood"],
+    }, {
+        "novel_combination": True,
+        "massMultiplier": 2,
+        "materialCategory": ["metal"],
+        "salientMaterials": ["metal"],
+    }],
+    "chooseSize": [{
         "info": ["small", "shelf"],
         "attributes": ["receptacle", "stackTarget"],
+        "open_areas": [{
+            "id": "",
+            "position": {
+                "x": 0,
+                "y": 0.78 * 0.5,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.77 * 0.5,
+                "y": 0,
+                "z": 0.39 * 0.5
+            }
+        }, {
+            "id": "_top_right_shelf",
+            "position": {
+                "x": 0.175 * 0.5,
+                "y": 0.56 * 0.5,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.33 * 0.5,
+                "y": 0.33 * 0.5,
+                "z": 0.38 * 0.5
+            }
+        }, {
+            "id": "_top_left_shelf",
+            "position": {
+                "x": -0.175 * 0.5,
+                "y": 0.56 * 0.5,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.33 * 0.5,
+                "y": 0.33 * 0.5,
+                "z": 0.38 * 0.5
+            }
+        }, {
+            "id": "_bottom_right_shelf",
+            "position": {
+                "x": 0.175 * 0.5,
+                "y": 0.21 * 0.5,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.33 * 0.5,
+                "y": 0.33 * 0.5,
+                "z": 0.38 * 0.5
+            }
+        }, {
+            "id": "_bottom_left_shelf",
+            "position": {
+                "x": -0.175 * 0.5,
+                "y": 0.21 * 0.5,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.33 * 0.5,
+                "y": 0.33 * 0.5,
+                "z": 0.38 * 0.5
+            }
+        }],
+        "dimensions": {
+            "x": 0.78 * 0.5,
+            "y": 0.77 * 0.5,
+            "z": 0.4 * 0.5
+        },
         "mass": 5,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": 0,
-                "y": 0.78 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.77 * 0.5,
-                "y": 0,
-                "z": 0.39 * 0.5
-            }
-        }, {
-            "id": "_top_right_shelf",
-            "position": {
-                "x": 0.175 * 0.5,
-                "y": 0.56 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 0.5,
-                "y": 0.33 * 0.5,
-                "z": 0.38 * 0.5
-            }
-        }, {
-            "id": "_top_left_shelf",
-            "position": {
-                "x": -0.175 * 0.5,
-                "y": 0.56 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 0.5,
-                "y": 0.33 * 0.5,
-                "z": 0.38 * 0.5
-            }
-        }, {
-            "id": "_bottom_right_shelf",
-            "position": {
-                "x": 0.175 * 0.5,
-                "y": 0.21 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 0.5,
-                "y": 0.33 * 0.5,
-                "z": 0.38 * 0.5
-            }
-        }, {
-            "id": "_bottom_left_shelf",
-            "position": {
-                "x": -0.175 * 0.5,
-                "y": 0.21 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 0.5,
-                "y": 0.33 * 0.5,
-                "z": 0.38 * 0.5
-            }
-        }],
-        "dimensions": {
-            "x": 0.78 * 0.5,
-            "y": 0.77 * 0.5,
-            "z": 0.4 * 0.5
-        },
         "offset": {
             "x": 0,
             "y": 0.385 * 0.5,
@@ -3487,9 +2644,6 @@ OBJECTS_IMMOBILE = [{
     }, {
         "info": ["medium", "shelf"],
         "attributes": ["receptacle"],
-        "mass": 10,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
         "open_areas": [{
 # Remove for now because it's too high up.
 #            "id": "",
@@ -3557,6 +2711,7 @@ OBJECTS_IMMOBILE = [{
             "y": 0.77,
             "z": 0.4
         },
+        "mass": 10,
         "offset": {
             "x": 0,
             "y": 0.385,
@@ -3572,329 +2727,74 @@ OBJECTS_IMMOBILE = [{
         "novel_combination": True,
         "info": ["huge", "shelf"],
         "attributes": ["receptacle"],
+        "open_areas": [{
+# Remove for now because it's too high up.
+#            "id": "",
+#            "position": {
+#                "x": 0,
+#                "y": 0.78 * 2,
+#                "z": 0
+#            },
+#            "dimensions": {
+#                "x": 0.77 * 2,
+#                "y": 0,
+#                "z": 0.39 * 2
+#            }
+#        }, {
+#            "id": "_top_right_shelf",
+#            "position": {
+#                "x": 0.175 * 2,
+#                "y": 0.56 * 2,
+#                "z": 0
+#            },
+#            "dimensions": {
+#                "x": 0.33 * 2,
+#                "y": 0.33 * 2,
+#                "z": 0.38 * 2
+#            }
+#        }, {
+#            "id": "_top_left_shelf",
+#            "position": {
+#                "x": -0.175 * 2,
+#                "y": 0.56 * 2,
+#                "z": 0
+#            },
+#            "dimensions": {
+#                "x": 0.33 * 2,
+#                "y": 0.33 * 2,
+#                "z": 0.38 * 2
+#            }
+#        }, {
+            "id": "_bottom_right_shelf",
+            "position": {
+                "x": 0.175 * 2,
+                "y": 0.21 * 2,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.33 * 2,
+                "y": 0.33 * 2,
+                "z": 0.38 * 2
+            }
+        }, {
+            "id": "_bottom_left_shelf",
+            "position": {
+                "x": -0.175 * 2,
+                "y": 0.21 * 2,
+                "z": 0
+            },
+            "dimensions": {
+                "x": 0.33 * 2,
+                "y": 0.33 * 2,
+                "z": 0.38 * 2
+            }
+        }],
+        "dimensions": {
+            "x": 0.78 * 2,
+            "y": 0.77 * 2,
+            "z": 0.4 * 2
+        },
         "mass": 15,
-        "materialCategory": ["wood"],
-        "salientMaterials": ["wood"],
-        "open_areas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.78 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.77 * 2,
-#                "y": 0,
-#                "z": 0.39 * 2
-#            }
-#        }, {
-#            "id": "_top_right_shelf",
-#            "position": {
-#                "x": 0.175 * 2,
-#                "y": 0.56 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.33 * 2,
-#                "y": 0.33 * 2,
-#                "z": 0.38 * 2
-#            }
-#        }, {
-#            "id": "_top_left_shelf",
-#            "position": {
-#                "x": -0.175 * 2,
-#                "y": 0.56 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.33 * 2,
-#                "y": 0.33 * 2,
-#                "z": 0.38 * 2
-#            }
-#        }, {
-            "id": "_bottom_right_shelf",
-            "position": {
-                "x": 0.175 * 2,
-                "y": 0.21 * 2,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 2,
-                "y": 0.33 * 2,
-                "z": 0.38 * 2
-            }
-        }, {
-            "id": "_bottom_left_shelf",
-            "position": {
-                "x": -0.175 * 2,
-                "y": 0.21 * 2,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 2,
-                "y": 0.33 * 2,
-                "z": 0.38 * 2
-            }
-        }],
-        "dimensions": {
-            "x": 0.78 * 2,
-            "y": 0.77 * 2,
-            "z": 0.4 * 2
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.385 * 2,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 2,
-            "y": 2,
-            "z": 2
-        }
-    }, {
-        "novel_combination": True,
-        "info": ["small", "shelf"],
-        "attributes": ["receptacle", "stackTarget"],
-        "mass": 10,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-            "id": "",
-            "position": {
-                "x": 0,
-                "y": 0.78 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.77 * 0.5,
-                "y": 0,
-                "z": 0.39 * 0.5
-            }
-        }, {
-            "id": "_top_right_shelf",
-            "position": {
-                "x": 0.175 * 0.5,
-                "y": 0.56 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 0.5,
-                "y": 0.33 * 0.5,
-                "z": 0.38 * 0.5
-            }
-        }, {
-            "id": "_top_left_shelf",
-            "position": {
-                "x": -0.175 * 0.5,
-                "y": 0.56 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 0.5,
-                "y": 0.33 * 0.5,
-                "z": 0.38 * 0.5
-            }
-        }, {
-            "id": "_bottom_right_shelf",
-            "position": {
-                "x": 0.175 * 0.5,
-                "y": 0.21 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 0.5,
-                "y": 0.33 * 0.5,
-                "z": 0.38 * 0.5
-            }
-        }, {
-            "id": "_bottom_left_shelf",
-            "position": {
-                "x": -0.175 * 0.5,
-                "y": 0.21 * 0.5,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 0.5,
-                "y": 0.33 * 0.5,
-                "z": 0.38 * 0.5
-            }
-        }],
-        "dimensions": {
-            "x": 0.78 * 0.5,
-            "y": 0.77 * 0.5,
-            "z": 0.4 * 0.5
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.385 * 0.5,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 0.5,
-            "y": 0.5,
-            "z": 0.5
-        }
-    }, {
-        "novel_combination": True,
-        "info": ["medium", "shelf"],
-        "attributes": ["receptacle"],
-        "mass": 20,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.78,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.77,
-#                "y": 0,
-#                "z": 0.39
-#            }
-#        }, {
-            "id": "_top_right_shelf",
-            "position": {
-                "x": 0.175,
-                "y": 0.56,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33,
-                "y": 0.33,
-                "z": 0.38
-            }
-        }, {
-            "id": "_top_left_shelf",
-            "position": {
-                "x": -0.175,
-                "y": 0.56,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33,
-                "y": 0.33,
-                "z": 0.38
-            }
-        }, {
-            "id": "_bottom_right_shelf",
-            "position": {
-                "x": 0.175,
-                "y": 0.21,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33,
-                "y": 0.33,
-                "z": 0.38
-            }
-        }, {
-            "id": "_bottom_left_shelf",
-            "position": {
-                "x": -0.175,
-                "y": 0.21,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33,
-                "y": 0.33,
-                "z": 0.38
-            }
-        }],
-        "dimensions": {
-            "x": 0.78,
-            "y": 0.77,
-            "z": 0.4
-        },
-        "offset": {
-            "x": 0,
-            "y": 0.385,
-            "z": 0
-        },
-        "position_y": 0,
-        "scale": {
-            "x": 1,
-            "y": 1,
-            "z": 1
-        }
-    }, {
-        "info": ["huge", "shelf"],
-        "attributes": ["receptacle"],
-        "mass": 30,
-        "materialCategory": ["metal"],
-        "salientMaterials": ["metal"],
-        "open_areas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.78 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.77 * 2,
-#                "y": 0,
-#                "z": 0.39 * 2
-#            }
-#        }, {
-#            "id": "_top_right_shelf",
-#            "position": {
-#                "x": 0.175 * 2,
-#                "y": 0.56 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.33 * 2,
-#                "y": 0.33 * 2,
-#                "z": 0.38 * 2
-#            }
-#        }, {
-#            "id": "_top_left_shelf",
-#            "position": {
-#                "x": -0.175 * 2,
-#                "y": 0.56 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.33 * 2,
-#                "y": 0.33 * 2,
-#                "z": 0.38 * 2
-#            }
-#        }, {
-            "id": "_bottom_right_shelf",
-            "position": {
-                "x": 0.175 * 2,
-                "y": 0.21 * 2,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 2,
-                "y": 0.33 * 2,
-                "z": 0.38 * 2
-            }
-        }, {
-            "id": "_bottom_left_shelf",
-            "position": {
-                "x": -0.175 * 2,
-                "y": 0.21 * 2,
-                "z": 0
-            },
-            "dimensions": {
-                "x": 0.33 * 2,
-                "y": 0.33 * 2,
-                "z": 0.38 * 2
-            }
-        }],
-        "dimensions": {
-            "x": 0.78 * 2,
-            "y": 0.77 * 2,
-            "z": 0.4 * 2
-        },
         "offset": {
             "x": 0,
             "y": 0.385 * 2,
@@ -3986,7 +2886,7 @@ OBJECTS_IMMOBILE = [{
     "open_areas": [{
         "id": "",
         "position": {
-            "x": -0.03
+            "x": -0.03,
             "y": 0.62,
             "z": 0
         },
@@ -4021,7 +2921,7 @@ OBJECTS_IMMOBILE = [{
     "open_areas": [{
         "id": "",
         "position": {
-            "x": 0.005
+            "x": 0.005,
             "y": 0.59,
             "z": 0.125
         },
@@ -4173,7 +3073,7 @@ OBJECTS_IMMOBILE = [{
     "mass": 5,
     "salientMaterials": ["organic", "ceramic"],
     "attributes": [],
-    "choose": [{
+    "chooseType": [{
         "type": "plant_1",
         "dimensions": {
             "x": 0.931 * 2,
@@ -4538,7 +3438,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "sphere",
     "info": ["medium", "ball"],
     "mass": 0.75,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -4735,7 +3635,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "sphere",
     "info": ["small", "ball"],
     "mass": 0.5,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -4931,7 +3831,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "sphere",
     "info": ["tiny", "ball"],
     "mass": 0.25,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -5125,7 +4025,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "cube",
     "info": ["medium", "cube"],
     "mass": 0.75,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -5338,7 +4238,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "cube",
     "info": ["small", "cube"],
     "mass": 0.5,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -5549,7 +4449,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "cube",
     "info": ["tiny", "cube"],
     "mass": 0.25,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -5758,7 +4658,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "cylinder",
     "info": ["medium", "cylinder"],
     "mass": 0.75,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -5962,7 +4862,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "cylinder",
     "info": ["small", "cylinder"],
     "mass": 0.5,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -6164,7 +5064,7 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "cylinder",
     "info": ["tiny", "cylinder"],
     "mass": 0.25,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["plastic"],
         "salientMaterials": ["plastic", "hollow"]
     }, {
@@ -6370,7 +5270,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     "attributes": ["moveable", "pickupable"],
     "info": ["tiny", "duck"],
     "mass": 2,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
@@ -6399,7 +5299,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     "attributes": ["moveable", "pickupable"],
     "info": ["small", "duck"],
     "mass": 4,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
@@ -6428,7 +5328,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     "attributes": ["moveable", "pickupable"],
     "info": ["medium", "duck"],
     "mass": 8,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
@@ -6457,7 +5357,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     "attributes": ["moveable", "pickupable"],
     "info": ["tiny", "car"],
     "mass": 2,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
@@ -6492,7 +5392,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     "attributes": ["moveable", "pickupable"],
     "info": ["small", "car"],
     "mass": 4,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
@@ -6527,7 +5427,7 @@ OBJECTS_INTPHYS_NOVEL = [{
     "attributes": ["moveable", "pickupable"],
     "info": ["medium", "car"],
     "mass": 4,
-    "choose": [{
+    "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
     }, {
@@ -6628,8 +5528,8 @@ def get_enclosed_containers() -> List[Dict[str, Any]]:
         _ENCLOSED_CONTAINERS = [
             obj_def for obj_def in all_defs
             if ('enclosed_areas' in obj_def and len(obj_def['enclosed_areas']) > 0)
-            or (('choose' in obj_def) and ('enclosed_areas' in obj_def['choose'][0])
-                and (len(obj_def['choose'][0]['enclosed_areas']) > 0))
+            or (('chooseSize' in obj_def) and ('enclosed_areas' in obj_def['chooseSize'][0])
+                and (len(obj_def['chooseSize'][0]['enclosed_areas']) > 0))
         ]
     return _ENCLOSED_CONTAINERS
 

--- a/scene_generator/objects.py
+++ b/scene_generator/objects.py
@@ -4,7 +4,7 @@ from typing import Tuple, Dict, Any, List
 
 OBJECTS_PICKUPABLE_BALLS = [{
     "type": "sphere",
-    "info": ["tiny", "ball"],
+    "shape": ["ball"],
     "attributes": ["moveable", "pickupable"],
     "chooseMaterial": [{
         "massMultiplier": 0.5,
@@ -26,6 +26,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
+        "size": "tiny",
         "dimensions": {
             "x": 0.025,
             "y": 0.025,
@@ -39,6 +40,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
             "z": 0.025
         }
     }, {
+        "size": "tiny",
         "dimensions": {
             "x": 0.05,
             "y": 0.05,
@@ -52,6 +54,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
             "z": 0.05
         }
     }, {
+        "size": "tiny",
         "dimensions": {
             "x": 0.1,
             "y": 0.1,
@@ -65,7 +68,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
             "z": 0.1
         }
     }, {
-        "info": ["small", "ball"],
+        "size": "small",
         "dimensions": {
             "x": 0.25,
             "y": 0.25,
@@ -84,7 +87,7 @@ OBJECTS_PICKUPABLE_BALLS = [{
 OBJECTS_PICKUPABLE_BLOCKS = [{
     "type": "block_blank_wood_cube",
     "obstruct": "vision",
-    "info": ["tiny", "blank block", "cube"],
+    "shape": ["blank block", "cube"],
     "attributes": ["moveable", "pickupable", "stackTarget"],
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -95,6 +98,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
+        "size": "tiny",
         "dimensions": {
             "x": 0.1,
             "y": 0.1,
@@ -113,6 +117,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "z": 1
         }
     }, {
+        "size": "tiny",
         "dimensions": {
             "x": 0.1,
             "y": 0.2,
@@ -131,6 +136,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "z": 1
         }
     }, {
+        "size": "tiny",
         "dimensions": {
             "x": 0.2,
             "y": 0.1,
@@ -152,7 +158,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
 }, {
     "type": "block_blank_wood_cylinder",
     "obstruct": "vision",
-    "info": ["tiny", "blank block", "cylinder"],
+    "shape": ["blank block", "cylinder"],
     "attributes": ["moveable", "pickupable"],
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -163,6 +169,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
+        "size": "tiny",
         "dimensions": {
             "x": 0.1,
             "y": 0.1,
@@ -181,6 +188,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "z": 1
         }
     }, {
+        "size": "tiny",
         "dimensions": {
             "x": 0.1,
             "y": 0.2,
@@ -199,6 +207,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
             "z": 1
         }
     }, {
+        "size": "tiny",
         "dimensions": {
             "x": 0.2,
             "y": 0.1,
@@ -221,7 +230,8 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
     # Readers, please ignore the "blue letter c" in the type: the object's chosen material will change this design.
     "type": "block_blue_letter_c",
     "obstruct": "vision",
-    "info": ["tiny", "letter block", "cube"],
+    "shape": ["letter block", "cube"],
+    "size": "tiny",
     "mass": 0.66,
     "materialCategory": ["block_letter"],
     "salientMaterials": ["wood"],
@@ -246,7 +256,8 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
     # Readers, please ignore the "yellow number 1" in the type: the object's chosen material will change this design.
     "type": "block_yellow_number_1",
     "obstruct": "vision",
-    "info": ["tiny", "number block", "cube"],
+    "shape": ["number block", "cube"],
+    "size": "tiny",
     "mass": 0.66,
     "materialCategory": ["block_number"],
     "salientMaterials": ["wood"],
@@ -271,6 +282,7 @@ OBJECTS_PICKUPABLE_BLOCKS = [{
 
 OBJECTS_PICKUPABLE_TOYS = [{
     "type": "duck_on_wheels",
+    "shape": ["duck"],
     "attributes": ["moveable", "pickupable"],
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -281,7 +293,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
-        "info": ["tiny", "duck"],
+        "size": "tiny",
         "dimensions": {
             "x": 0.105,
             "y": 0.085,
@@ -300,7 +312,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "z": 0.5
         }
     }, {
-        "info": ["tiny", "duck"],
+        "size": "tiny",
         "dimensions": {
             "x": 0.21,
             "y": 0.17,
@@ -319,7 +331,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "z": 1
         }
     }, {
-        "info": ["small", "duck"],
+        "size": "small",
         "dimensions": {
             "x": 0.42,
             "y": 0.34,
@@ -340,6 +352,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
     }]
 }, {
     "type": "racecar_red",
+    "shape": ["car"],
     "attributes": ["moveable", "pickupable"],
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -350,7 +363,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
-        "info": ["tiny", "car"],
+        "size": "tiny",
         "dimensions": {
             "x": 0.0525,
             "y": 0.045,
@@ -369,7 +382,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "z": 0.75
         }
     }, {
-        "info": ["tiny", "car"],
+        "size": "tiny",
         "dimensions": {
             "x": 0.105,
             "y": 0.09,
@@ -388,7 +401,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "z": 1.5
         }
     }, {
-        "info": ["small", "car"],
+        "size": "small",
         "dimensions": {
             "x": 0.21,
             "y": 0.18,
@@ -409,7 +422,8 @@ OBJECTS_PICKUPABLE_TOYS = [{
     }]
 }, {
     "type": "pacifier",
-    "info": ["tiny", "pacifier"],
+    "shape": ["pacifier"],
+    "size": "tiny",
     "color": ["blue"],
     "mass": 0.125,
     "materialCategory": [],
@@ -435,9 +449,10 @@ OBJECTS_PICKUPABLE_TOYS = [{
     "chooseMaterial": [{
         # TODO
         "type": "crayon_blue",
-        "info": ["tiny", "crayon"],
         "color": ["blue"]
     }],
+    "shape": ["crayon"],
+    "size": "tiny",
     "mass": 0.125,
     "materialCategory": [],
     "salientMaterials": ["wax"],
@@ -460,6 +475,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
     }
 }, {
     "type": "turtle_on_wheels",
+    "shape": ["turtle"],
     "attributes": ["moveable", "pickupable"],
     "novelShape": True,
     "chooseMaterial": [{
@@ -470,7 +486,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
-        "info": ["tiny", "turtle"],
+        "size": "tiny",
         "dimensions": {
             "x": 0.24 * 0.5,
             "y": 0.14 * 0.5,
@@ -489,7 +505,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "z": 0.5
         }
     }, {
-        "info": ["tiny", "turtle"],
+        "size": "tiny",
         "dimensions": {
             "x": 0.24,
             "y": 0.14,
@@ -508,7 +524,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "z": 1
         }
     }, {
-        "info": ["small", "turtle"],
+        "size": "small",
         "dimensions": {
             "x": 0.24 * 2,
             "y": 0.14 * 2,
@@ -529,6 +545,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
     }]
 }, {
     "type": "car_1",
+    "shape": ["car"],
     "attributes": ["moveable", "pickupable"],
     "novelShape": True,
     "chooseMaterial": [{
@@ -539,7 +556,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
-        "info": ["tiny", "car"],
+        "size": "tiny",
         "dimensions": {
             "x": 0.075 * 0.75,
             "y": 0.065 * 0.75,
@@ -558,7 +575,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "z": 0.75
         }
     }, {
-        "info": ["tiny", "car"],
+        "size": "tiny",
         "dimensions": {
             "x": 0.075 * 1.5,
             "y": 0.065 * 1.5,
@@ -577,7 +594,7 @@ OBJECTS_PICKUPABLE_TOYS = [{
             "z": 1.5
         }
     }, {
-        "info": ["small", "car"],
+        "size": "small",
         "dimensions": {
             "x": 0.075 * 3,
             "y": 0.065 * 3,
@@ -600,8 +617,9 @@ OBJECTS_PICKUPABLE_TOYS = [{
 
 OBJECTS_PICKUPABLE_MISC = [{
     "type": "apple_1",
-    "info": ["tiny", "apple"],
     "color": ["red"],
+    "shape": ["apple"],
+    "size": "tiny",
     "mass": 0.5,
     "materialCategory": [],
     "salientMaterials": ["food"],
@@ -624,8 +642,9 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "apple_2",
-    "info": ["tiny", "apple"],
     "color": ["green"],
+    "shape": ["apple"],
+    "size": "tiny",
     "mass": 0.5,
     "materialCategory": [],
     "salientMaterials": ["food"],
@@ -648,7 +667,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "bowl_3",
-    "info": ["tiny", "bowl"],
+    "shape": ["bowl"],
+    "size": "tiny",
     "chooseMaterial": [{
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
@@ -678,7 +698,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "bowl_4",
-    "info": ["tiny", "bowl"],
+    "shape": ["bowl"],
+    "size": "tiny",
     "chooseMaterial": [{
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
@@ -708,7 +729,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "bowl_6",
-    "info": ["tiny", "bowl"],
+    "shape": ["bowl"],
+    "size": "tiny",
     "novelShape": True,
     "chooseMaterial": [{
         "massMultiplier": 0.5,
@@ -738,7 +760,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "cup_2",
-    "info": ["tiny", "cup"],
+    "shape": ["cup"],
+    "size": "tiny",
     "chooseMaterial": [{
         "massMultiplier": 0.25,
         "materialCategory": ["plastic"],
@@ -768,7 +791,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "cup_3",
-    "info": ["tiny", "cup"],
+    "shape": ["cup"],
+    "size": "tiny",
     "novelShape": True,
     "chooseMaterial": [{
         "massMultiplier": 0.5,
@@ -798,7 +822,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "cup_6",
-    "info": ["tiny", "cup"],
+    "shape": ["cup"],
+    "size": "tiny",
     "chooseMaterial": [{
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
@@ -828,7 +853,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "plate_1",
-    "info": ["tiny", "plate"],
+    "shape": ["plate"],
+    "size": "tiny",
     "chooseMaterial": [{
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
@@ -858,7 +884,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "plate_3",
-    "info": ["tiny", "plate"],
+    "shape": ["plate"],
+    "size": "tiny",
     "chooseMaterial": [{
         "massMultiplier": 0.5,
         "materialCategory": ["plastic"],
@@ -888,7 +915,8 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "plate_4",
-    "info": ["tiny", "plate"],
+    "shape": ["plate"],
+    "size": "tiny",
     "novelShape": True,
     "chooseMaterial": [{
         "massMultiplier": 0.5,
@@ -919,8 +947,9 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_2",
     "obstruct": "vision",
-    "info": ["small", "box"],
     "color": ["brown"],
+    "shape": ["box"],
+    "size": "small",
     "mass": 0.5,
     "materialCategory": [],
     "salientMaterials": ["paper"],
@@ -967,8 +996,9 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_2",
     "obstruct": "vision",
-    "info": ["tiny", "box"],
     "color": ["brown"],
+    "shape": ["box"],
+    "size": "tiny",
     "mass": 0.25,
     "materialCategory": [],
     "salientMaterials": ["paper"],
@@ -1015,8 +1045,9 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_3",
     "obstruct": "vision",
-    "info": ["small", "box"],
     "color": ["brown"],
+    "shape": ["box"],
+    "size": "small",
     "mass": 0.5,
     "materialCategory": [],
     "salientMaterials": ["paper"],
@@ -1063,8 +1094,9 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_3",
     "obstruct": "vision",
-    "info": ["tiny", "box"],
     "color": ["brown"],
+    "shape": ["box"],
+    "size": "tiny",
     "mass": 0.25,
     "materialCategory": [],
     "salientMaterials": ["paper"],
@@ -1111,8 +1143,9 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_4",
     "obstruct": "vision",
-    "info": ["small", "box"],
     "color": ["grey"],
+    "shape": ["box"],
+    "size": "small",
     "mass": 0.5,
     "materialCategory": [],
     "novelColor": True,
@@ -1161,8 +1194,9 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_4",
     "obstruct": "vision",
-    "info": ["tiny", "box"],
     "color": ["grey"],
+    "shape": ["box"],
+    "size": "tiny",
     "mass": 0.25,
     "materialCategory": [],
     "novelColor": True,
@@ -1216,7 +1250,7 @@ OBJECTS_PICKUPABLE = [item for sublist in OBJECTS_PICKUPABLE_LISTS for item in s
 
 OBJECTS_MOVEABLE = [{
     "type": "chair_1",
-    "info": ["medium", "chair"],
+    "shape": ["chair"],
     "attributes": ["moveable", "receptacle", "stackTarget"],
     "chooseMaterial": [{
         "materialCategory": ["wood"],
@@ -1233,6 +1267,7 @@ OBJECTS_MOVEABLE = [{
         "salientMaterials": ["metal"]
     }],
     "chooseSize": [{
+        "size": "medium",
         "openAreas": [{
             "id": "",
             "position": {
@@ -1264,7 +1299,7 @@ OBJECTS_MOVEABLE = [{
             "z": 1
         }
     }, {
-        "info": ["small", "chair"],
+        "size": "small",
         "openAreas": [{
             "id": "",
             "position": {
@@ -1298,8 +1333,8 @@ OBJECTS_MOVEABLE = [{
     }]
 }, {
     "type": "chair_2",
+    "shape": ["stool"],
     "obstruct": "navigation",
-    "info": ["medium", "stool"],
     "attributes": ["moveable", "receptacle", "stackTarget"],
     "chooseMaterial": [{
         "massMultiplier": 0.5,
@@ -1316,6 +1351,7 @@ OBJECTS_MOVEABLE = [{
         "salientMaterials": ["wood"]
     }],
     "chooseSize": [{
+        "size": "medium",
         "openAreas": [{
             "id": "",
             "position": {
@@ -1347,7 +1383,7 @@ OBJECTS_MOVEABLE = [{
             "z": 1
         }
     }, {
-        "info": ["small", "stool"],
+        "size": "small",
         "openAreas": [{
             "id": "",
             "position": {
@@ -1382,7 +1418,8 @@ OBJECTS_MOVEABLE = [{
 }, {
     "type": "block_blank_wood_cube",
     "obstruct": "vision",
-    "info": ["small", "blank block", "cube"],
+    "shape": ["blank block", "cube"],
+    "size": "small",
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
@@ -1412,7 +1449,8 @@ OBJECTS_MOVEABLE = [{
 }, {
     "type": "block_blank_wood_cylinder",
     "obstruct": "vision",
-    "info": ["small", "blank block", "cylinder"],
+    "shape": ["blank block", "cylinder"],
+    "size": "small",
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
         "salientMaterials": ["wood"]
@@ -1442,12 +1480,13 @@ OBJECTS_MOVEABLE = [{
 }, {
     "type": "box_2",
     "color": ["brown"],
+    "shape": ["box"],
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
     "materialCategory": [],
     "salientMaterials": ["paper"],
     "chooseSize": [{
-        "info": ["small", "box"],
+        "size": "small",
         "mass": 1,
         "enclosedAreas": [{
             "id": "",
@@ -1489,7 +1528,7 @@ OBJECTS_MOVEABLE = [{
             "z": 1.25
         }
     }, {
-        "info": ["medium", "box"],
+        "size": "medium",
         "mass": 3,
         "enclosedAreas": [{
             "id": "",
@@ -1534,12 +1573,13 @@ OBJECTS_MOVEABLE = [{
 }, {
     "type": "box_3",
     "color": ["brown"],
+    "shape": ["box"],
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
     "materialCategory": [],
     "salientMaterials": ["paper"],
     "chooseSize": [{
-        "info": ["small", "box"],
+        "size": "small",
         "mass": 1,
         "enclosedAreas": [{
             "id": "",
@@ -1581,7 +1621,7 @@ OBJECTS_MOVEABLE = [{
             "z": 1
         }
     }, {
-        "info": ["medium", "box"],
+        "size": "medium",
         "mass": 3,
         "enclosedAreas": [{
             "id": "",
@@ -1626,6 +1666,7 @@ OBJECTS_MOVEABLE = [{
 }, {
     "type": "box_4",
     "color": ["grey"],
+    "shape": ["box"],
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
     "materialCategory": [],
@@ -1633,7 +1674,7 @@ OBJECTS_MOVEABLE = [{
     "novelColor": True,
     "novelShape": True,
     "chooseSize": [{
-        "info": ["small", "box"],
+        "size": "small",
         "mass": 1,
         "enclosedAreas": [{
             "id": "",
@@ -1675,7 +1716,7 @@ OBJECTS_MOVEABLE = [{
             "z": 1
         }
     }, {
-        "info": ["tiny", "box"],
+        "size": "medium",
         "mass": 0.25,
         "enclosedAreas": [{
             "id": "",
@@ -1718,7 +1759,8 @@ OBJECTS_MOVEABLE = [{
         }
     }]
 }, {
-    "info": ["medium", "potted plant"],
+    "shape": ["potted plant"],
+    "size": "medium",
     "mass": 2.5,
     "materialCategory": [],
     "salientMaterials": ["organic", "ceramic"],
@@ -1839,7 +1881,8 @@ OBJECTS_MOVEABLE = [{
         }
     }]
 }, {
-    "info": ["small", "potted plant"],
+    "shape": ["potted plant"],
+    "size": "small",
     "mass": 1,
     "materialCategory": [],
     "salientMaterials": ["organic", "ceramic"],
@@ -1964,7 +2007,8 @@ OBJECTS_MOVEABLE = [{
 OBJECTS_IMMOBILE = [{
     "type": "changing_table",
     "obstruct": "vision",
-    "info": ["huge", "changing table"],
+    "shape": ["changing table"],
+    "size": "huge",
     "mass": 100,
     "materialCategory": ["wood"],
     "salientMaterials": ["wood"],
@@ -2073,7 +2117,8 @@ OBJECTS_IMMOBILE = [{
     }
 }, {
     "type": "crib",
-    "info": ["huge", "crib"],
+    "shape": ["crib"],
+    "size": "huge",
     "materialCategory": ["wood"],
     "salientMaterials": ["wood"],
     "mass": 25,
@@ -2096,6 +2141,7 @@ OBJECTS_IMMOBILE = [{
     }
 }, {
     "type": "table_1",
+    "shape": ["table"],
     "attributes": ["receptacle"],
     "chooseMaterial": [{
         "materialCategory": ["wood", "wood"],
@@ -2107,7 +2153,7 @@ OBJECTS_IMMOBILE = [{
         "salientMaterials": ["metal"],
     }],
     "chooseSize": [{
-        "info": ["huge", "table"],
+        "size": "huge",
 # Remove for now because it's too high up.
 #        "openAreas": [{
 #            "id": "",
@@ -2140,7 +2186,7 @@ OBJECTS_IMMOBILE = [{
             "z": 1
         }
     }, {
-        "info": ["large", "table"],
+        "size": "large",
 # Remove for now because it's too high up.
 #        "openAreas": [{
 #            "id": "",
@@ -2173,7 +2219,7 @@ OBJECTS_IMMOBILE = [{
             "z": 1
         }
     }, {
-        "info": ["medium", "table"],
+        "size": "medium",
         "obstruct": "navigation",
         "openAreas": [{
             "id": "",
@@ -2208,6 +2254,7 @@ OBJECTS_IMMOBILE = [{
     }]
 }, {
     "type": "table_3",
+    "shape": ["table"],
     "obstruct": "navigation",
     "novelShape": True,
     "chooseMaterial": [{
@@ -2220,7 +2267,7 @@ OBJECTS_IMMOBILE = [{
         "salientMaterials": ["metal"],
     }],
     "chooseSize": [{
-        "info": ["large", "table"],
+        "size": "large",
         "attributes": ["moveable", "receptacle"],
 # Remove for now because it's too high up.
 #        "openAreas": [{
@@ -2254,7 +2301,7 @@ OBJECTS_IMMOBILE = [{
             "z": 1
         }
     }, {
-        "info": ["medium", "table"],
+        "size": "medium",
         "attributes": ["moveable", "receptacle", "stackTarget"],
         "openAreas": [{
             "id": "",
@@ -2289,6 +2336,7 @@ OBJECTS_IMMOBILE = [{
     }]
 }, {
     "type": "table_5",
+    "shape": ["table"],
     "obstruct": "navigation",
     "chooseMaterial": [{
         "materialCategory": ["wood", "wood"],
@@ -2301,7 +2349,7 @@ OBJECTS_IMMOBILE = [{
     }],
     "chooseSize": [{
         "attributes": ["receptacle"],
-        "info": ["large", "table"],
+        "size": "large",
 # Remove for now because it's too high up.
 #        "openAreas": [{
 #            "id": "",
@@ -2335,7 +2383,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "attributes": ["receptacle", "stackTarget"],
-        "info": ["huge", "table"],
+        "size": "huge",
 # Remove for now because it's too high up.
 #        "openAreas": [{
 #            "id": "",
@@ -2369,7 +2417,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "attributes": ["receptacle", "stackTarget"],
-        "info": ["large", "table"],
+        "size": "large",
         "openAreas": [{
             "id": "",
             "position": {
@@ -2403,6 +2451,7 @@ OBJECTS_IMMOBILE = [{
     }]
 }, {
     "type": "shelf_2",
+    "shape": ["shelf"],
     "obstruct": "navigation",
     "chooseMaterial": [{
         "materialCategory": ["wood"],
@@ -2414,7 +2463,7 @@ OBJECTS_IMMOBILE = [{
         "salientMaterials": ["metal"],
     }],
     "chooseSize": [{
-        "info": ["small", "shelf"],
+        "size": "small",
         "attributes": ["receptacle", "stackTarget"],
         "openAreas": [{
             "id": "",
@@ -2471,7 +2520,7 @@ OBJECTS_IMMOBILE = [{
             "z": 0.5
         }
     }, {
-        "info": ["medium", "shelf"],
+        "size": "medium",
         "attributes": ["receptacle"],
         "openAreas": [{
 # Remove for now because it's too high up.
@@ -2529,7 +2578,7 @@ OBJECTS_IMMOBILE = [{
             "z": 0.5
         }
     }, {
-        "info": ["huge", "shelf"],
+        "size": "huge",
         "attributes": ["receptacle"],
         "openAreas": [{
 # Remove for now because it's too high up.
@@ -2589,6 +2638,7 @@ OBJECTS_IMMOBILE = [{
     }]
 }, {
     "type": "shelf_1",
+    "shape": ["shelf"],
     "chooseMaterial": [{
         "materialCategory": ["wood"],
         "salientMaterials": ["wood"],
@@ -2599,7 +2649,7 @@ OBJECTS_IMMOBILE = [{
         "salientMaterials": ["metal"],
     }],
     "chooseSize": [{
-        "info": ["small", "shelf"],
+        "size": "small",
         "attributes": ["receptacle", "stackTarget"],
         "openAreas": [{
             "id": "",
@@ -2680,7 +2730,7 @@ OBJECTS_IMMOBILE = [{
             "z": 0.5
         }
     }, {
-        "info": ["medium", "shelf"],
+        "size": "medium",
         "attributes": ["receptacle"],
         "openAreas": [{
 # Remove for now because it's too high up.
@@ -2763,7 +2813,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "novelCombination": True,
-        "info": ["huge", "shelf"],
+        "size": "huge",
         "attributes": ["receptacle"],
         "openAreas": [{
 # Remove for now because it's too high up.
@@ -2848,8 +2898,9 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "sofa_1",
     "obstruct": "vision",
-    "info": ["huge", "sofa"],
     "color": ["brown"],
+    "shape": ["sofa"],
+    "size": "huge",
     "mass": 100,
     "materialCategory": [],
     "salientMaterials": ["fabric"],
@@ -2886,8 +2937,9 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "sofa_2",
     "obstruct": "vision",
-    "info": ["huge", "sofa"],
     "color": ["grey"],
+    "shape": ["sofa"],
+    "size": "huge",
     "mass": 100,
     "materialCategory": [],
     "salientMaterials": ["fabric"],
@@ -2924,8 +2976,9 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "sofa_chair_1",
     "obstruct": "vision",
-    "info": ["huge", "sofa chair"],
     "color": ["black"],
+    "shape": ["sofa chair"],
+    "size": "huge",
     "mass": 50,
     "materialCategory": [],
     "salientMaterials": ["fabric"],
@@ -2962,8 +3015,9 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "sofa_chair_2",
     "obstruct": "vision",
-    "info": ["huge", "sofa chair"],
     "color": ["grey"],
+    "shape": ["sofa chair"],
+    "size": "huge",
     "mass": 50,
     "materialCategory": [],
     "salientMaterials": ["fabric"],
@@ -3000,7 +3054,8 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "wardrobe",
     "obstruct": "vision",
-    "info": ["huge", "wardrobe"],
+    "shape": ["wardrobe"],
+    "size": "huge",
     "mass": 100,
     "materialCategory": ["wood"],
     "salientMaterials": ["wood"],
@@ -3119,7 +3174,8 @@ OBJECTS_IMMOBILE = [{
         "z": 1
     }
 }, {
-    "info": ["large", "potted plant"],
+    "shape": ["potted plant"],
+    "size": "large",
     "mass": 5,
     "materialCategory": [],
     "salientMaterials": ["organic", "ceramic"],
@@ -3244,7 +3300,8 @@ OBJECTS_IMMOBILE = [{
 
 OCCLUDER_INSTANCE_NORMAL = [{
     "id": "occluder_wall_",
-    "info": [],
+    "shape": ["wall"],
+    "size": "huge",
     "type": "cube",
     "kinematic": True,
     "structure": True,
@@ -3315,7 +3372,8 @@ OCCLUDER_INSTANCE_NORMAL = [{
     }]
 }, {
     "id": "occluder_pole_",
-    "info": [],
+    "shape": ["pole"],
+    "size": "medium",
     "type": "cylinder",
     "kinematic": True,
     "structure": True,
@@ -3364,7 +3422,8 @@ OCCLUDER_INSTANCE_NORMAL = [{
 
 OCCLUDER_INSTANCE_SIDEWAYS = [{
     "id": "occluder_wall_",
-    "info": [],
+    "shape": ["wall"],
+    "size": "huge",
     "type": "cube",
     "kinematic": True,
     "structure": True,
@@ -3435,7 +3494,8 @@ OCCLUDER_INSTANCE_SIDEWAYS = [{
     }]
 }, {
     "id": "occluder_pole_",
-    "info": [],
+    "shape": ["pole"],
+    "size": "medium",
     "type": "cylinder",
     "kinematic": True,
     "structure": True,
@@ -3489,7 +3549,8 @@ OCCLUDER_INSTANCE_SIDEWAYS = [{
 
 OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     "type": "sphere",
-    "info": ["medium", "ball"],
+    "shape": ["ball"],
+    "size": "medium",
     "mass": 0.75,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -3686,7 +3747,8 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     }]
 }, {
     "type": "sphere",
-    "info": ["small", "ball"],
+    "shape": ["ball"],
+    "size": "small",
     "mass": 0.5,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -3882,7 +3944,8 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     }]
 }, {
     "type": "sphere",
-    "info": ["tiny", "ball"],
+    "shape": ["ball"],
+    "size": "tiny",
     "mass": 0.25,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -4076,7 +4139,8 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     }]
 }, {
     "type": "cube",
-    "info": ["medium", "cube"],
+    "shape": ["cube"],
+    "size": "medium",
     "mass": 0.75,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -4289,7 +4353,8 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     }]
 }, {
     "type": "cube",
-    "info": ["small", "cube"],
+    "shape": ["cube"],
+    "size": "small",
     "mass": 0.5,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -4500,7 +4565,8 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     }]
 }, {
     "type": "cube",
-    "info": ["tiny", "cube"],
+    "shape": ["cube"],
+    "size": "tiny",
     "mass": 0.25,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -4709,7 +4775,8 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     }]
 }, {
     "type": "cylinder",
-    "info": ["medium", "cylinder"],
+    "shape": ["cylinder"],
+    "size": "medium",
     "mass": 0.75,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -4913,7 +4980,8 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     }]
 }, {
     "type": "cylinder",
-    "info": ["small", "cylinder"],
+    "shape": ["cylinder"],
+    "size": "small",
     "mass": 0.5,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -5115,7 +5183,8 @@ OBJECTS_INTPHYS: List[Dict[str, Any]] = [{
     }]
 }, {
     "type": "cylinder",
-    "info": ["tiny", "cylinder"],
+    "shape": ["cylinder"],
+    "size": "tiny",
     "mass": 0.25,
     "chooseMaterial": [{
         "materialCategory": ["plastic"],
@@ -5321,7 +5390,8 @@ OBJECTS_INTPHYS_NOVEL = [{
     "type": "duck_on_wheels",
     "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
-    "info": ["tiny", "duck"],
+    "shape": ["duck"],
+    "size": "tiny",
     "mass": 2,
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -5350,7 +5420,8 @@ OBJECTS_INTPHYS_NOVEL = [{
     "type": "duck_on_wheels",
     "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
-    "info": ["small", "duck"],
+    "shape": ["duck"],
+    "size": "small",
     "mass": 4,
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -5379,7 +5450,8 @@ OBJECTS_INTPHYS_NOVEL = [{
     "type": "duck_on_wheels",
     "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
-    "info": ["medium", "duck"],
+    "shape": ["duck"],
+    "size": "medium",
     "mass": 8,
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -5408,7 +5480,8 @@ OBJECTS_INTPHYS_NOVEL = [{
     "type": "racecar_red",
     "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
-    "info": ["tiny", "car"],
+    "shape": ["car"],
+    "size": "tiny",
     "mass": 2,
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -5443,7 +5516,8 @@ OBJECTS_INTPHYS_NOVEL = [{
     "type": "racecar_red",
     "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
-    "info": ["small", "car"],
+    "shape": ["car"],
+    "size": "small",
     "mass": 4,
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -5478,7 +5552,8 @@ OBJECTS_INTPHYS_NOVEL = [{
     "type": "racecar_red",
     "novelShape": True, # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
-    "info": ["medium", "car"],
+    "shape": ["car"],
+    "size": "medium",
     "mass": 4,
     "chooseMaterial": [{
         "materialCategory": ["block_blank"],
@@ -5531,6 +5606,10 @@ def create_occluder(wall_material: Tuple[str, List[str]], pole_material: Tuple[s
     occluder[WALL]['materials'] = [wall_material[0]]
     occluder[POLE]['materials'] = [pole_material[0]]
 
+    occluder[WALL]['color'] = wall_material[1]
+    occluder[POLE]['color'] = pole_material[1]
+
+    # Just set the occluder's info to its color for now.
     occluder[WALL]['info'] = wall_material[1]
     occluder[POLE]['info'] = pole_material[1]
 

--- a/scene_generator/objects.py
+++ b/scene_generator/objects.py
@@ -409,8 +409,10 @@ OBJECTS_PICKUPABLE_TOYS = [{
     }]
 }, {
     "type": "pacifier",
-    "info": ["tiny", "blue", "pacifier"],
+    "info": ["tiny", "pacifier"],
+    "color": ["blue"],
     "mass": 0.125,
+    "materialCategory": [],
     "salientMaterials": ["plastic"],
     "attributes": ["moveable", "pickupable"],
     "dimensions": {
@@ -433,9 +435,11 @@ OBJECTS_PICKUPABLE_TOYS = [{
     "chooseMaterial": [{
         # TODO
         "type": "crayon_blue",
-        "info": ["tiny", "blue", "crayon"]
+        "info": ["tiny", "crayon"],
+        "color": ["blue"]
     }],
     "mass": 0.125,
+    "materialCategory": [],
     "salientMaterials": ["wax"],
     "attributes": ["moveable", "pickupable"],
     "dimensions": {
@@ -596,8 +600,10 @@ OBJECTS_PICKUPABLE_TOYS = [{
 
 OBJECTS_PICKUPABLE_MISC = [{
     "type": "apple_1",
-    "info": ["tiny", "red", "apple"],
+    "info": ["tiny", "apple"],
+    "color": ["red"],
     "mass": 0.5,
+    "materialCategory": [],
     "salientMaterials": ["food"],
     "attributes": ["moveable", "pickupable"],
     "dimensions": {
@@ -618,8 +624,10 @@ OBJECTS_PICKUPABLE_MISC = [{
     }
 }, {
     "type": "apple_2",
-    "info": ["tiny", "green", "apple"],
+    "info": ["tiny", "apple"],
+    "color": ["green"],
     "mass": 0.5,
+    "materialCategory": [],
     "salientMaterials": ["food"],
     "attributes": ["moveable", "pickupable"],
     "dimensions": {
@@ -911,8 +919,10 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_2",
     "obstruct": "vision",
-    "info": ["small", "brown", "box"],
+    "info": ["small", "box"],
+    "color": ["brown"],
     "mass": 0.5,
+    "materialCategory": [],
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
     "enclosedAreas": [{
@@ -957,8 +967,10 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_2",
     "obstruct": "vision",
-    "info": ["tiny", "brown", "box"],
+    "info": ["tiny", "box"],
+    "color": ["brown"],
     "mass": 0.25,
+    "materialCategory": [],
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
     "enclosedAreas": [{
@@ -1003,8 +1015,10 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_3",
     "obstruct": "vision",
-    "info": ["small", "brown", "box"],
+    "info": ["small", "box"],
+    "color": ["brown"],
     "mass": 0.5,
+    "materialCategory": [],
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
     "enclosedAreas": [{
@@ -1049,8 +1063,10 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_3",
     "obstruct": "vision",
-    "info": ["tiny", "brown", "box"],
+    "info": ["tiny", "box"],
+    "color": ["brown"],
     "mass": 0.25,
+    "materialCategory": [],
     "salientMaterials": ["paper"],
     "attributes": ["moveable", "pickupable", "receptacle", "openable"],
     "enclosedAreas": [{
@@ -1095,8 +1111,10 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_4",
     "obstruct": "vision",
-    "info": ["small", "grey", "box"],
+    "info": ["small", "box"],
+    "color": ["grey"],
     "mass": 0.5,
+    "materialCategory": [],
     "novelColor": True,
     "novelShape": True,
     "salientMaterials": ["paper"],
@@ -1143,8 +1161,10 @@ OBJECTS_PICKUPABLE_MISC = [{
 }, {
     "type": "box_4",
     "obstruct": "vision",
-    "info": ["tiny", "grey", "box"],
+    "info": ["tiny", "box"],
+    "color": ["grey"],
     "mass": 0.25,
+    "materialCategory": [],
     "novelColor": True,
     "novelShape": True,
     "salientMaterials": ["paper"],
@@ -1421,12 +1441,14 @@ OBJECTS_MOVEABLE = [{
     }
 }, {
     "type": "box_2",
+    "color": ["brown"],
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
+    "materialCategory": [],
+    "salientMaterials": ["paper"],
     "chooseSize": [{
-        "info": ["small", "brown", "box"],
+        "info": ["small", "box"],
         "mass": 1,
-        "salientMaterials": ["paper"],
         "enclosedAreas": [{
             "id": "",
             "position": {
@@ -1467,9 +1489,8 @@ OBJECTS_MOVEABLE = [{
             "z": 1.25
         }
     }, {
-        "info": ["medium", "brown", "box"],
+        "info": ["medium", "box"],
         "mass": 3,
-        "salientMaterials": ["paper"],
         "enclosedAreas": [{
             "id": "",
             "position": {
@@ -1512,12 +1533,14 @@ OBJECTS_MOVEABLE = [{
     }]
 }, {
     "type": "box_3",
+    "color": ["brown"],
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
+    "materialCategory": [],
+    "salientMaterials": ["paper"],
     "chooseSize": [{
-        "info": ["small", "brown", "box"],
+        "info": ["small", "box"],
         "mass": 1,
-        "salientMaterials": ["paper"],
         "enclosedAreas": [{
             "id": "",
             "position": {
@@ -1558,9 +1581,8 @@ OBJECTS_MOVEABLE = [{
             "z": 1
         }
     }, {
-        "info": ["medium", "brown", "box"],
+        "info": ["medium", "box"],
         "mass": 3,
-        "salientMaterials": ["paper"],
         "enclosedAreas": [{
             "id": "",
             "position": {
@@ -1603,14 +1625,16 @@ OBJECTS_MOVEABLE = [{
     }]
 }, {
     "type": "box_4",
+    "color": ["grey"],
     "obstruct": "vision",
     "attributes": ["moveable", "receptacle", "openable"],
+    "materialCategory": [],
+    "salientMaterials": ["paper"],
     "novelColor": True,
     "novelShape": True,
     "chooseSize": [{
-        "info": ["small", "grey", "box"],
+        "info": ["small", "box"],
         "mass": 1,
-        "salientMaterials": ["paper"],
         "enclosedAreas": [{
             "id": "",
             "position": {
@@ -1651,9 +1675,8 @@ OBJECTS_MOVEABLE = [{
             "z": 1
         }
     }, {
-        "info": ["tiny", "grey", "box"],
+        "info": ["tiny", "box"],
         "mass": 0.25,
-        "salientMaterials": ["paper"],
         "enclosedAreas": [{
             "id": "",
             "position": {
@@ -1697,10 +1720,12 @@ OBJECTS_MOVEABLE = [{
 }, {
     "info": ["medium", "potted plant"],
     "mass": 2.5,
+    "materialCategory": [],
     "salientMaterials": ["organic", "ceramic"],
     "attributes": ["moveable"],
     "chooseType": [{
         "type": "plant_1",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.931,
             "y": 0.807,
@@ -1719,6 +1744,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_5",
+        "color": ["green", "grey", "brown"],
         "dimensions": {
             "x": 0.522,
             "y": 0.656,
@@ -1737,6 +1763,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_7",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.72,
             "y": 1.094,
@@ -1755,6 +1782,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_9",
+        "color": ["green", "grey", "brown"],
         "dimensions": {
             "x": 0.679,
             "y": 0.859,
@@ -1773,6 +1801,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_14",
+        "color": ["red", "brown"],
         "dimensions": {
             "x": 0.508,
             "y": 0.815,
@@ -1791,6 +1820,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_16",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.702,
             "y": 1.278,
@@ -1811,10 +1841,12 @@ OBJECTS_MOVEABLE = [{
 }, {
     "info": ["small", "potted plant"],
     "mass": 1,
+    "materialCategory": [],
     "salientMaterials": ["organic", "ceramic"],
     "attributes": ["moveable"],
     "chooseType": [{
         "type": "plant_1",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.931 / 0.5,
             "y": 0.807 / 0.5,
@@ -1833,6 +1865,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_5",
+        "color": ["green", "grey", "brown"],
         "dimensions": {
             "x": 0.522 / 0.5,
             "y": 0.656 / 0.5,
@@ -1851,6 +1884,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_7",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.72 / 0.5,
             "y": 1.094 / 0.5,
@@ -1869,6 +1903,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_9",
+        "color": ["green", "grey", "brown"],
         "dimensions": {
             "x": 0.679 / 0.5,
             "y": 0.859 / 0.5,
@@ -1887,6 +1922,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_14",
+        "color": ["red", "brown"],
         "dimensions": {
             "x": 0.508 / 0.5,
             "y": 0.815 / 0.5,
@@ -1905,6 +1941,7 @@ OBJECTS_MOVEABLE = [{
         }
     }, {
         "type": "plant_16",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.702 / 0.5,
             "y": 1.278 / 0.5,
@@ -2038,6 +2075,7 @@ OBJECTS_IMMOBILE = [{
     "type": "crib",
     "info": ["huge", "crib"],
     "materialCategory": ["wood"],
+    "salientMaterials": ["wood"],
     "mass": 25,
     "attributes": [],
     "dimensions": {
@@ -2810,8 +2848,11 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "sofa_1",
     "obstruct": "vision",
-    "info": ["huge", "brown", "sofa"],
+    "info": ["huge", "sofa"],
+    "color": ["brown"],
     "mass": 100,
+    "materialCategory": [],
+    "salientMaterials": ["fabric"],
     "attributes": ["receptacle", "stackTarget"],
     "openAreas": [{
         "id": "",
@@ -2845,8 +2886,11 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "sofa_2",
     "obstruct": "vision",
-    "info": ["huge", "grey", "sofa"],
+    "info": ["huge", "sofa"],
+    "color": ["grey"],
     "mass": 100,
+    "materialCategory": [],
+    "salientMaterials": ["fabric"],
     "attributes": ["receptacle", "stackTarget"],
     "openAreas": [{
         "id": "",
@@ -2880,8 +2924,11 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "sofa_chair_1",
     "obstruct": "vision",
-    "info": ["huge", "black", "sofa chair"],
+    "info": ["huge", "sofa chair"],
+    "color": ["black"],
     "mass": 50,
+    "materialCategory": [],
+    "salientMaterials": ["fabric"],
     "attributes": ["receptacle", "stackTarget"],
     "openAreas": [{
         "id": "",
@@ -2915,8 +2962,11 @@ OBJECTS_IMMOBILE = [{
 }, {
     "type": "sofa_chair_2",
     "obstruct": "vision",
-    "info": ["huge", "grey", "sofa chair"],
+    "info": ["huge", "sofa chair"],
+    "color": ["grey"],
     "mass": 50,
+    "materialCategory": [],
+    "salientMaterials": ["fabric"],
     "attributes": ["receptacle", "stackTarget"],
     "openAreas": [{
         "id": "",
@@ -3071,10 +3121,12 @@ OBJECTS_IMMOBILE = [{
 }, {
     "info": ["large", "potted plant"],
     "mass": 5,
+    "materialCategory": [],
     "salientMaterials": ["organic", "ceramic"],
     "attributes": [],
     "chooseType": [{
         "type": "plant_1",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.931 * 2,
             "y": 0.807 * 2,
@@ -3093,6 +3145,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "type": "plant_5",
+        "color": ["green", "grey", "brown"],
         "dimensions": {
             "x": 0.522 * 2,
             "y": 0.656 * 2,
@@ -3111,6 +3164,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "type": "plant_7",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.72 * 2,
             "y": 1.094 * 2,
@@ -3129,6 +3183,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "type": "plant_9",
+        "color": ["green", "grey", "brown"],
         "dimensions": {
             "x": 0.679 * 2,
             "y": 0.859 * 2,
@@ -3147,6 +3202,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "type": "plant_14",
+        "color": ["red", "brown"],
         "dimensions": {
             "x": 0.508 * 2,
             "y": 0.815 * 2,
@@ -3165,6 +3221,7 @@ OBJECTS_IMMOBILE = [{
         }
     }, {
         "type": "plant_16",
+        "color": ["green", "brown"],
         "dimensions": {
             "x": 0.702 * 2,
             "y": 1.278 * 2,

--- a/scene_generator/objects_test.py
+++ b/scene_generator/objects_test.py
@@ -67,7 +67,8 @@ def test_all_objects_have_expected_properties():
     for object_definition in retrieve_full_object_definition_list(get_all_object_defs()):
         print(f'{object_definition["type"]}')
         assert 'type' in object_definition
-        assert 'info' in object_definition
+        assert 'size' in object_definition
+        assert 'shape' in object_definition
         assert 'mass' in object_definition
         assert 'attributes' in object_definition
         assert 'dimensions' in object_definition
@@ -75,4 +76,5 @@ def test_all_objects_have_expected_properties():
         assert 'salientMaterials' in object_definition
         if len(object_definition['materialCategory']) == 0:
             assert 'color' in object_definition
+        assert 'info' not in object_definition
 

--- a/scene_generator/objects_test.py
+++ b/scene_generator/objects_test.py
@@ -1,6 +1,7 @@
 from objects import *
 import uuid
 import random
+from util import retrieve_full_object_definition_list
 
 
 def test_create_occluder_normal():
@@ -54,4 +55,24 @@ def test_get_enclosed_containers():
     for container in containers:
         assert 'enclosedAreas' in container or 'chooseSize' in container \
             and 'enclosedAreas' in container['chooseSize'][0]
+
+
+def test_get_intphys_objects():
+    objs = get_intphys_objects()
+    for obj in objs:
+        assert 'intphysOptions' in obj
+
+
+def test_all_objects_have_expected_properties():
+    for object_definition in retrieve_full_object_definition_list(get_all_object_defs()):
+        print(f'{object_definition["type"]}')
+        assert 'type' in object_definition
+        assert 'info' in object_definition
+        assert 'mass' in object_definition
+        assert 'attributes' in object_definition
+        assert 'dimensions' in object_definition
+        assert 'materialCategory' in object_definition
+        assert 'salientMaterials' in object_definition
+        if len(object_definition['materialCategory']) == 0:
+            assert 'color' in object_definition
 

--- a/scene_generator/objects_test.py
+++ b/scene_generator/objects_test.py
@@ -19,12 +19,10 @@ def test_create_occluder_normal():
     assert pole['materials'] == ['test_material_pole']
     assert wall['info'] == ['white']
     assert pole['info'] == ['brown']
-    assert wall['info_string'] == 'white'
-    assert pole['info_string'] == 'brown'
     for x in wall, pole:
         assert x['shows'][0]['position']['x'] == x_position
 
-        
+
 def test_create_occluder_sideways():
     wall_material = ['test_material_wall', ['white']]
     pole_material = ['test_material_pole', ['brown']]
@@ -41,10 +39,8 @@ def test_create_occluder_sideways():
     assert pole['materials'] == ['test_material_pole']
     assert wall['info'] == ['white']
     assert pole['info'] == ['brown']
-    assert wall['info_string'] == 'white'
-    assert pole['info_string'] == 'brown'
 
-    
+
 def test_get_all_object_defs():
     all = get_all_object_defs()
     dup = get_all_object_defs()
@@ -56,5 +52,6 @@ def test_get_all_object_defs():
 def test_get_enclosed_containers():
     containers = get_enclosed_containers()
     for container in containers:
-        assert 'enclosed_areas' in container or 'chooseSize' in container \
-            and 'enclosed_areas' in container['chooseSize'][0]
+        assert 'enclosedAreas' in container or 'chooseSize' in container \
+            and 'enclosedAreas' in container['chooseSize'][0]
+

--- a/scene_generator/objects_test.py
+++ b/scene_generator/objects_test.py
@@ -56,5 +56,5 @@ def test_get_all_object_defs():
 def test_get_enclosed_containers():
     containers = get_enclosed_containers()
     for container in containers:
-        assert 'enclosed_areas' in container or 'choose' in container \
-            and 'enclosed_areas' in container['choose'][0]
+        assert 'enclosed_areas' in container or 'chooseSize' in container \
+            and 'enclosed_areas' in container['chooseSize'][0]

--- a/scene_generator/pairs.py
+++ b/scene_generator/pairs.py
@@ -566,8 +566,8 @@ class InteractionPair():
         # If needed, position both the target and confusor together inside a receptacle.
         if containerize_target and containerize_confusor and show_confusor and is_confusor_close:
             target_receptacle_instance = copy.deepcopy(receptacle_template)
-            # Update the Y position of the location to use the position_y from the receptacle definition.
-            target_location['position']['y'] = receptacle_definition.get('position_y', 0)
+            # Update the Y position of the location to use the positionY from the receptacle definition.
+            target_location['position']['y'] = receptacle_definition.get('positionY', 0)
             util.move_to_location(receptacle_definition, target_receptacle_instance, target_location)
             containers.put_objects_in_container(target_definition, target_instance, confusor_definition, \
                     confusor_instance, target_receptacle_instance, receptacle_definition, area_index, orientation, \
@@ -578,8 +578,8 @@ class InteractionPair():
             if containerize_target:
                 # Use the target location for its receptacle, then position the target inside its receptacle.
                 target_receptacle_instance = copy.deepcopy(receptacle_template)
-                # Update the Y position of the location to use the position_y from the receptacle definition.
-                target_location['position']['y'] = receptacle_definition.get('position_y', 0)
+                # Update the Y position of the location to use the positionY from the receptacle definition.
+                target_location['position']['y'] = receptacle_definition.get('positionY', 0)
                 util.move_to_location(receptacle_definition, target_receptacle_instance, target_location)
                 containers.put_object_in_container(target_definition, target_instance, target_receptacle_instance, \
                         receptacle_definition, area_index, target_rotation)
@@ -591,8 +591,8 @@ class InteractionPair():
                 if containerize_confusor:
                     # Use the confusor location for its receptacle, then position the confusor inside its receptacle.
                     confusor_receptacle_instance = copy.deepcopy(receptacle_template)
-                    # Update the Y position of the location to use the position_y from the receptacle definition.
-                    confusor_location['position']['y'] = receptacle_definition.get('position_y', 0)
+                    # Update the Y position of the location to use the positionY from the receptacle definition.
+                    confusor_location['position']['y'] = receptacle_definition.get('positionY', 0)
                     confusor_receptacle_instance['id'] = confusor_receptacle_id
                     util.move_to_location(receptacle_definition, confusor_receptacle_instance, confusor_location)
                     containers.put_object_in_container(confusor_definition, confusor_instance, \

--- a/scene_generator/pairs.py
+++ b/scene_generator/pairs.py
@@ -543,7 +543,7 @@ class InteractionPair():
         if show_obstructor:
             obstructor_instance = copy.deepcopy(obstructor_template)
             util.move_to_location(obstructor_definition, obstructor_instance, obstructor_location)
-            bounds_list.append(obstructor_instance['shows'][0]['bounding_box'])
+            bounds_list.append(obstructor_instance['shows'][0]['boundingBox'])
             return obstructor_instance
 
         return None
@@ -572,7 +572,7 @@ class InteractionPair():
             containers.put_objects_in_container(target_definition, target_instance, confusor_definition, \
                     confusor_instance, target_receptacle_instance, receptacle_definition, area_index, orientation, \
                     target_rotation, confusor_rotation)
-            bounds_list.append(target_receptacle_instance['shows'][0]['bounding_box'])
+            bounds_list.append(target_receptacle_instance['shows'][0]['boundingBox'])
 
         else:
             if containerize_target:
@@ -583,10 +583,10 @@ class InteractionPair():
                 util.move_to_location(receptacle_definition, target_receptacle_instance, target_location)
                 containers.put_object_in_container(target_definition, target_instance, target_receptacle_instance, \
                         receptacle_definition, area_index, target_rotation)
-                bounds_list.append(target_receptacle_instance['shows'][0]['bounding_box'])
+                bounds_list.append(target_receptacle_instance['shows'][0]['boundingBox'])
             else:
                 util.move_to_location(target_definition, target_instance, target_location)
-                bounds_list.append(target_instance['shows'][0]['bounding_box'])
+                bounds_list.append(target_instance['shows'][0]['boundingBox'])
             if show_confusor:
                 if containerize_confusor:
                     # Use the confusor location for its receptacle, then position the confusor inside its receptacle.
@@ -597,10 +597,10 @@ class InteractionPair():
                     util.move_to_location(receptacle_definition, confusor_receptacle_instance, confusor_location)
                     containers.put_object_in_container(confusor_definition, confusor_instance, \
                             confusor_receptacle_instance, receptacle_definition, area_index, confusor_rotation)
-                    bounds_list.append(confusor_receptacle_instance['shows'][0]['bounding_box'])
+                    bounds_list.append(confusor_receptacle_instance['shows'][0]['boundingBox'])
                 else:
                     util.move_to_location(confusor_definition, confusor_instance, confusor_location)
-                    bounds_list.append(confusor_instance['shows'][0]['bounding_box'])
+                    bounds_list.append(confusor_instance['shows'][0]['boundingBox'])
 
         return target_instance, confusor_instance, target_receptacle_instance, confusor_receptacle_instance
 

--- a/scene_generator/pairs_test.py
+++ b/scene_generator/pairs_test.py
@@ -90,7 +90,7 @@ def verify_obstructor(goal, scene, obstruct_vision = False):
     performer_start = goal.get_performer_start()
     target = goal.get_target_list()[0]
     obstructor = goal.get_obstructor_list()[0]
-    dimensions = obstructor['closed_dimensions'] if 'closed_dimensions' in obstructor else obstructor['dimensions']
+    dimensions = obstructor['closedDimensions'] if 'closedDimensions' in obstructor else obstructor['dimensions']
 
     is_bigger = (target['dimensions']['x'] <= dimensions['x'] or target['dimensions']['z'] <= dimensions['z']) and \
             (not obstruct_vision or target['dimensions']['y'] <= dimensions['y'])

--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -360,7 +360,7 @@ class ShapeConstancyQuartet(Quartet):
             raise exceptions.SceneException(f'no valid choices for "b" object. a = {a}')
         b_def = random.choice(possible_defs)
         b_def = util.finalize_object_definition(b_def)
-        b = util.instantiate_object(b_def, a['original_location'], a['materials_list'])
+        b = util.instantiate_object(b_def, a['originalLocation'], a['materialsList'])
         b['id'] = a['id']
         logging.debug(f'a type: {a["type"]}\tb type: {b["type"]}')
         return b

--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -16,7 +16,7 @@ import util
 def get_position_step(target: Dict[str, Any], x_position: float,
                       left_to_right: bool, forwards: bool) -> int:
     """Get the step number at which the target reaches x_position"""
-    positions = target['intphys_option']['position_by_step']
+    positions = target['intphysOption']['position_by_step']
     if forwards:
         rang = range(len(positions))
         counting_up = not left_to_right
@@ -56,14 +56,14 @@ class ObjectPermanenceQuartet(Quartet):
         target_id = self._goal._tag_to_objects['target'][0]['id']
         target = [obj for obj in body['objects'] if obj['id'] == target_id][0]
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
-            implausible_event_index = target['intphys_option']['occluder_indices'][0]
+            implausible_event_index = target['intphysOption']['occluder_indices'][0]
             implausible_event_step = implausible_event_index + target['forces'][0]['stepBegin']
-            implausible_event_x = target['intphys_option']['position_by_step'][implausible_event_index]
+            implausible_event_x = target['intphysOption']['position_by_step'][implausible_event_index]
             target['shows'][0]['position']['x'] = implausible_event_x
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             # 8 is enough steps for anything to fall to the ground
             implausible_event_step = 8 + target['shows'][0]['stepBegin']
-            target['shows'][0]['position']['y'] = target['intphys_option']['position_y']
+            target['shows'][0]['position']['y'] = target['intphysOption']['positionY']
         else:
             raise ValueError('unknown object creation function, cannot update scene')
         target['shows'][0]['stepBegin'] = implausible_event_step
@@ -72,7 +72,7 @@ class ObjectPermanenceQuartet(Quartet):
         target_id = self._goal._tag_to_objects['target'][0]['id']
         target = [obj for obj in body['objects'] if obj['id'] == target_id][0]
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
-            implausible_event_step = target['intphys_option']['occluder_indices'][0] + \
+            implausible_event_step = target['intphysOption']['occluder_indices'][0] + \
                 target['forces'][0]['stepBegin']
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             # 8 is enough steps for anything to fall to the ground
@@ -124,11 +124,11 @@ class SpatioTemporalContinuityQuartet(Quartet):
 
     def _check_stepBegin(self, scene: Dict[str, Any]) -> None:
         target = self._goal._tag_to_objects['target'][0]
-        implausible_event_index1 = target['intphys_option']['occluder_indices'][0]
-        implausible_event_index2 = target['intphys_option']['occluder_indices'][1]
+        implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
+        implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
         orig_stepBegin = target['shows'][0]['stepBegin']
         new_stepBegin = orig_stepBegin + abs(implausible_event_index1 - implausible_event_index2)
-        max_stepBegin = scene['goal']['last_step'] - len(target['intphys_option']['position_by_step'])
+        max_stepBegin = scene['goal']['last_step'] - len(target['intphysOption']['position_by_step'])
         if new_stepBegin > max_stepBegin:
             # need to adjust the original to accomodate what we need for scene #4
             diff = new_stepBegin - max_stepBegin
@@ -145,8 +145,8 @@ class SpatioTemporalContinuityQuartet(Quartet):
         other_occluder = None
         other_object_id = None
         for obj in scene['objects']:
-            if obj.get('intphys_option', {}).get('is_occluder', False):
-                occluded_id = obj.get('intphys_option', {}).get('occluded_id', None)
+            if obj.get('intphysOption', {}).get('is_occluder', False):
+                occluded_id = obj.get('intphysOption', {}).get('occluded_id', None)
                 if occluded_id != target_id:
                     other_occluder = obj
                     other_object_id = occluded_id
@@ -164,20 +164,20 @@ class SpatioTemporalContinuityQuartet(Quartet):
         target = all_targets[0]
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
             # go from the lower index to the higher one so we teleport forward
-            implausible_event_index1 = target['intphys_option']['occluder_indices'][0]
-            implausible_event_index2 = target['intphys_option']['occluder_indices'][1]
+            implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
+            implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
             if implausible_event_index1 < implausible_event_index2:
                 implausible_event_index = implausible_event_index1
                 destination_index = implausible_event_index2
-                destination_x = target['intphys_option']['position_by_step'][destination_index]
+                destination_x = target['intphysOption']['position_by_step'][destination_index]
             else:
                 implausible_event_index = implausible_event_index2
                 destination_index = implausible_event_index1
-                destination_x = target['intphys_option']['position_by_step'][destination_index]
+                destination_x = target['intphysOption']['position_by_step'][destination_index]
             implausible_event_step = implausible_event_index + target['forces'][0]['stepBegin']
             position = {
                 'x': destination_x,
-                'y': target['intphys_option']['position_y'],
+                'y': target['intphysOption']['positionY'],
                 'z': target['shows'][0]['position']['z']
             }
             if random.random() <= 0.5:
@@ -215,7 +215,7 @@ class SpatioTemporalContinuityQuartet(Quartet):
                     'stepEnd': implausible_event_step,
                     'position': {
                         'x': target['shows'][0]['position']['x'],
-                        'y': target['intphys_option']['position_y'],
+                        'y': target['intphysOption']['positionY'],
                         'z': target['shows'][0]['position']['z']
                     }
                 }]
@@ -224,7 +224,7 @@ class SpatioTemporalContinuityQuartet(Quartet):
                 'stepEnd': implausible_event_step,
                 'position': {
                     'x': destination_x,
-                    'y': target['intphys_option']['position_y'],
+                    'y': target['intphysOption']['positionY'],
                     'z': target['shows'][0]['position']['z']
                 }
             }]
@@ -235,16 +235,16 @@ class SpatioTemporalContinuityQuartet(Quartet):
         target = self._goal._tag_to_objects['target'][0]
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
             # go from the higher index to the lower one so we teleport backward
-            implausible_event_index1 = target['intphys_option']['occluder_indices'][0]
-            implausible_event_index2 = target['intphys_option']['occluder_indices'][1]
+            implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
+            implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
             if implausible_event_index1 > implausible_event_index2:
                 implausible_event_index = implausible_event_index1
                 destination_index = implausible_event_index2
-                destination_x = target['intphys_option']['position_by_step'][destination_index]
+                destination_x = target['intphysOption']['position_by_step'][destination_index]
             else:
                 implausible_event_index = implausible_event_index2
                 destination_index = implausible_event_index1
-                destination_x = target['intphys_option']['position_by_step'][destination_index]
+                destination_x = target['intphysOption']['position_by_step'][destination_index]
             implausible_event_step = implausible_event_index + target['forces'][0]['stepBegin']
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             # 8 is enough for it to fall to the ground
@@ -268,7 +268,7 @@ class SpatioTemporalContinuityQuartet(Quartet):
                     'stepEnd': implausible_event_step,
                     'position': {
                         'x': other_object['shows'][0]['position']['x'],
-                        'y': other_object['intphys_option']['position_y'],
+                        'y': other_object['intphysOption']['positionY'],
                         'z': other_object['shows'][0]['position']['z']
                     }
                 }]
@@ -280,7 +280,7 @@ class SpatioTemporalContinuityQuartet(Quartet):
             'stepEnd': implausible_event_step,
             'position': {
                 'x': destination_x,
-                'y': target['intphys_option']['position_y'],
+                'y': target['intphysOption']['positionY'],
                 'z': target['shows'][0]['position']['z']
             }
         }]
@@ -288,8 +288,8 @@ class SpatioTemporalContinuityQuartet(Quartet):
     def _move_later(self, scene: Dict[str, Any]) -> None:
         target = self._goal._tag_to_objects['target'][0]
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
-            implausible_event_index1 = target['intphys_option']['occluder_indices'][0]
-            implausible_event_index2 = target['intphys_option']['occluder_indices'][1]
+            implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
+            implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
             adjustment = abs(implausible_event_index1 - implausible_event_index2)
             target['shows'][0]['stepBegin'] += adjustment
             if 'forces' in target:
@@ -369,16 +369,16 @@ class ShapeConstancyQuartet(Quartet):
         a = scene['objects'][0]
         b = copy.deepcopy(self._b)
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
-            implausible_event_index = a['intphys_option']['occluder_indices'][0]
+            implausible_event_index = a['intphysOption']['occluder_indices'][0]
             implausible_event_step = implausible_event_index + a['forces'][0]['stepBegin']
-            implausible_event_x = a['intphys_option']['position_by_step'][implausible_event_index]
+            implausible_event_x = a['intphysOption']['position_by_step'][implausible_event_index]
             b['shows'][0]['position']['x'] = implausible_event_x
             b['forces'] = copy.deepcopy(a['forces'])
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             # 8 steps is enough time for the object to fall to the ground
             implausible_event_step = 8 + a['shows'][0]['stepBegin']
             b['shows'][0]['position']['x'] = a['shows'][0]['position']['x']
-            b['shows'][0]['position']['y'] = a['intphys_option']['position_y']
+            b['shows'][0]['position']['y'] = a['intphysOption']['positionY']
         else:
             raise ValueError(f'unknown object creation function, cannot update scene: {self._goal._object_creator}')
         b['shows'][0]['position']['z'] = a['shows'][0]['position']['z']
@@ -394,15 +394,15 @@ class ShapeConstancyQuartet(Quartet):
         b = copy.deepcopy(self._b)
         b['shows'][0]['position']['x'] = a['shows'][0]['position']['x']
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
-            implausible_event_index = a['intphys_option']['occluder_indices'][0]
+            implausible_event_index = a['intphysOption']['occluder_indices'][0]
             implausible_event_step = implausible_event_index + a['forces'][0]['stepBegin']
-            implausible_event_x = a['intphys_option']['position_by_step'][implausible_event_index]
+            implausible_event_x = a['intphysOption']['position_by_step'][implausible_event_index]
             b['forces'] = copy.deepcopy(a['forces'])
             a['shows'][0]['position']['x'] = implausible_event_x
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             implausible_event_step = 8 + a['shows'][0]['stepBegin']
             b['shows'][0]['position']['y'] = a['shows'][0]['position']['y']
-            a['shows'][0]['position']['y'] = a['intphys_option']['position_y']
+            a['shows'][0]['position']['y'] = a['intphysOption']['positionY']
         else:
             raise ValueError(f'unknown object creation function, cannot update scene: {self._goal._object_creator}')
         b['shows'][0]['stepBegin'] = a['shows'][0]['stepBegin']
@@ -495,7 +495,7 @@ class GravityQuartet(Quartet):
         target = scene['objects'][0]
         if q == 2 or q == 4:
             # switch the target to use lowest force.x
-            new_intphys_option = sorted(target['intphys_option']['saved_options'],
+            new_intphys_option = sorted(target['intphysOption']['saved_options'],
                                         key=lambda io: io['force']['x'])[0]
             target['forces'][0]['vector']['x'] = new_intphys_option['force']['x']
             if not self._goal.is_left_to_right():
@@ -509,7 +509,7 @@ class GravityQuartet(Quartet):
             scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
             _, top_offset = self._get_ramp_offsets()
             logging.debug(f'top_offset={top_offset}')
-            implausible_x_start = target['intphys_option']['ramp_x_term'] + top_offset
+            implausible_x_start = target['intphysOption']['ramp_x_term'] + top_offset
             implausible_step = get_position_step(target, implausible_x_start,
                                                  self._goal.is_left_to_right(),
                                                  False) - 1 + \
@@ -552,7 +552,7 @@ class GravityQuartet(Quartet):
     def _make_roll_down(self, scene: Dict[str, Any]) -> None:
         ramp_type = self._goal.get_ramp_type()
         for obj in scene['objects']:
-            if obj.get('intphys_option', {}).get('moving_object', False):
+            if obj.get('intphysOption', {}).get('moving_object', False):
                 obj['shows'][0]['position']['x'] *= -1
                 obj['forces'][0]['vector']['x'] *= -1
                 # adjust height to be on top of ramp
@@ -573,7 +573,7 @@ class GravityQuartet(Quartet):
         target_id = self._goal._tag_to_objects['target'][0]['id']
         target = [obj for obj in scene['objects'] if obj['id'] == target_id][0]
         bottom_offset, top_offset = self._get_ramp_offsets()
-        implausible_x_start = target['intphys_option']['ramp_x_term'] + bottom_offset
+        implausible_x_start = target['intphysOption']['ramp_x_term'] + bottom_offset
         implausible_step = get_position_step(target, implausible_x_start,
                                              self._goal.is_left_to_right(),
                                              True) + \
@@ -588,7 +588,7 @@ class GravityQuartet(Quartet):
         target_id = self._goal._tag_to_objects['target'][0]['id']
         target = [obj for obj in scene['objects'] if obj['id'] == target_id][0]
         bottom_offset, top_offset = self._get_ramp_offsets()
-        implausible_x_start = target['intphys_option']['ramp_x_term'] + top_offset
+        implausible_x_start = target['intphysOption']['ramp_x_term'] + top_offset
         implausible_step = get_position_step(target, implausible_x_start,
                                              self._goal.is_left_to_right(),
                                              False) + \

--- a/scene_generator/quartets_test.py
+++ b/scene_generator/quartets_test.py
@@ -10,7 +10,7 @@ TEMPLATE = {'wallMaterial': 'dummy', 'wallColors': ['color']}
 
 def test_get_position_step():
     target = {
-        'intphys_option': objects.OBJECTS_INTPHYS[0]['intphys_options'][0]
+        'intphysOption': objects.OBJECTS_INTPHYS[0]['intphysOptions'][0]
     }
     x = 1.0
     expected_step = 2
@@ -65,8 +65,8 @@ def test_STCQ_get_scene_2_teleport_forward():
     if 'teleports' in target:
         assert target['teleports'][0]['stepBegin'] == target['teleports'][0]['stepEnd']
         if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
-            implausible_event_index1 = target['intphys_option']['occluder_indices'][0]
-            implausible_event_index2 = target['intphys_option']['occluder_indices'][1]
+            implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
+            implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
             assert target['teleports'][0]['stepBegin'] == min(implausible_event_index1, implausible_event_index2) + target['forces'][0]['stepBegin']
         else:
             assert target['teleports'][0]['stepBegin'] >= 8
@@ -82,8 +82,8 @@ def test_STCQ_get_scene_3_teleport_backward():
     assert 'teleports' in target
     assert target['teleports'][0]['stepBegin'] == target['teleports'][0]['stepEnd']
     if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
-        implausible_event_index1 = target['intphys_option']['occluder_indices'][0]
-        implausible_event_index2 = target['intphys_option']['occluder_indices'][1]
+        implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
+        implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
         assert target['teleports'][0]['stepBegin'] == max(implausible_event_index1, implausible_event_index2) + target['forces'][0]['stepBegin']
     else:
         assert target['teleports'][0]['stepBegin'] >= 8
@@ -164,7 +164,7 @@ def test_ShapeConstancyQuartet_get_scene_2():
     else:
         assert a['shows'][0]['stepBegin'] >= 8
         assert b['shows'][0]['position']['x'] == a['shows'][0]['position']['x']
-        assert b['shows'][0]['position']['y'] == a['intphys_option']['position_y']
+        assert b['shows'][0]['position']['y'] == a['intphysOption']['positionY']
 
 
 def test_ShapeConstancyQuartet_get_scene_3():
@@ -181,7 +181,7 @@ def test_ShapeConstancyQuartet_get_scene_3():
         assert a['forces'] == b['forces']
     else:
         assert a['shows'][0]['stepBegin'] >= 8
-        assert a['shows'][0]['position']['y'] == a['intphys_option']['position_y']
+        assert a['shows'][0]['position']['y'] == a['intphysOption']['positionY']
 
 
 def test_ShapeConstancyQuartet_get_scene_4():

--- a/scene_generator/scene_generator.py
+++ b/scene_generator/scene_generator.py
@@ -68,15 +68,15 @@ def strip_debug_info(body: Dict[str, Any]) -> None:
 def clean_object(obj: Dict[str, Any]) -> None:
     """Remove properties we do not want TA1s to have access to."""
     obj.pop('info', None)
-    obj.pop('info_string', None)
+    obj.pop('goal_string', None)
     obj.pop('dimensions', None)
-    obj.pop('intphys_option', None)
+    obj.pop('intphysOption', None)
     obj.pop('materials_list', None)
     obj.pop('materialCategory', None)
     obj.pop('original_location', None)
-    obj.pop('novel_color', None)
-    obj.pop('novel_combination', None)
-    obj.pop('novel_shape', None)
+    obj.pop('novelColor', None)
+    obj.pop('novelCombination', None)
+    obj.pop('novelShape', None)
     obj.pop('shape', None)
     if 'shows' in obj:
         obj['shows'][0].pop('bounding_box', None)

--- a/scene_generator/scene_generator.py
+++ b/scene_generator/scene_generator.py
@@ -70,6 +70,11 @@ def clean_object(obj: Dict[str, Any]) -> None:
     obj.pop('info', None)
     obj.pop('goal_string', None)
     obj.pop('dimensions', None)
+    obj.pop('offset', None)
+    obj.pop('closedDimensions', None)
+    obj.pop('closedOffset', None)
+    obj.pop('enclosedAreas', None)
+    obj.pop('openAreas', None)
     obj.pop('intphysOption', None)
     obj.pop('materials_list', None)
     obj.pop('materialCategory', None)
@@ -77,7 +82,9 @@ def clean_object(obj: Dict[str, Any]) -> None:
     obj.pop('novelColor', None)
     obj.pop('novelCombination', None)
     obj.pop('novelShape', None)
+    obj.pop('color', None)
     obj.pop('shape', None)
+    obj.pop('size', None)
     if 'shows' in obj:
         obj['shows'][0].pop('bounding_box', None)
 

--- a/scene_generator/scene_generator.py
+++ b/scene_generator/scene_generator.py
@@ -68,7 +68,7 @@ def strip_debug_info(body: Dict[str, Any]) -> None:
 def clean_object(obj: Dict[str, Any]) -> None:
     """Remove properties we do not want TA1s to have access to."""
     obj.pop('info', None)
-    obj.pop('goal_string', None)
+    obj.pop('goalString', None)
     obj.pop('dimensions', None)
     obj.pop('offset', None)
     obj.pop('closedDimensions', None)
@@ -76,9 +76,9 @@ def clean_object(obj: Dict[str, Any]) -> None:
     obj.pop('enclosedAreas', None)
     obj.pop('openAreas', None)
     obj.pop('intphysOption', None)
-    obj.pop('materials_list', None)
+    obj.pop('materialsList', None)
     obj.pop('materialCategory', None)
-    obj.pop('original_location', None)
+    obj.pop('originalLocation', None)
     obj.pop('novelColor', None)
     obj.pop('novelCombination', None)
     obj.pop('novelShape', None)
@@ -86,7 +86,7 @@ def clean_object(obj: Dict[str, Any]) -> None:
     obj.pop('shape', None)
     obj.pop('size', None)
     if 'shows' in obj:
-        obj['shows'][0].pop('bounding_box', None)
+        obj['shows'][0].pop('boundingBox', None)
 
 
 def generate_body_template(name: str) -> Dict[str, Any]:

--- a/scene_generator/scene_generator_test.py
+++ b/scene_generator/scene_generator_test.py
@@ -11,17 +11,22 @@ def find_object(id, obj_list):
 def test_clean_object():
     obj = {
         'id': 'thing1',
-        'dimensions': {
-            'x': 13,
-            'z': 42
-        },
         'info': ['a', 'b', 'c', 'd'],
         'goal_string': 'abcd',
+        'materialCategory': ['wood'],
+        'dimensions': { 'x': 13, 'z': 42 },
+        'offset': { 'x': 13, 'z': 42 },
+        'closedDimensions': { 'x': 13, 'z': 42 },
+        'closedOffset': { 'x': 13, 'z': 42 },
+        'enclosedAreas': [{}],
+        'openAreas': [{}],
         'intphysOption': 'stuff',
         'novelColor': True,
         'novelCombination': False,
         'novelShape': True,
+        'color': ['black', 'white'],
         'shape': 'shape',
+        'size': 'medium',
         'shows': [{
             'stepBegin': 0,
             'bounding_box': 'dummy'
@@ -35,3 +40,4 @@ def test_clean_object():
     }
     clean_object(obj)
     assert obj == expected
+

--- a/scene_generator/scene_generator_test.py
+++ b/scene_generator/scene_generator_test.py
@@ -12,7 +12,7 @@ def test_clean_object():
     obj = {
         'id': 'thing1',
         'info': ['a', 'b', 'c', 'd'],
-        'goal_string': 'abcd',
+        'goalString': 'abcd',
         'materialCategory': ['wood'],
         'dimensions': { 'x': 13, 'z': 42 },
         'offset': { 'x': 13, 'z': 42 },
@@ -29,7 +29,7 @@ def test_clean_object():
         'size': 'medium',
         'shows': [{
             'stepBegin': 0,
-            'bounding_box': 'dummy'
+            'boundingBox': 'dummy'
         }]
     }
     expected = {

--- a/scene_generator/scene_generator_test.py
+++ b/scene_generator/scene_generator_test.py
@@ -16,11 +16,11 @@ def test_clean_object():
             'z': 42
         },
         'info': ['a', 'b', 'c', 'd'],
-        'info_string': 'abcd',
-        'intphys_option': 'stuff',
-        'novel_color': True,
-        'novel_combination': False,
-        'novel_shape': True,
+        'goal_string': 'abcd',
+        'intphysOption': 'stuff',
+        'novelColor': True,
+        'novelCombination': False,
+        'novelShape': True,
         'shape': 'shape',
         'shows': [{
             'stepBegin': 0,

--- a/scene_generator/tags.py
+++ b/scene_generator/tags.py
@@ -86,11 +86,11 @@ def append_object_tags(tags: List[str], tag_to_objects: Dict[str, List[Dict[str,
 def append_object_tags_of_type(tags: List[str], objs: List[Dict[str, Any]], name: str) -> List[str]:
     for obj in objs:
         enclosed_tag = (name + ' not enclosed') if obj.get('locationParent', None) is None else (name + ' enclosed')
-        novel_color_tag = (name + ' novel color') if 'novel_color' in obj and obj['novel_color'] else \
+        novel_color_tag = (name + ' novel color') if 'novelColor' in obj and obj['novelColor'] else \
                 (name + ' not novel color')
-        novel_combination_tag = (name + ' novel combination') if 'novel_combination' in obj and \
-                obj['novel_combination'] else (name + ' not novel combination')
-        novel_shape_tag = (name + ' novel shape') if 'novel_shape' in obj and obj['novel_shape'] else \
+        novel_combination_tag = (name + ' novel combination') if 'novelCombination' in obj and \
+                obj['novelCombination'] else (name + ' not novel combination')
+        novel_shape_tag = (name + ' novel shape') if 'novelShape' in obj and obj['novelShape'] else \
                 (name + ' not novel shape')
         for new_tag in [enclosed_tag, novel_color_tag, novel_combination_tag, novel_shape_tag]:
             if new_tag not in tags:

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -79,21 +79,18 @@ def finalize_object_materials_and_colors(object_definition: Dict[str, Any], \
 
     materials_lists = [override_materials_list] if override_materials_list else []
 
-    if not 'materialCategory' in object_definition or not object_definition['materialCategory']:
-        # TODO MCS-327 Uncomment
-        # raise exceptions.SceneException(f'object definition "{object_definition["type"]}" doesn\'t have material category')
+    if not 'materialCategory' in object_definition:
         object_definition['materialCategory'] = []
 
     if not materials_lists:
         materials_lists = generate_materials_lists(object_definition['materialCategory'], [])
 
     if not materials_lists:
-        # TODO MCS-327 Uncomment
-        # raise exceptions.SceneException(f'object definition "{object_definition["type"]}" doesn\'t have materials')
         object_definition_copy = copy.deepcopy(object_definition)
         object_definition_copy['color'] = object_definition_copy['color'] if 'color' in object_definition_copy else []
         object_definition_copy['materials_list'] = []
-        object_definition_copy['materials'] = None
+        object_definition_copy['materials'] = object_definition_copy['materials'] if 'materials' in \
+                object_definition_copy else []
         return [object_definition_copy]
 
     object_definition_list = []
@@ -170,7 +167,6 @@ def instantiate_object(object_def: Dict[str, Any],
     if 'color' not in object_def or 'materials' not in object_def:
         object_def = random.choice(finalize_object_materials_and_colors(object_def, materials_list))
 
-    new_object['materialCategory'] = object_def['materialCategory']
     # need the materials list for quartets
     new_object['materials_list'] = object_def['materials_list']
     new_object['materials'] = object_def['materials']

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -104,7 +104,7 @@ def finalize_object_materials_and_colors(object_definition: Dict[str, Any], \
         object_definition_copy['materials'] = [material_and_color[0] for material_and_color in materials_list]
         for material_and_color in materials_list:
             if material_and_color[0] in materials.NOVEL_COLOR_LIST:
-                object_definition_copy['novel_color'] = True
+                object_definition_copy['novelColor'] = True
             for color in material_and_color[1]:
                 if color not in object_definition_copy['color']:
                     object_definition_copy['color'].append(color)
@@ -133,9 +133,9 @@ def instantiate_object(object_def: Dict[str, Any],
         'type': object_def['type'],
         'mass': object_def['mass'] * (object_def['massMultiplier'] if 'massMultiplier' in object_def else 1),
         'info': object_def['info'].copy(),
-        'novel_color': object_def['novel_color'] if 'novel_color' in object_def else False,
-        'novel_combination': object_def['novel_combination'] if 'novel_combination' in object_def else False,
-        'novel_shape': object_def['novel_shape'] if 'novel_shape' in object_def else False
+        'novelColor': object_def['novelColor'] if 'novelColor' in object_def else False,
+        'novelCombination': object_def['novelCombination'] if 'novelCombination' in object_def else False,
+        'novelShape': object_def['novelShape'] if 'novelShape' in object_def else False
     }
     if 'dimensions' in object_def:
         new_object['dimensions'] = object_def['dimensions']
@@ -175,8 +175,8 @@ def instantiate_object(object_def: Dict[str, Any],
     new_object['materials_list'] = object_def['materials_list']
     new_object['materials'] = object_def['materials']
     new_object['color'] = object_def['color']
-    new_object['novel_color'] = (object_def['novel_color'] if 'novel_color' in object_def else False) or \
-            new_object['novel_color']
+    new_object['novelColor'] = (object_def['novelColor'] if 'novelColor' in object_def else False) or \
+            new_object['novelColor']
 
     # The info list contains words that we can use to filter on specific object tags in the UI.
     # Start with this specific ordering of object tags in the info list needed for making the goal_string:
@@ -196,28 +196,25 @@ def instantiate_object(object_def: Dict[str, Any],
         weight = 'massive'
     new_object['info'] = new_object['info'][:1] + [weight] + new_object['info'][1:]
 
-    # Save a string of the joined info list that we can use to filter on the specific object in the UI.
-    new_object['info_string'] = ' '.join(new_object['info'])
-
     # Use the object's goal_string for goal descriptions.
-    new_object['goal_string'] = new_object['info_string']
+    new_object['goal_string'] = ' '.join(new_object['info'])
 
     # Save the object shape and size tags now before we add more tags to the end of the info list.
     new_object['shape'] = new_object['info'][-1]
     new_object['size'] = new_object['info'][0]
 
-    if new_object['novel_color']:
+    if new_object['novelColor']:
         for color in list(new_object['color']):
             new_object['info'].append('novel ' + color)
 
-    if new_object['novel_shape']:
+    if new_object['novelShape']:
         new_object['info'].append('novel ' + new_object['shape'])
 
     # This object can't be marked as a novel combination if it's a novel color or a novel shape.
-    if new_object['novel_combination'] and (new_object['novel_color'] or new_object['novel_shape']):
-        new_object['novel_combination'] = False
+    if new_object['novelCombination'] and (new_object['novelColor'] or new_object['novelShape']):
+        new_object['novelCombination'] = False
 
-    if new_object['novel_combination']:
+    if new_object['novelCombination']:
         for color in list(new_object['color']):
             new_object['info'].append('novel ' + color + ' ' + new_object['shape'])
 

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -88,7 +88,7 @@ def finalize_object_materials_and_colors(object_definition: Dict[str, Any], \
     if not materials_lists:
         object_definition_copy = copy.deepcopy(object_definition)
         object_definition_copy['color'] = object_definition_copy['color'] if 'color' in object_definition_copy else []
-        object_definition_copy['materials_list'] = []
+        object_definition_copy['materialsList'] = []
         object_definition_copy['materials'] = object_definition_copy['materials'] if 'materials' in \
                 object_definition_copy else []
         return [object_definition_copy]
@@ -97,7 +97,7 @@ def finalize_object_materials_and_colors(object_definition: Dict[str, Any], \
     for materials_list in materials_lists:
         object_definition_copy = copy.deepcopy(object_definition)
         object_definition_copy['color'] = []
-        object_definition_copy['materials_list'] = materials_list
+        object_definition_copy['materialsList'] = materials_list
         object_definition_copy['materials'] = [material_and_color[0] for material_and_color in materials_list]
         for material_and_color in materials_list:
             if material_and_color[0] in materials.NOVEL_COLOR_LIST:
@@ -145,7 +145,7 @@ def instantiate_object(object_def: Dict[str, Any],
         new_object[attribute] = True
 
     # need the original position for quartets
-    new_object['original_location'] = copy.deepcopy(object_location)
+    new_object['originalLocation'] = copy.deepcopy(object_location)
     object_location = copy.deepcopy(object_location)
     if 'offset' in object_def:
         object_location['position']['x'] -= object_def['offset']['x']
@@ -170,14 +170,14 @@ def instantiate_object(object_def: Dict[str, Any],
         object_def = random.choice(finalize_object_materials_and_colors(object_def, materials_list))
 
     # need the materials list for quartets
-    new_object['materials_list'] = object_def['materials_list']
+    new_object['materialsList'] = object_def['materialsList']
     new_object['materials'] = object_def['materials']
     new_object['color'] = object_def['color']
     new_object['novelColor'] = (object_def['novelColor'] if 'novelColor' in object_def else False) or \
             new_object['novelColor']
 
     # The info list contains words that we can use to filter on specific object tags in the UI.
-    # Start with this specific ordering of object tags in the info list needed for making the goal_string:
+    # Start with this specific ordering of object tags in the info list needed for making the goalString:
     # size weight color(s) material(s) shape
     if 'pickupable' in object_def['attributes']:
         weight = 'light'
@@ -196,8 +196,8 @@ def instantiate_object(object_def: Dict[str, Any],
 
     new_object['info'] = new_object['info'] + new_object['shape']
 
-    # Use the object's goal_string for goal descriptions.
-    new_object['goal_string'] = ' '.join(new_object['info'])
+    # Use the object's goalString for goal descriptions.
+    new_object['goalString'] = ' '.join(new_object['info'])
 
     if new_object['novelColor']:
         for color in list(new_object['color']):
@@ -368,8 +368,8 @@ def move_to_location(obj_def: Dict[str, Any], obj: Dict[str, Any], location: Dic
         new_location['position']['z'] -= obj_def['offset']['z']
     obj['shows'][0]['position'] = new_location['position']
     obj['shows'][0]['rotation'] = new_location['rotation']
-    if 'bounding_box' in new_location:
-        obj['shows'][0]['bounding_box'] = new_location['bounding_box']
+    if 'boundingBox' in new_location:
+        obj['shows'][0]['boundingBox'] = new_location['boundingBox']
     return obj
 
 

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -92,7 +92,7 @@ def test_instantiate_object():
     assert type(obj['id']) is str
     assert obj['type'] == 'sofa_1'
     assert obj['dimensions'] == object_def['dimensions']
-    assert obj['goal_string'] == 'huge massive sofa'
+    assert obj['goalString'] == 'huge massive sofa'
     assert obj['info'] == ['huge', 'massive', 'sofa']
     assert obj['mass'] == 12.34
     assert obj['novelColor'] is False
@@ -146,7 +146,7 @@ def test_instantiate_object_choose():
         assert obj['moveable']
         assert obj['novelShape']
         assert obj['info'] == ['medium', 'heavy', 'sofa', 'novel sofa']
-        assert obj['goal_string'] == 'medium heavy sofa'
+        assert obj['goalString'] == 'medium heavy sofa'
         assert obj['dimensions'] == {'x': 0.5, 'y': 0.25, 'z': 0.25}
         assert obj['mass'] == 12.34
         assert obj['shows'][0]['scale'] == {'x': 0.5, 'y': 0.5, 'z': 0.5}
@@ -154,7 +154,7 @@ def test_instantiate_object_choose():
         assert 'moveable' not in obj
         assert not obj['novelShape']
         assert obj['info'] == ['huge', 'massive', 'sofa']
-        assert obj['goal_string'] == 'huge massive sofa'
+        assert obj['goalString'] == 'huge massive sofa'
         assert obj['dimensions'] == {'x': 1, 'y': 0.5, 'z': 0.5}
         assert obj['mass'] == 56.78
         assert obj['shows'][0]['scale'] == {'x': 1, 'y': 1, 'z': 1}
@@ -183,7 +183,7 @@ def test_instantiate_object_heavy_moveable():
         }
     }
     obj = instantiate_object(object_def, object_location)
-    assert obj['goal_string'] == 'huge heavy sofa'
+    assert obj['goalString'] == 'huge heavy sofa'
     assert obj['info'] == ['huge', 'heavy', 'sofa']
     assert obj['moveable'] is True
 
@@ -211,7 +211,7 @@ def test_instantiate_object_light_pickupable():
         }
     }
     obj = instantiate_object(object_def, object_location)
-    assert obj['goal_string'] == 'huge light sofa'
+    assert obj['goalString'] == 'huge light sofa'
     assert obj['info'] == ['huge', 'light', 'sofa']
     assert obj['moveable'] is True
     assert obj['pickupable'] is True
@@ -306,7 +306,7 @@ def test_instantiate_object_materials():
     obj = instantiate_object(object_def, object_location)
     assert obj['materials'] == ['test_material']
     assert obj['color'] == ['blue', 'yellow']
-    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['goalString'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa']
 
 
@@ -338,7 +338,7 @@ def test_instantiate_object_multiple_materials():
     obj = instantiate_object(object_def, object_location)
     assert obj['materials'] == ['test_material_1', 'test_material_2']
     assert obj['color'] == ['blue', 'yellow']
-    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['goalString'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa']
 
 
@@ -367,7 +367,7 @@ def test_instantiate_object_salient_materials():
     }
     obj = instantiate_object(object_def, object_location)
     assert obj['salientMaterials'] == ['fabric', 'wood']
-    assert obj['goal_string'] == 'huge massive fabric wood sofa'
+    assert obj['goalString'] == 'huge massive fabric wood sofa'
     assert obj['info'] == ['huge', 'massive', 'fabric', 'wood', 'sofa']
 
 
@@ -558,7 +558,7 @@ def test_instantiate_object_novel_color():
         }
     }
     obj = instantiate_object(object_def, object_location)
-    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['goalString'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel blue', 'novel yellow']
 
 
@@ -588,7 +588,7 @@ def test_instantiate_object_novel_combination():
         }
     }
     obj = instantiate_object(object_def, object_location)
-    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['goalString'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel blue sofa', 'novel yellow sofa']
 
 
@@ -618,7 +618,7 @@ def test_instantiate_object_novel_shape():
         }
     }
     obj = instantiate_object(object_def, object_location)
-    assert obj['goal_string'] == 'huge massive blue yellow sofa'
+    assert obj['goalString'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel sofa']
 
 
@@ -627,13 +627,13 @@ def test_move_to_location():
     location = {
         'position': {'x': 2, 'y': 0, 'z': 2},
         'rotation': {'x': 0, 'y': 0, 'z': 0},
-        'bounding_box': [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, {'x': 1, 'z': 3}]
+        'boundingBox': [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, {'x': 1, 'z': 3}]
     }
     actual = move_to_location({}, instance, location)
     assert actual == instance
     assert instance['shows'][0]['position'] == {'x': 2, 'y': 0, 'z': 2}
     assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
-    assert instance['shows'][0]['bounding_box'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
+    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
             {'x': 1, 'z': 3}]
 
     definition = {'offset': {'x': 0.1, 'z': -0.5}}
@@ -641,7 +641,7 @@ def test_move_to_location():
     assert actual == instance
     assert instance['shows'][0]['position'] == {'x': 1.9, 'y': 0, 'z': 2.5}
     assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
-    assert instance['shows'][0]['bounding_box'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
+    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
             {'x': 1, 'z': 3}]
 
 

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -10,7 +10,6 @@ from util import finalize_object_definition, instantiate_object, check_same_and_
 
 PACIFIER = {
     "type": "pacifier",
-    "info": ["tiny", "blue", "pacifier"],
     "color": "blue",
     "shape": "pacifier",
     "size": "tiny",
@@ -71,7 +70,8 @@ def test_instantiate_object():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'attributes': ['foo', 'bar'],
         'scale': {'x': 1, 'y': 1, 'z': 1}
@@ -98,7 +98,7 @@ def test_instantiate_object():
     assert obj['novelColor'] is False
     assert obj['novelCombination'] is False
     assert obj['novelShape'] is False
-    assert obj['shape'] == 'sofa'
+    assert obj['shape'] == ['sofa']
     assert obj['size'] == 'huge'
     assert obj['foo'] is True
     assert obj['bar'] is True
@@ -113,13 +113,15 @@ def test_instantiate_object_choose():
         'type': 'sofa_1',
         'chooseSize': [{
             'novelShape': True,
-            'info': ['medium', 'sofa'],
+            'shape': 'sofa',
+            'size': 'medium',
             'attributes': ['moveable'],
             'dimensions': {'x': 0.5, 'y': 0.25, 'z': 0.25},
             'mass': 12.34,
             'scale': {'x': 0.5, 'y': 0.5, 'z': 0.5}
         }, {
-            'info': ['huge', 'sofa'],
+            'shape': 'sofa',
+            'size': 'huge',
             'attributes': [],
             'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
             'mass': 56.78,
@@ -162,7 +164,8 @@ def test_instantiate_object_heavy_moveable():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'attributes': ['moveable'],
         'scale': {'x': 1, 'y': 1, 'z': 1}
@@ -189,7 +192,8 @@ def test_instantiate_object_light_pickupable():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'attributes': ['moveable', 'pickupable'],
         'scale': {'x': 1, 'y': 1, 'z': 1}
@@ -221,7 +225,8 @@ def test_instantiate_object_offset():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
@@ -251,7 +256,8 @@ def test_instantiate_object_rotation():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
@@ -278,7 +284,8 @@ def test_instantiate_object_materials():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
@@ -309,7 +316,8 @@ def test_instantiate_object_multiple_materials():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
@@ -338,7 +346,8 @@ def test_instantiate_object_salient_materials():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
@@ -366,7 +375,8 @@ def test_instantiate_object_size():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': {'x': 1, 'y': 1, 'z': 1},
         'attributes': [],
@@ -528,7 +538,8 @@ def test_instantiate_object_novel_color():
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'novelColor': True,
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': 1.0,
         'attributes': [],
@@ -557,7 +568,8 @@ def test_instantiate_object_novel_combination():
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'novelCombination': True,
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': 1.0,
         'attributes': [],
@@ -586,7 +598,8 @@ def test_instantiate_object_novel_shape():
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
         'novelShape': True,
-        'info': ['huge', 'sofa'],
+        'shape': 'sofa',
+        'size': 'huge',
         'mass': 12.34,
         'scale': 1.0,
         'attributes': [],

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -44,22 +44,24 @@ def test_random_real():
 
 
 def test_finalize_object_definition():
-    object_type = 'type1'
+    dimensions = {'x': 1, 'y': 1, 'z': 1}
     mass = 12.34
     material_category = ['plastic']
     salient_materials = ['plastic', 'hollow']
     object_def = {
-        'type': 'type2',
+        'type': 'type1',
         'mass': 56.78,
-        'choose': [{
-            'type': object_type,
-            'mass': mass,
+        'chooseMaterial': [{
             'materialCategory': material_category,
             'salientMaterials': salient_materials
+        }],
+        'chooseSize': [{
+            'dimensions': dimensions,
+            'mass': mass
         }]
     }
     obj = finalize_object_definition(object_def)
-    assert obj['type'] == object_type
+    assert obj['dimensions'] == dimensions
     assert obj['mass'] == mass
     assert obj['materialCategory'] == material_category
     assert obj['salientMaterials'] == salient_materials
@@ -110,7 +112,7 @@ def test_instantiate_object():
 def test_instantiate_object_choose():
     object_def = {
         'type': 'sofa_1',
-        'choose': [{
+        'chooseSize': [{
             'novel_shape': True,
             'info': ['medium', 'sofa'],
             'attributes': ['moveable'],
@@ -646,20 +648,20 @@ def test_retrieve_full_object_definition_list():
     actual_1 = retrieve_full_object_definition_list(list_1)
     assert len(actual_1) == 1
 
-    list_2 = [{ 'type': 'ball', 'choose': [{ 'mass': 1 }, { 'mass': 2 }] }]
+    list_2 = [{ 'type': 'ball', 'chooseSize': [{ 'mass': 1 }, { 'mass': 2 }] }]
     actual_2 = retrieve_full_object_definition_list(list_2)
     assert len(actual_2) == 2
 
     list_3 = [
         { 'type': 'sofa' },
-        { 'type': 'ball', 'choose': [{ 'mass': 1 }, { 'mass': 2 }] }
+        { 'type': 'ball', 'chooseSize': [{ 'mass': 1 }, { 'mass': 2 }] }
     ]
     actual_3 = retrieve_full_object_definition_list(list_3)
     assert len(actual_3) == 3
 
     list_4 = [
-        { 'type': 'sofa', 'choose': [{ 'mass': 1 }, { 'mass': 3 }] },
-        { 'type': 'ball', 'choose': [{ 'mass': 1 }, { 'mass': 2 }] }
+        { 'type': 'sofa', 'chooseSize': [{ 'mass': 1 }, { 'mass': 3 }] },
+        { 'type': 'ball', 'chooseSize': [{ 'mass': 1 }, { 'mass': 2 }] }
     ]
     actual_4 = retrieve_full_object_definition_list(list_4)
     assert len(actual_4) == 4

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -14,7 +14,6 @@ PACIFIER = {
     "color": "blue",
     "shape": "pacifier",
     "size": "tiny",
-    "mass": 0.125,
     "salientMaterials": ["plastic"],
     "attributes": ["moveable", "pickupable"],
     "dimensions": {
@@ -22,12 +21,13 @@ PACIFIER = {
         "y": 0.04,
         "z": 0.05
     },
+    "mass": 0.125,
     "offset": {
         "x": 0,
         "y": 0.02,
         "z": 0
     },
-    "position_y": 0.01,
+    "positionY": 0.01,
     "scale": {
         "x": 1,
         "y": 1,
@@ -94,11 +94,10 @@ def test_instantiate_object():
     assert obj['dimensions'] == object_def['dimensions']
     assert obj['goal_string'] == 'huge massive sofa'
     assert obj['info'] == ['huge', 'massive', 'sofa']
-    assert obj['info_string'] == 'huge massive sofa'
     assert obj['mass'] == 12.34
-    assert obj['novel_color'] is False
-    assert obj['novel_combination'] is False
-    assert obj['novel_shape'] is False
+    assert obj['novelColor'] is False
+    assert obj['novelCombination'] is False
+    assert obj['novelShape'] is False
     assert obj['shape'] == 'sofa'
     assert obj['size'] == 'huge'
     assert obj['foo'] is True
@@ -113,7 +112,7 @@ def test_instantiate_object_choose():
     object_def = {
         'type': 'sofa_1',
         'chooseSize': [{
-            'novel_shape': True,
+            'novelShape': True,
             'info': ['medium', 'sofa'],
             'attributes': ['moveable'],
             'dimensions': {'x': 0.5, 'y': 0.25, 'z': 0.25},
@@ -143,18 +142,16 @@ def test_instantiate_object_choose():
     assert obj['size'] == 'medium' or obj['size'] == 'huge'
     if obj['size'] == 'medium':
         assert obj['moveable']
-        assert obj['novel_shape']
+        assert obj['novelShape']
         assert obj['info'] == ['medium', 'heavy', 'sofa', 'novel sofa']
-        assert obj['info_string'] == 'medium heavy sofa'
         assert obj['goal_string'] == 'medium heavy sofa'
         assert obj['dimensions'] == {'x': 0.5, 'y': 0.25, 'z': 0.25}
         assert obj['mass'] == 12.34
         assert obj['shows'][0]['scale'] == {'x': 0.5, 'y': 0.5, 'z': 0.5}
     if obj['size'] == 'huge':
         assert 'moveable' not in obj
-        assert not obj['novel_shape']
+        assert not obj['novelShape']
         assert obj['info'] == ['huge', 'massive', 'sofa']
-        assert obj['info_string'] == 'huge massive sofa'
         assert obj['goal_string'] == 'huge massive sofa'
         assert obj['dimensions'] == {'x': 1, 'y': 0.5, 'z': 0.5}
         assert obj['mass'] == 56.78
@@ -185,7 +182,6 @@ def test_instantiate_object_heavy_moveable():
     obj = instantiate_object(object_def, object_location)
     assert obj['goal_string'] == 'huge heavy sofa'
     assert obj['info'] == ['huge', 'heavy', 'sofa']
-    assert obj['info_string'] == 'huge heavy sofa'
     assert obj['moveable'] is True
 
 
@@ -213,7 +209,6 @@ def test_instantiate_object_light_pickupable():
     obj = instantiate_object(object_def, object_location)
     assert obj['goal_string'] == 'huge light sofa'
     assert obj['info'] == ['huge', 'light', 'sofa']
-    assert obj['info_string'] == 'huge light sofa'
     assert obj['moveable'] is True
     assert obj['pickupable'] is True
 
@@ -306,7 +301,6 @@ def test_instantiate_object_materials():
     assert obj['color'] == ['blue', 'yellow']
     assert obj['goal_string'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa']
-    assert obj['info_string'] == 'huge massive blue yellow sofa'
 
 
 def test_instantiate_object_multiple_materials():
@@ -338,7 +332,6 @@ def test_instantiate_object_multiple_materials():
     assert obj['color'] == ['blue', 'yellow']
     assert obj['goal_string'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa']
-    assert obj['info_string'] == 'huge massive blue yellow sofa'
 
 
 def test_instantiate_object_salient_materials():
@@ -367,7 +360,6 @@ def test_instantiate_object_salient_materials():
     assert obj['salientMaterials'] == ['fabric', 'wood']
     assert obj['goal_string'] == 'huge massive fabric wood sofa'
     assert obj['info'] == ['huge', 'massive', 'fabric', 'wood', 'sofa']
-    assert obj['info_string'] == 'huge massive fabric wood sofa'
 
 
 def test_instantiate_object_size():
@@ -535,7 +527,7 @@ def test_instantiate_object_novel_color():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'novel_color': True,
+        'novelColor': True,
         'info': ['huge', 'sofa'],
         'mass': 12.34,
         'scale': 1.0,
@@ -557,7 +549,6 @@ def test_instantiate_object_novel_color():
     obj = instantiate_object(object_def, object_location)
     assert obj['goal_string'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel blue', 'novel yellow']
-    assert obj['info_string'] == 'huge massive blue yellow sofa'
 
 
 def test_instantiate_object_novel_combination():
@@ -565,7 +556,7 @@ def test_instantiate_object_novel_combination():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'novel_combination': True,
+        'novelCombination': True,
         'info': ['huge', 'sofa'],
         'mass': 12.34,
         'scale': 1.0,
@@ -587,7 +578,6 @@ def test_instantiate_object_novel_combination():
     obj = instantiate_object(object_def, object_location)
     assert obj['goal_string'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel blue sofa', 'novel yellow sofa']
-    assert obj['info_string'] == 'huge massive blue yellow sofa'
 
 
 def test_instantiate_object_novel_shape():
@@ -595,7 +585,7 @@ def test_instantiate_object_novel_shape():
     object_def = {
         'type': 'sofa_1',
         'dimensions': {'x': 1, 'y': 0.5, 'z': 0.5},
-        'novel_shape': True,
+        'novelShape': True,
         'info': ['huge', 'sofa'],
         'mass': 12.34,
         'scale': 1.0,
@@ -617,7 +607,6 @@ def test_instantiate_object_novel_shape():
     obj = instantiate_object(object_def, object_location)
     assert obj['goal_string'] == 'huge massive blue yellow sofa'
     assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel sofa']
-    assert obj['info_string'] == 'huge massive blue yellow sofa'
 
 
 def test_move_to_location():


### PR DESCRIPTION
- Split the object definition 'choose' property into multiple separate properties ('chooseMaterial', 'chooseSize', 'chooseType') to reduce redundancy in object definitions.
- Changed object definition properties from snake_case to camelCase for consistency, based on Dean's request.  (This may affect the Eval 3 UI ingest pipeline.)
- Added 'materialCategory', 'shape', 'size', and (if needed) 'color' properties to all object definitions for continuity.
- Removed 'info_string' because it ended up being redundant with 'goal_string'.