### PR TITLE
MCS-38 - Adding linter/autofixer (only in python_api/ for now)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E402, W504
+exclude = python_api/machine_common_sense/__init__.py

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 ignore = E402, W504
-exclude = python_api/machine_common_sense/__init__.py
+exclude = python_api/machine_common_sense/__init__.py,scene_generator,validation,truthing,masks,occluder,hotfix,setup.py,template_playroom.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+files: 'python_api/'
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: check-yaml
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.5.4
+    hooks:
+    -   id: autopep8

--- a/python_api/.vscode/settings.json
+++ b/python_api/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.lintOnSave": true,
+    "python.linting.flake8Args": [
+        "--ignore",
+        "E402,W504",
+        "--exclude",
+        "__init__.py"
+    ],
+    "python.formatting.provider": "autopep8",
+    "python.formatting.autopep8Args": [
+        "--aggressive",
+        "--aggressive",
+        "--ignore",
+        "E402"
+    ],
+    "[python]": {
+        "editor.formatOnSave": true
+    }
+}

--- a/python_api/README.md
+++ b/python_api/README.md
@@ -11,7 +11,7 @@ The latest release of the MCS Python library is `0.0.10`. We will accept Evaluat
 1. Install the required third-party Python libraries:
 
 ```
-pip3 install ai2thor==2.2.0 numpy Pillow
+pip3 install -r requirements.txt
 ```
 
 2. Ensure you've installed `ai2thor` version `2.2.0`:

--- a/python_api/machine_common_sense/README.md
+++ b/python_api/machine_common_sense/README.md
@@ -74,8 +74,8 @@ See https://numpydoc.readthedocs.io/en/latest/format.html
 ## Linting
 
 We are currently using [flake8](https://flake8.pycqa.org/en/latest/) and [autopep8](https://pypi.org/project/autopep8/) for linting and formatting our Python code. This is only enforced within the python_api project for now. Both are [PEP 8](https://www.python.org/dev/peps/pep-0008/) compliant, although we are ignoring the following rules:
-**E402**: Module level import not at top of file
-**W504**: Line break occurred after a binary operator
+- **E402**: Module level import not at top of file
+- **W504**: Line break occurred after a binary operator
 
 A full list of error codes and warnings enforced can be found [here](https://flake8.pycqa.org/en/latest/user/error-codes.html)
 

--- a/python_api/machine_common_sense/README.md
+++ b/python_api/machine_common_sense/README.md
@@ -12,12 +12,7 @@
 2. Install the Python dependencies (I tested on Python v3.6.5)
 
 ```
-pip install ai2thor
-pip install Pillow
-pip install numpy
-pip install autopep8
-pip install flake8
-pip install pre-commit
+pip install -r ../requirements.txt
 ```
 
 3. Run pre-commit install to set up git hook
@@ -75,6 +70,31 @@ Packaging the project is done with the [setup.py](../../setup.py) file located i
 ## Documentation Style Guide
 
 See https://numpydoc.readthedocs.io/en/latest/format.html
+
+## Linting
+
+We are currently using [flake8](https://flake8.pycqa.org/en/latest/) and [autopep8](https://pypi.org/project/autopep8/) for linting and formatting our Python code. This is only enforced within the python_api project for now. Both are [PEP 8](https://www.python.org/dev/peps/pep-0008/) compliant, although we are ignoring the following rules:
+**E402**: Module level import not at top of file
+**W504**: Line break occurred after a binary operator
+
+A full list of error codes and warnings enforced can be found [here](https://flake8.pycqa.org/en/latest/user/error-codes.html)
+
+Both have settings so that they should run on save within Visual Studio Code [settings.json](../.vscode/settings.json) as well as on commit after running `pre-commit install` (see [.pre-commit-config.yaml](../../.pre-commit-config.yaml) and [.flake8](../../.flake8)), but can also be run on the command line:
+
+
+```
+flake8
+```
+
+and
+
+```
+autopep8 --in-place --aggressive --aggressive --recursive <directory>
+```
+or
+```
+autopep8 --in-place --aggressive --aggressive <file>
+```
 
 ## Making GIFs
 

--- a/python_api/machine_common_sense/README.md
+++ b/python_api/machine_common_sense/README.md
@@ -14,7 +14,18 @@
 ```
 pip install ai2thor
 pip install Pillow
+pip install numpy
+pip install autopep8
+pip install flake8
+pip install pre-commit
 ```
+
+3. Run pre-commit install to set up git hook
+
+```
+pre-commit install
+```
+
 
 ## Running
 

--- a/python_api/machine_common_sense/getchHelper.py
+++ b/python_api/machine_common_sense/getchHelper.py
@@ -1,8 +1,10 @@
-# Source: https://stackoverflow.com/questions/510357/python-read-a-single-character-from-the-user 
+# Source:
+# https://stackoverflow.com/questions/510357/python-read-a-single-character-from-the-user
 
 class _Getch:
     """Gets a single character from standard input.  Does not echo to the
 screen."""
+
     def __init__(self):
         try:
             self.impl = _GetchWindows()
@@ -12,15 +14,19 @@ screen."""
             except ImportError:
                 self.impl = _GetchMacCarbon()
 
-    def __call__(self): return self.impl()
+    def __call__(self):
+        return self.impl()
 
 
 class _GetchUnix:
     def __init__(self):
-        import tty, sys
+        import tty  # noqa: F401
+        import sys  # noqa: F401
 
     def __call__(self):
-        import sys, tty, termios
+        import sys
+        import tty
+        import termios
         fd = sys.stdin.fileno()
         old_settings = termios.tcgetattr(fd)
         try:
@@ -33,10 +39,10 @@ class _GetchUnix:
 
 class _GetchWindows:
     def __init__(self):
-        import msvcrt # pylint: disable=import-error
+        import msvcrt  # pylint: disable=import-error # noqa: F401
 
     def __call__(self):
-        import msvcrt # pylint: disable=import-error
+        import msvcrt  # pylint: disable=import-error # noqa: F401
         return msvcrt.getch()
 
 
@@ -47,14 +53,15 @@ class _GetchMacCarbon:
     page http://www.mactech.com/macintosh-c/chap02-1.html was
     very helpful in figuring out how to do this.
     """
+
     def __init__(self):
-        import Carbon # pylint: disable=import-error
+        import Carbon  # pylint: disable=import-error
         # pylint: disable= W0104
-        Carbon.Evt #see if it has this (in Unix, it doesn't)
+        Carbon.Evt  # see if it has this (in Unix, it doesn't)
 
     def __call__(self):
-        import Carbon # pylint: disable=import-error
-        if Carbon.Evt.EventAvail(0x0008)[0]==0: # 0x0008 is the keyDownMask
+        import Carbon  # pylint: disable=import-error
+        if Carbon.Evt.EventAvail(0x0008)[0] == 0:  # 0x0008 is the keyDownMask
             return ''
         else:
             #
@@ -66,7 +73,7 @@ class _GetchMacCarbon:
             # number is converted to an ASCII character with chr() and
             # returned
             #
-            (what, msg, *other)=Carbon.Evt.GetNextEvent(0x0008)[1]
+            (what, msg, *other) = Carbon.Evt.GetNextEvent(0x0008)[1]
             return chr(msg & 0x000000FF)
 
 

--- a/python_api/machine_common_sense/mcs.py
+++ b/python_api/machine_common_sense/mcs.py
@@ -6,6 +6,7 @@ from .mcs_controller_ai2thor import MCS_Controller_AI2THOR
 
 TIME_LIMIT_SECONDS = 60
 
+
 @contextmanager
 def time_limit(seconds):
     def signal_handler(signum, frame):
@@ -17,9 +18,11 @@ def time_limit(seconds):
     finally:
         signal.alarm(0)
 
+
 class MCS:
     """
-    Defines utility functions for machine learning modules to create MCS controllers and handle config data files.
+    Defines utility functions for machine learning modules to create MCS
+    controllers and handle config data files.
     """
 
     """
@@ -36,15 +39,19 @@ class MCS:
     MCS_Controller
     """
     @staticmethod
-    def create_controller(unity_app_file_path, debug=False, enable_noise=False, seed=None):
+    def create_controller(
+            unity_app_file_path,
+            debug=False,
+            enable_noise=False,
+            seed=None):
         # TODO: Toggle between AI2-THOR and other controllers like ThreeDWorld?
         try:
             with time_limit(TIME_LIMIT_SECONDS):
-                return MCS_Controller_AI2THOR(unity_app_file_path, debug, enable_noise, seed)
+                return MCS_Controller_AI2THOR(
+                    unity_app_file_path, debug, enable_noise, seed)
         except Exception as Msg:
             print("create_controller() is Hanging. ", Msg)
             return None
-    
 
     """
     Loads the given JSON config file and returns its data.
@@ -64,11 +71,13 @@ class MCS:
     @staticmethod
     def load_config_json_file(config_json_file_path):
         try:
-            with open(config_json_file_path, encoding='utf-8-sig') as config_json_file_object:
+            with open(config_json_file_path, encoding='utf-8-sig') \
+                    as config_json_file_object:
                 try:
                     return json.load(config_json_file_object), None
                 except ValueError:
-                    return {}, "The given file '" + config_json_file_path + "' does not contain valid JSON."
+                    return {}, "The given file '" + config_json_file_path + \
+                        "' does not contain valid JSON."
         except IOError:
-            return {}, "The given file '" + config_json_file_path + "' cannot be found."
-
+            return {}, "The given file '" + config_json_file_path + \
+                "' cannot be found."

--- a/python_api/machine_common_sense/mcs_action.py
+++ b/python_api/machine_common_sense/mcs_action.py
@@ -1,5 +1,6 @@
 from enum import Enum, unique
 
+
 @unique
 class MCS_Action(Enum):
     CLOSE_OBJECT = "CloseObject"
@@ -22,4 +23,3 @@ class MCS_Action(Enum):
     THROW_OBJECT = "ThrowObject"
     # Pass should always be the last action in the enum.
     PASS = "Pass"
-

--- a/python_api/machine_common_sense/mcs_action_api_desc.py
+++ b/python_api/machine_common_sense/mcs_action_api_desc.py
@@ -1,22 +1,46 @@
 from enum import Enum, unique
 
+
 @unique
 class MCS_Action_API_DESC(Enum):
-    CLOSE_OBJECT = "Close a nearby object. (objectId=string, amount=float (default:1), objectDirectionX=float, objectDirectionY=float, objectDirectionZ=float)"
+    CLOSE_OBJECT = "Close a nearby object. (objectId=string, amount=float " \
+        "(default:1), objectDirectionX=float, objectDirectionY=float, " \
+        "objectDirectionZ=float)"
     CRAWL = "Change pose to 'CRAWLING' (no params)"
     DROP_OBJECT = "Drop an object you are holding. (objectId=string)"
     LIE_DOWN = "Change pose to 'LYING' (rotation=float)"
-    MOVE_AHEAD = "Move yourself ahead based on your current view. (amount=float (default:0.5))"
-    MOVE_BACK = "Move yourself back based on your current view. (amount=float (default:0.5))"
-    MOVE_LEFT = "Move yourself to your left based on your current view. (amount=float (default:0.5))"
-    MOVE_RIGHT = "Move yourself to your right based on your current view. (amount=float (default:0.5))"
-    OPEN_OBJECT = "Open a nearby object. (objectId=string, amount=float (default:1), objectDirectionX=float, objectDirectionY=float, objectDirectionZ=float)"
+    MOVE_AHEAD = "Move yourself ahead based on your current view. " \
+        "(amount=float (default:0.5))"
+    MOVE_BACK = "Move yourself back based on your current view. " \
+        "(amount=float (default:0.5))"
+    MOVE_LEFT = "Move yourself to your left based on your current view. " \
+        "(amount=float (default:0.5))"
+    MOVE_RIGHT = "Move yourself to your right based on your current view. " \
+        "(amount=float(default: 0.5))"
+    OPEN_OBJECT = "Open a nearby object. (objectId=string, " \
+        "amount=float (default:1), objectDirectionX=float, " \
+        "objectDirectionY=float, objectDirectionZ=float)"
     PASS = "Do nothing. (no params)"
-    PICKUP_OBJECT = "Pickup a nearby object and hold it in your hand. (objectId=string, objectDirectionX=float, objectDirectionY=float, objectDirectionZ=float)"
-    PULL_OBJECT = "Pull a nearby object. (objectId=string, rotation=float, horizon=float, force=float (default:0.5), objectDirectionX=float, objectDirectionY=float, objectDirectionZ=float)"
-    PUSH_OBJECT = "Push a nearby object. (objectId=string, rotation=float, horizon=float, force=float (default:0.5), objectDirectionX=float, objectDirectionY=float, objectDirectionZ=float)"
-    PUT_OBJECT = "Place an object you are holding into/onto a nearby receptacle object. (objectId=string, receptacleObjectId=string, receptacleObjectDirectionX=float, receptacleObjectDirectionY=float, receptacleObjectDirectionZ=float)"
-    ROTATE_LOOK = "Rotate your view left/right and/or up/down based on your current view. (rotation=float, horizon=float)"
-    ROTATE_OBJECT_IN_HAND = "Rotate a held object. (objectId=string, rotationX=float, rotationY=float, rotationZ=float, , objectDirectionX=float, objectDirectionY=float, objectDirectionZ=float)"
+    PICKUP_OBJECT = "Pickup a nearby object and hold it in your hand. " \
+        "(objectId=string, objectDirectionX=float, objectDirectionY=float, " \
+        "objectDirectionZ=float)"
+    PULL_OBJECT = "Pull a nearby object. (objectId=string, rotation=float, " \
+        "horizon=float, force=float (default:0.5), objectDirectionX=float, " \
+        "objectDirectionY=float, objectDirectionZ=float)"
+    PUSH_OBJECT = "Push a nearby object. (objectId=string, rotation=float, " \
+        "horizon=float, force=float (default:0.5), objectDirectionX=float, " \
+        "objectDirectionY=float, objectDirectionZ=float)"
+    PUT_OBJECT = "Place an object you are holding into/onto a nearby " \
+        "receptacle object. (objectId=string, receptacleObjectId=string, " \
+        "receptacleObjectDirectionX=float, receptacleObjectDirectionY=float," \
+        " receptacleObjectDirectionZ=float)"
+    ROTATE_LOOK = "Rotate your view left/right and/or up/down based on your " \
+        "current view. (rotation=float, horizon=float)"
+    ROTATE_OBJECT_IN_HAND = "Rotate a held object. (objectId=string, " \
+        "rotationX=float, rotationY=float, rotationZ=float, " \
+        "objectDirectionX=float, objectDirectionY=float, " \
+        "objectDirectionZ=float)"
     STAND = "Change pose to 'STANDING' (no params)"
-    THROW_OBJECT = "Throw an object you are holding. (objectId=string, objectDirectionX=float, objectDirectionY=float, objectDirectionZ=float, force=float (default:0.5))"
+    THROW_OBJECT = "Throw an object you are holding. (objectId=string, " \
+        "objectDirectionX=float, objectDirectionY=float, " \
+        "objectDirectionZ=float, force=float (default:0.5))"

--- a/python_api/machine_common_sense/mcs_action_keys.py
+++ b/python_api/machine_common_sense/mcs_action_keys.py
@@ -1,5 +1,6 @@
 from enum import Enum, unique
 
+
 @unique
 class MCS_Action_Keys(Enum):
     CLOSE_OBJECT = "1"

--- a/python_api/machine_common_sense/mcs_controller.py
+++ b/python_api/machine_common_sense/mcs_controller.py
@@ -1,14 +1,17 @@
 from .mcs_step_output import MCS_Step_Output
 import random
 
+
 class MCS_Controller:
     """
-    Starts and ends scenes, runs actions on each step, and returns scene output data.
+    Starts and ends scenes, runs actions on each step, and returns scene
+    output data.
 
     Parameters
     ----------
     enable_noise : boolean, optional
-        An optional flag to enable noise in the system for move, amount, force actions
+        An optional flag to enable noise in the system for move, amount,
+        force actions
     """
 
     def __init__(self, enable_noise=False):
@@ -20,16 +23,20 @@ class MCS_Controller:
     Parameters
     ----------
     classification : string, optional
-        The selected classification for "classify" goals.  Is not required for other goals.
+        The selected classification for "classify" goals.  Is not required
+        for other goals.
     confidence : float, optional
-        The classification confidence between 0 and 1 for "classify" goals.  Is not required for other goals.
+        The classification confidence between 0 and 1 for "classify" goals.
+        Is not required for other goals.
     """
+
     def end_scene(self, classification, confidence):
         # TODO Override
         pass
 
     """
-    Starts a new scene using the given scene configuration data dict and returns the scene output data object.
+    Starts a new scene using the given scene configuration data dict and
+    returns the scene output data object.
 
     Parameters
     ----------
@@ -39,15 +46,17 @@ class MCS_Controller:
     Returns
     -------
     MCS_Step_Output
-        The output data object from the start of the scene (the output from an "Initialize" action).
+        The output data object from the start of the scene (the output from an
+        "Initialize" action).
     """
+
     def start_scene(self, config_data):
         # TODO Override
         return MCS_Step_Output()
 
-
     """
-    Runs the given action within the current scene and unpauses the scene's physics simulation for a few frames.
+    Runs the given action within the current scene and unpauses the scene's
+    physics simulation for a few frames.
 
     Parameters
     ----------
@@ -59,20 +68,23 @@ class MCS_Controller:
     Returns
     -------
     MCS_Step_Output
-        The output data object from after the action and the physics simulation were run.
+        The output data object from after the action and the physics
+        simulation were run.
     """
+
     def step(self, action, **kwargs):
         # TODO Override
         return MCS_Step_Output()
 
     """
-    Calculates a random value float between -0.05 and 0.05 to add some noise into move, amount, force actions
+    Calculates a random value float between -0.05 and 0.05 to add some noise
+    into move, amount, force actions
 
     Returns
     -------
     float
         A float value for the amount of noise that will be applied to actions.
     """
+
     def generate_noise(self):
         return random.uniform(-0.5, 0.5)
-

--- a/python_api/machine_common_sense/mcs_controller_ai2thor.py
+++ b/python_api/machine_common_sense/mcs_controller_ai2thor.py
@@ -3,8 +3,6 @@ import datetime
 import glob
 import io
 import json
-import math
-import numpy
 import os
 import random
 import sys
@@ -14,9 +12,11 @@ from PIL import Image
 import ai2thor.controller
 import ai2thor.server
 
-# How far the player can reach.  I think this value needs to be bigger than the MAX_MOVE_DISTANCE or else the
-# player may not be able to move into a position to reach some objects (it may be mathematically impossible).
-# TODO Reduce this number once the player can crouch down to reach and pickup small objects on the floor.
+# How far the player can reach.  I think this value needs to be bigger
+# than the MAX_MOVE_DISTANCE or else the player may not be able to move
+# into a position to reach some objects (it may be mathematically impossible).
+# TODO Reduce this number once the player can crouch down to reach and
+# pickup small objects on the floor.
 MAX_REACH_DISTANCE = 1.0
 
 # How far the player can move with a single step.
@@ -28,7 +28,6 @@ PERFORMER_CAMERA_Y = 0.4625
 from .mcs_action import MCS_Action
 from .mcs_controller import MCS_Controller
 from .mcs_goal import MCS_Goal
-from .mcs_goal_category import MCS_Goal_Category
 from .mcs_object import MCS_Object
 from .mcs_pose import MCS_Pose
 from .mcs_return_status import MCS_Return_Status
@@ -37,14 +36,20 @@ from .mcs_scene_history import MCS_Scene_History
 from .mcs_step_output import MCS_Step_Output
 from .mcs_util import MCS_Util
 
-# From https://github.com/NextCenturyCorporation/ai2thor/blob/master/ai2thor/server.py#L232-L240
+# From https://github.com/NextCenturyCorporation/ai2thor/blob/master/ai2thor/server.py#L232-L240 # noqa: E501
+
+
 def __image_depth_override(self, image_depth_data, **kwargs):
-    # The MCS depth shader in Unity is completely different now, so override the original AI2-THOR depth image code.
+    # The MCS depth shader in Unity is completely different now, so override
+    # the original AI2-THOR depth image code.
     # Just return what Unity sends us.
-    image_depth = ai2thor.server.read_buffer_image(image_depth_data, self.screen_width, self.screen_height, **kwargs)
+    image_depth = ai2thor.server.read_buffer_image(
+        image_depth_data, self.screen_width, self.screen_height, **kwargs)
     return image_depth
 
+
 ai2thor.server.Event._image_depth = __image_depth_override
+
 
 class MCS_Controller_AI2THOR(MCS_Controller):
     """
@@ -55,19 +60,24 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
     ACTION_LIST = [item.value for item in MCS_Action]
 
-    # Please keep the aspect ratio as 3:2 because the IntPhys scenes are built on this assumption.
+    # Please keep the aspect ratio as 3:2 because the IntPhys scenes are built
+    # on this assumption.
     SCREEN_HEIGHT = 400
     SCREEN_WIDTH = 600
 
-    # AI2-THOR creates a square grid across the scene that is uses for "snap-to-grid" movement.
-    # (This value may not really matter because we set continuous to True in the step input.)
+    # AI2-THOR creates a square grid across the scene that is
+    # uses for "snap-to-grid" movement. (This value may not
+    # really matter because we set continuous to True in
+    # the step input.)
     GRID_SIZE = 0.1
 
-    # The amount of force to offset force values, that seems appropriate for a baby
-    # TODO Check with psych team about this about what we should use for a baby, defaulting to 50 now
+    # The amount of force to offset force values, that seems
+    # appropriate for a baby
+    # TODO Check with psych team about this about what we
+    # should use for a baby, defaulting to 50 now
     MAX_BABY_FORCE = 50.0
 
-    DEFAULT_HORIZON= 0
+    DEFAULT_HORIZON = 0
     DEFAULT_ROTATION = 0
     DEFAULT_FORCE = 0.5
     DEFAULT_AMOUNT = 0.5
@@ -95,8 +105,10 @@ class MCS_Controller_AI2THOR(MCS_Controller):
     RECEPTACLE_DIRECTION_Y = 'receptacleObjectDirectionY'
     RECEPTACLE_DIRECTION_Z = 'receptacleObjectDirectionZ'
 
-    # Hard coding actions that effect MoveMagnitude so the appropriate value is set based off of the action
-    # TODO: Move this to an enum or some place, so that you can determine special move interactions that way
+    # Hard coding actions that effect MoveMagnitude so the appropriate
+    # value is set based off of the action
+    # TODO: Move this to an enum or some place, so that you can determine
+    # special move interactions that way
     FORCE_ACTIONS = ["ThrowObject", "PushObject", "PullObject"]
     OBJECT_MOVE_ACTIONS = ["CloseObject", "OpenObject"]
     MOVE_ACTIONS = ["MoveAhead", "MoveLeft", "MoveRight", "MoveBack"]
@@ -113,17 +125,22 @@ class MCS_Controller_AI2THOR(MCS_Controller):
     CONFIG_AWS_ACCESS_KEY_ID = 'aws_access_key_id'
     CONFIG_AWS_SECRET_ACCESS_KEY = 'aws_secret_access_key'
     CONFIG_METADATA_MODE = 'metadata'
-    CONFIG_METADATA_MODE_FULL = 'full' # Normal metadata plus metadata for all hidden objects
-    CONFIG_METADATA_MODE_NO_NAVIGATION = 'no_navigation' # No navigation metadata like 3D coordinates
-    CONFIG_METADATA_MODE_NO_VISION = 'no_vision' # No vision (image feature) metadata, except for the images
-    CONFIG_METADATA_MODE_NONE = 'none' # No metadata, except for the images and haptic/audio feedback
+    # Normal metadata plus metadata for all hidden objects
+    CONFIG_METADATA_MODE_FULL = 'full'
+    # No navigation metadata like 3D coordinates
+    CONFIG_METADATA_MODE_NO_NAVIGATION = 'no_navigation'
+    # No vision (image feature) metadata, except for the images
+    CONFIG_METADATA_MODE_NO_VISION = 'no_vision'
+    # No metadata, except for the images and haptic/audio feedback
+    CONFIG_METADATA_MODE_NONE = 'none'
     CONFIG_SAVE_IMAGES_TO_S3_BUCKET = 'save_images_to_s3_bucket'
     CONFIG_SAVE_IMAGES_TO_S3_FOLDER = 'save_images_to_s3_folder'
     CONFIG_TEAM = 'team'
 
-    def __init__(self, unity_app_file_path, debug=False, enable_noise=False, seed=None):
+    def __init__(self, unity_app_file_path, debug=False,
+                 enable_noise=False, seed=None):
         super().__init__()
-        
+
         self._controller = ai2thor.controller.Controller(
             quality='Medium',
             fullscreen=False,
@@ -135,29 +152,32 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             # Set the name of our Scene in our Unity app
             scene='MCS',
             logs=True,
-            # This constructor always initializes a scene, so add a scene config to ensure it doesn't error
+            # This constructor always initializes a scene, so add a scene
+            # config to ensure it doesn't error
             sceneConfig={
                 "objects": []
             }
         )
-        
+
         self.on_init(debug, enable_noise, seed)
 
     def on_init(self, debug=False, enable_noise=False, seed=None):
-        
-        self.__debug_to_file = True if (debug is True or debug is 'file') else False
-        self.__debug_to_terminal = True if (debug is True or debug is 'terminal') else False
+
+        self.__debug_to_file = True if (
+            debug is True or debug == 'file') else False
+        self.__debug_to_terminal = True if (
+            debug is True or debug == 'terminal') else False
 
         self.__enable_noise = enable_noise
         self.__seed = seed
-        
+
         if self.__seed:
             random.seed(self.__seed)
 
         self._goal = MCS_Goal()
         self.__head_tilt = 0.0
         self.__history_list = []
-        self.__output_folder = None # Save output image files to debug
+        self.__output_folder = None  # Save output image files to debug
         self.__scene_configuration = None
         self.__scene_history_file = None
         self.__step_number = 0
@@ -168,21 +188,29 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
         self._config = self.read_config_file()
 
-        if self.CONFIG_AWS_ACCESS_KEY_ID in self._config and self.CONFIG_AWS_SECRET_ACCESS_KEY in self._config:
+        if ((self.CONFIG_AWS_ACCESS_KEY_ID in self._config) and
+                (self.CONFIG_AWS_SECRET_ACCESS_KEY in self._config)):
             if not os.path.exists(self.AWS_CREDENTIALS_FOLDER):
                 os.makedirs(self.AWS_CREDENTIALS_FOLDER)
-            # From https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html
+            # From https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html # noqa: E501
             with open(self.AWS_CREDENTIALS_FILE, 'w') as credentials_file:
-                credentials_file.write('[default]\n' + self.AWS_ACCESS_KEY_ID + ' = ' + \
-                        self._config[self.CONFIG_AWS_ACCESS_KEY_ID] + '\n' + self.AWS_SECRET_ACCESS_KEY + ' = ' + \
-                        self._config[self.CONFIG_AWS_SECRET_ACCESS_KEY] + '\n')
+                credentials_file.write(
+                    '[default]\n' +
+                    self.AWS_ACCESS_KEY_ID +
+                    ' = ' +
+                    self._config[self.CONFIG_AWS_ACCESS_KEY_ID] +
+                    '\n' +
+                    self.AWS_SECRET_ACCESS_KEY +
+                    ' = ' +
+                    self._config[self.CONFIG_AWS_SECRET_ACCESS_KEY] +
+                    '\n'
+                )
 
         if self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET in self._config:
             if 'boto3' not in sys.modules:
                 import boto3
-                from botocore.exceptions import ClientError
+                from botocore.exceptions import ClientError  # noqa: F401
                 self.__s3_client = boto3.client('s3')
-
 
     def get_seed_value(self):
         return self.__seed
@@ -191,16 +219,19 @@ class MCS_Controller_AI2THOR(MCS_Controller):
     def write_history_file(self, history_string):
         if self.__scene_history_file:
             with open(self.__scene_history_file, "a+") as history_file:
-                history_file.write(json.dumps(json.loads(history_string)) + '\n')
+                history_file.write(json.dumps(
+                    json.loads(history_string)) + '\n')
 
     # Override
     def end_scene(self, classification, confidence):
-        history_item = '{"classification": ' + classification + ', "confidence": ' + str(confidence) + '}'
+        history_item = '{"classification": ' + classification + \
+            ', "confidence": ' + str(confidence) + '}'
         self.__history_list.append(history_item)
         self.write_history_file(history_item)
 
         super().end_scene(classification, confidence)
-        # TODO MCS-54 Save classification, confidence, and list of actions (steps) taken in this scene for scoring (maybe save to file?)
+        # TODO MCS-54 Save classification, confidence, and list of actions
+        # (steps) taken in this scene for scoring (maybe save to file?)
         pass
 
     # Override
@@ -214,9 +245,12 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         if 'screenshot' in config_data and config_data['screenshot']:
             self.__scene_history_file = None
         else:
-            self.__scene_history_file = os.path.join(self.HISTORY_DIRECTORY, config_data['name'].replace('.json','') + "-" + \
-                    self.generate_time() + ".txt")
-        skip_preview_phase = True if 'goal' in config_data and 'skip_preview_phase' in config_data['goal'] else False
+            self.__scene_history_file = os.path.join(
+                self.HISTORY_DIRECTORY, config_data['name'].replace(
+                    '.json', '') + "-" + self.generate_time() + ".txt")
+        skip_preview_phase = (True if 'goal' in config_data and
+                              'skip_preview_phase' in config_data['goal']
+                              else False)
 
         if self.__debug_to_file and config_data['name'] is not None:
             os.makedirs('./' + config_data['name'], exist_ok=True)
@@ -225,10 +259,12 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             for file_path in file_list:
                 os.remove(file_path)
 
-        output = self.wrap_output(self._controller.step(self.wrap_step(action='Initialize', sceneConfig=config_data)))
+        output = self.wrap_output(self._controller.step(
+            self.wrap_step(action='Initialize', sceneConfig=config_data)))
 
         if not skip_preview_phase:
-            if self._goal is not None and self._goal.last_preview_phase_step > 0:
+            if (self._goal is not None and
+                    self._goal.last_preview_phase_step > 0):
                 image_list = output.image_list
                 depth_mask_list = output.depth_mask_list
                 object_mask_list = output.object_mask_list
@@ -240,7 +276,8 @@ class MCS_Controller_AI2THOR(MCS_Controller):
                     output = self.step('Pass')
                     image_list = image_list + output.image_list
                     depth_mask_list = depth_mask_list + output.depth_mask_list
-                    object_mask_list = object_mask_list + output.object_mask_list
+                    object_mask_list = (object_mask_list +
+                                        output.object_mask_list)
 
                 if self.__debug_to_terminal:
                     print('ENDING PREVIEW PHASE')
@@ -253,26 +290,38 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
         return output
 
-    # TODO: may need to reevaluate validation strategy/error handling in the future
+    # TODO: may need to reevaluate validation strategy/error handling in the
+    # future
     """
     Need a validation/conversion step for what ai2thor will accept as input
     to keep parameters more simple for the user (in this case, wrapping
     rotation degrees into an object)
     """
+
     def validate_and_convert_params(self, action, **kwargs):
         moveMagnitude = MAX_MOVE_DISTANCE
         rotation = kwargs.get(self.ROTATION_KEY, self.DEFAULT_ROTATION)
         horizon = kwargs.get(self.HORIZON_KEY, self.DEFAULT_HORIZON)
-        amount = kwargs.get(self.AMOUNT_KEY,
-            self.DEFAULT_OBJECT_MOVE_AMOUNT if action in self.OBJECT_MOVE_ACTIONS else self.DEFAULT_AMOUNT)
+        amount = kwargs.get(
+            self.AMOUNT_KEY,
+            self.DEFAULT_OBJECT_MOVE_AMOUNT
+            if action in self.OBJECT_MOVE_ACTIONS
+            else self.DEFAULT_AMOUNT
+        )
         force = kwargs.get(self.FORCE_KEY, self.DEFAULT_FORCE)
 
-        objectDirectionX = kwargs.get(self.OBJECT_DIRECTION_X_KEY, self.DEFAULT_DIRECTION)
-        objectDirectionY = kwargs.get(self.OBJECT_DIRECTION_Y_KEY, self.DEFAULT_DIRECTION)
-        objectDirectionZ = kwargs.get(self.OBJECT_DIRECTION_Z_KEY, self.DEFAULT_DIRECTION)
-        receptacleObjectDirectionX = kwargs.get(self.RECEPTACLE_DIRECTION_X, self.DEFAULT_DIRECTION)
-        receptacleObjectDirectionY = kwargs.get(self.RECEPTACLE_DIRECTION_Y, self.DEFAULT_DIRECTION)
-        receptacleObjectDirectionZ = kwargs.get(self.RECEPTACLE_DIRECTION_Z, self.DEFAULT_DIRECTION)
+        objectDirectionX = kwargs.get(
+            self.OBJECT_DIRECTION_X_KEY, self.DEFAULT_DIRECTION)
+        objectDirectionY = kwargs.get(
+            self.OBJECT_DIRECTION_Y_KEY, self.DEFAULT_DIRECTION)
+        objectDirectionZ = kwargs.get(
+            self.OBJECT_DIRECTION_Z_KEY, self.DEFAULT_DIRECTION)
+        receptacleObjectDirectionX = kwargs.get(
+            self.RECEPTACLE_DIRECTION_X, self.DEFAULT_DIRECTION)
+        receptacleObjectDirectionY = kwargs.get(
+            self.RECEPTACLE_DIRECTION_Y, self.DEFAULT_DIRECTION)
+        receptacleObjectDirectionZ = kwargs.get(
+            self.RECEPTACLE_DIRECTION_Z, self.DEFAULT_DIRECTION)
 
         # Check params that should be numbers
         if not MCS_Util.is_number(rotation, self.ROTATION_KEY):
@@ -282,7 +331,8 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             horizon = self.DEFAULT_HORIZON
 
         if not MCS_Util.is_number(amount, self.AMOUNT_KEY):
-            # The default for open/close is 1, the default for "Move" actions is 0.5
+            # The default for open/close is 1, the default for "Move" actions
+            # is 0.5
             if action in self.OBJECT_MOVE_ACTIONS:
                 amount = self.DEFAULT_OBJECT_MOVE_AMOUNT
             else:
@@ -292,32 +342,59 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             force = self.DEFAULT_FORCE
 
         # Check object directions are numbers
-        if not MCS_Util.is_number(objectDirectionX, self.OBJECT_DIRECTION_X_KEY):
+        if not MCS_Util.is_number(
+                objectDirectionX,
+                self.OBJECT_DIRECTION_X_KEY):
             objectDirectionX = self.DEFAULT_DIRECTION
 
-        if not MCS_Util.is_number(objectDirectionY, self.OBJECT_DIRECTION_Y_KEY):
+        if not MCS_Util.is_number(
+                objectDirectionY,
+                self.OBJECT_DIRECTION_Y_KEY):
             objectDirectionY = self.DEFAULT_DIRECTION
 
-        if not MCS_Util.is_number(objectDirectionZ, self.OBJECT_DIRECTION_Z_KEY):
+        if not MCS_Util.is_number(
+                objectDirectionZ,
+                self.OBJECT_DIRECTION_Z_KEY):
             objectDirectionZ = self.DEFAULT_DIRECTION
 
         # Check receptacle directions are numbers
-        if not MCS_Util.is_number(receptacleObjectDirectionX, self.RECEPTACLE_DIRECTION_X):
+        if not MCS_Util.is_number(
+                receptacleObjectDirectionX,
+                self.RECEPTACLE_DIRECTION_X):
             receptacleObjectDirectionX = self.DEFAULT_DIRECTION
 
-        if not MCS_Util.is_number(receptacleObjectDirectionY, self.RECEPTACLE_DIRECTION_Y):
+        if not MCS_Util.is_number(
+                receptacleObjectDirectionY,
+                self.RECEPTACLE_DIRECTION_Y):
             receptacleObjectDirectionY = self.DEFAULT_DIRECTION
 
-        if not MCS_Util.is_number(receptacleObjectDirectionZ, self.RECEPTACLE_DIRECTION_Z):
+        if not MCS_Util.is_number(
+                receptacleObjectDirectionZ,
+                self.RECEPTACLE_DIRECTION_Z):
             receptacleObjectDirectionZ = self.DEFAULT_DIRECTION
 
         # Check that params that should fall in a range are in that range
-        horizon = MCS_Util.is_in_range(horizon, self.MIN_HORIZON, self.MAX_HORIZON, self.DEFAULT_HORIZON, \
-                self.HORIZON_KEY)
-        amount = MCS_Util.is_in_range(amount, self.MIN_AMOUNT, self.MAX_AMOUNT, self.DEFAULT_AMOUNT, self.AMOUNT_KEY)
-        force = MCS_Util.is_in_range(force, self.MIN_FORCE, self.MAX_FORCE, self.DEFAULT_FORCE, self.FORCE_KEY)
+        horizon = MCS_Util.is_in_range(
+            horizon,
+            self.MIN_HORIZON,
+            self.MAX_HORIZON,
+            self.DEFAULT_HORIZON,
+            self.HORIZON_KEY)
+        amount = MCS_Util.is_in_range(
+            amount,
+            self.MIN_AMOUNT,
+            self.MAX_AMOUNT,
+            self.DEFAULT_AMOUNT,
+            self.AMOUNT_KEY)
+        force = MCS_Util.is_in_range(
+            force,
+            self.MIN_FORCE,
+            self.MAX_FORCE,
+            self.DEFAULT_FORCE,
+            self.FORCE_KEY)
 
-        # TODO Consider the current "head tilt" value while validating the input "horizon" value.
+        # TODO Consider the current "head tilt" value while validating the
+        # input "horizon" value.
 
         # Set the Move Magnitude to the appropriate amount based on the action
         if action in self.FORCE_ACTIONS:
@@ -362,52 +439,72 @@ class MCS_Controller_AI2THOR(MCS_Controller):
     def step(self, action, **kwargs):
         super().step(action, **kwargs)
 
-        if self._goal.last_step is not None and self._goal.last_step == self.__step_number:
-            print("MCS Warning: You have passed the last step for this scene. Ignoring your action. " + \
-                    "Please call controller.end_scene() now.")
+        if (self._goal.last_step is not None and
+                self._goal.last_step == self.__step_number):
+            print(
+                "MCS Warning: You have passed the last step for this scene. " +
+                "Ignoring your action. Please call controller.end_scene() " +
+                "now.")
             return None
 
         if ',' in action:
             action, kwargs = MCS_Util.input_to_action_and_params(action)
 
         action_list = self.retrieve_action_list(self._goal, self.__step_number)
-        if not action in action_list:
-            print("MCS Warning: The given action '" + action + "' is not valid. Ignoring your action. " + \
-                    "Please call controller.step() with a valid action.")
-            print("Actions (Step " + str(self.__step_number) + "): " + ", ".join(action_list))
+        if action not in action_list:
+            print(
+                "MCS Warning: The given action '" +
+                action +
+                "' is not valid. Ignoring your action. " +
+                "Please call controller.step() with a valid action.")
+            print("Actions (Step " + str(self.__step_number) + "): " +
+                  ", ".join(action_list))
             return None
 
         self.__step_number += 1
 
         if self.__debug_to_terminal:
-            print("===============================================================================")
+            print(
+                "================================================"
+                "===============================")
             print("STEP: " + str(self.__step_number))
             print("ACTION: " + action)
 
         params = self.validate_and_convert_params(action, **kwargs)
 
-        # Only call mcs_action_to_ai2thor_action AFTER calling validate_and_convert_params
+        # Only call mcs_action_to_ai2thor_action AFTER calling
+        # validate_and_convert_params
         action = self.mcs_action_to_ai2thor_action(action)
 
-        if self._goal.last_step is not None and self._goal.last_step == self.__step_number:
-            print("MCS Warning: This is your last step for this scene. All your future actions will be skipped. " + \
-                    "Please call controller.end_scene() now.")
+        if (self._goal.last_step is not None and
+                self._goal.last_step == self.__step_number):
+            print(
+                "MCS Warning: This is your last step for this scene. All " +
+                "your future actions will be skipped. Please call " +
+                "controller.end_scene() now.")
 
-        output = self.wrap_output(self._controller.step(self.wrap_step(action=action, **params)))
+        output = self.wrap_output(self._controller.step(
+            self.wrap_step(action=action, **params)))
 
         output_copy = copy.deepcopy(output)
         del output_copy.depth_mask_list
         del output_copy.image_list
         del output_copy.object_mask_list
-        history_item = MCS_Scene_History(step=self.__step_number, action=action, args=kwargs, params=params, \
-                output=output_copy)
+        history_item = MCS_Scene_History(
+            step=self.__step_number,
+            action=action,
+            args=kwargs,
+            params=params,
+            output=output_copy)
         self.__history_list.append(history_item)
         filtered_history_item = self.filter_history_images(history_item)
         self.write_history_file(str(filtered_history_item))
 
         return output
 
-    def filter_history_images(self, history: MCS_Scene_History) -> MCS_Scene_History:
+    def filter_history_images(
+            self,
+            history: MCS_Scene_History) -> MCS_Scene_History:
         '''Remove the images from the history'''
         if 'target' in history.output.goal.metadata.keys():
             del history.output.goal.metadata['target']['image']
@@ -422,7 +519,8 @@ class MCS_Controller_AI2THOR(MCS_Controller):
 
     def mcs_action_to_ai2thor_action(self, action):
         if action == MCS_Action.CLOSE_OBJECT.value:
-            # The AI2-THOR Python library has buggy error checking specifically for the CloseObject action,
+            # The AI2-THOR Python library has buggy error checking
+            # specifically for the CloseObject action,
             # so just use our own custom action here.
             return "MCSCloseObject"
 
@@ -430,7 +528,8 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             return "DropHandObject"
 
         if action == MCS_Action.OPEN_OBJECT.value:
-            # The AI2-THOR Python library has buggy error checking specifically for the OpenObject action,
+            # The AI2-THOR Python library has buggy error checking
+            # specifically for the OpenObject action,
             # so just use our own custom action here.
             return "MCSOpenObject"
 
@@ -452,22 +551,45 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         return {}
 
     def restrict_goal_output_metadata(self, goal_output):
-        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+        mode = (
+            self._config[self.CONFIG_METADATA_MODE]
+            if self.CONFIG_METADATA_MODE in self._config
+            else ''
+        )
 
-        if mode == self.CONFIG_METADATA_MODE_NO_VISION or mode == self.CONFIG_METADATA_MODE_NONE:
-            if 'target' in goal_output.metadata and 'image' in goal_output.metadata['target']:
+        if (
+            mode == self.CONFIG_METADATA_MODE_NO_VISION or
+            mode == self.CONFIG_METADATA_MODE_NONE
+        ):
+            if (
+                'target' in goal_output.metadata and
+                'image' in goal_output.metadata['target']
+            ):
                 goal_output.metadata['target']['image'] = None
-            if 'target_1' in goal_output.metadata and 'image' in goal_output.metadata['target_1']:
+            if (
+                'target_1' in goal_output.metadata and
+                'image' in goal_output.metadata['target_1']
+            ):
                 goal_output.metadata['target_1']['image'] = None
-            if 'target_2' in goal_output.metadata and 'image' in goal_output.metadata['target_2']:
+            if (
+                'target_2' in goal_output.metadata and
+                'image' in goal_output.metadata['target_2']
+            ):
                 goal_output.metadata['target_2']['image'] = None
 
         return goal_output
 
     def restrict_object_output_metadata(self, object_output):
-        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+        mode = (
+            self._config[self.CONFIG_METADATA_MODE]
+            if self.CONFIG_METADATA_MODE in self._config
+            else ''
+        )
 
-        if mode == self.CONFIG_METADATA_MODE_NO_VISION or mode == self.CONFIG_METADATA_MODE_NONE:
+        if (
+            mode == self.CONFIG_METADATA_MODE_NO_VISION or
+            mode == self.CONFIG_METADATA_MODE_NONE
+        ):
             object_output.color = None
             object_output.dimensions = None
             object_output.direction = None
@@ -477,16 +599,26 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             object_output.shape = None
             object_output.texture_color_list = None
 
-        if mode == self.CONFIG_METADATA_MODE_NO_NAVIGATION or mode == self.CONFIG_METADATA_MODE_NONE:
+        if (
+            mode == self.CONFIG_METADATA_MODE_NO_NAVIGATION or
+            mode == self.CONFIG_METADATA_MODE_NONE
+        ):
             object_output.position = None
             object_output.rotation = None
 
         return object_output
 
     def restrict_step_output_metadata(self, step_output):
-        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+        mode = (
+            self._config[self.CONFIG_METADATA_MODE]
+            if self.CONFIG_METADATA_MODE in self._config
+            else ''
+        )
 
-        if mode == self.CONFIG_METADATA_MODE_NO_VISION or mode == self.CONFIG_METADATA_MODE_NONE:
+        if (
+            mode == self.CONFIG_METADATA_MODE_NO_VISION or
+            mode == self.CONFIG_METADATA_MODE_NONE
+        ):
             step_output.camera_aspect_ratio = None
             step_output.camera_clipping_planes = None
             step_output.camera_field_of_view = None
@@ -494,7 +626,10 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             step_output.depth_mask_list = []
             step_output.object_mask_list = []
 
-        if mode == self.CONFIG_METADATA_MODE_NO_NAVIGATION or mode == self.CONFIG_METADATA_MODE_NONE:
+        if (
+            mode == self.CONFIG_METADATA_MODE_NO_NAVIGATION or
+            mode == self.CONFIG_METADATA_MODE_NONE
+        ):
             step_output.position = None
             step_output.rotation = None
 
@@ -512,22 +647,38 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         return self.ACTION_LIST
 
     def retrieve_goal(self, scene_configuration):
-        goal_config = scene_configuration['goal'] if 'goal' in scene_configuration else {}
+        goal_config = (
+            scene_configuration['goal']
+            if 'goal' in scene_configuration
+            else {}
+        )
+
         if 'category' in goal_config:
             # Backwards compatibility
             goal_config['metadata']['category'] = goal_config['category']
 
         return self.restrict_goal_output_metadata(MCS_Goal(
-            action_list=(goal_config['action_list'] if 'action_list' in goal_config else None),
-            category=(goal_config['category'] if 'category' in goal_config else ''),
-            description=(goal_config['description'] if 'description' in goal_config else ''),
-            domain_list=(goal_config['domain_list'] if 'domain_list' in goal_config else []),
-            info_list=(goal_config['info_list'] if 'type_list' in goal_config else []),
-            last_preview_phase_step=(goal_config['last_preview_phase_step'] if 'last_preview_phase_step' \
-                    in goal_config else 0),
-            last_step=(goal_config['last_step'] if 'last_step' in goal_config else None),
-            type_list=(goal_config['type_list'] if 'type_list' in goal_config else []),
-            metadata=(goal_config['metadata'] if 'metadata' in goal_config else {})
+            action_list=(goal_config['action_list']
+                         if 'action_list' in goal_config else None),
+            category=(goal_config['category']
+                      if 'category' in goal_config else ''),
+            description=(goal_config['description']
+                         if 'description' in goal_config else ''),
+            domain_list=(goal_config['domain_list']
+                         if 'domain_list' in goal_config else []),
+            info_list=(goal_config['info_list']
+                       if 'type_list' in goal_config else []),
+            last_preview_phase_step=(
+                goal_config['last_preview_phase_step']
+                if 'last_preview_phase_step' in goal_config
+                else 0
+            ),
+            last_step=(goal_config['last_step']
+                       if 'last_step' in goal_config else None),
+            type_list=(goal_config['type_list']
+                       if 'type_list' in goal_config else []),
+            metadata=(goal_config['metadata']
+                      if 'metadata' in goal_config else {})
         ))
 
     def retrieve_head_tilt(self, scene_event):
@@ -537,51 +688,100 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         return scene_event.metadata['agent']['rotation']['y']
 
     def retrieve_object_colors(self, scene_event):
-        # Use the color map for the final event (though they should all be the same anyway).
-        return scene_event.events[len(scene_event.events) - 1].object_id_to_color
+        # Use the color map for the final event (though they should all be the
+        # same anyway).
+        return scene_event.events[len(
+            scene_event.events) - 1].object_id_to_color
 
     def retrieve_object_list(self, scene_event):
-        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+        mode = (
+            self._config[self.CONFIG_METADATA_MODE]
+            if self.CONFIG_METADATA_MODE in self._config
+            else ''
+        )
 
         if mode == self.CONFIG_METADATA_MODE_FULL:
-            return sorted([self.retrieve_object_output(object_metadata, self.retrieve_object_colors(scene_event)) for \
-                    object_metadata in scene_event.metadata['objects']], key=lambda x: x.uuid)
+            return sorted(
+                [
+                    self.retrieve_object_output(
+                        object_metadata,
+                        self.retrieve_object_colors(scene_event),
+                    )
+                    for object_metadata in scene_event.metadata['objects']
+                ],
+                key=lambda x: x.uuid
+            )
 
-        return sorted([self.retrieve_object_output(object_metadata, self.retrieve_object_colors(scene_event)) for \
-                object_metadata in scene_event.metadata['objects'] if object_metadata['visibleInCamera'] or \
-                object_metadata['isPickedUp']], key=lambda x: x.uuid)
+        return sorted(
+            [
+                self.retrieve_object_output(
+                    object_metadata, self.retrieve_object_colors(scene_event)
+                )
+                for object_metadata in scene_event.metadata['objects']
+                if object_metadata['visibleInCamera'] or
+                object_metadata['isPickedUp']
+            ],
+            key=lambda x: x.uuid
+        )
 
     def retrieve_object_output(self, object_metadata, object_id_to_color):
-        material_list = list(filter(MCS_Util.verify_material_enum_string, [material.upper() for material in \
-                object_metadata['salientMaterials']])) if object_metadata['salientMaterials'] is not None else []
+        material_list = (
+            list(
+                filter(
+                    MCS_Util.verify_material_enum_string,
+                    [
+                        material.upper()
+                        for material in object_metadata['salientMaterials']
+                    ],
+                )
+            )
+            if object_metadata['salientMaterials'] is not None
+            else []
+        )
 
-        rgb = object_id_to_color[object_metadata['objectId']] if object_metadata['objectId'] in object_id_to_color \
-                else [None, None, None]
+        rgb = (
+            object_id_to_color[object_metadata['objectId']]
+            if object_metadata['objectId'] in object_id_to_color
+            else [None, None, None]
+        )
 
-        bounds = object_metadata['objectBounds'] if 'objectBounds' in object_metadata and \
-            object_metadata['objectBounds'] is not None else {}
+        bounds = (
+            object_metadata['objectBounds']
+            if 'objectBounds' in object_metadata and
+            object_metadata['objectBounds'] is not None
+            else {}
+        )
 
-        return self.restrict_object_output_metadata(MCS_Object(
-            uuid=object_metadata['objectId'],
-            color={
-                'r': rgb[0],
-                'g': rgb[1],
-                'b': rgb[2]
-            },
-            dimensions=(bounds['objectBoundsCorners'] if 'objectBoundsCorners' in bounds else None),
-            direction=object_metadata['direction'],
-            distance=(object_metadata['distanceXZ'] / MAX_MOVE_DISTANCE), # DEPRECATED
-            distance_in_steps=(object_metadata['distanceXZ'] / MAX_MOVE_DISTANCE),
-            distance_in_world=(object_metadata['distance']),
-            held=object_metadata['isPickedUp'],
-            mass=object_metadata['mass'],
-            material_list=material_list,
-            position=object_metadata['position'],
-            rotation=object_metadata['rotation'],
-            shape=object_metadata['shape'],
-            texture_color_list=object_metadata['colorsFromMaterials'],
-            visible=(object_metadata['visibleInCamera'] or object_metadata['isPickedUp'])
-        ))
+        return self.restrict_object_output_metadata(
+            MCS_Object(
+                uuid=object_metadata['objectId'],
+                color={'r': rgb[0], 'g': rgb[1], 'b': rgb[2]},
+                dimensions=(
+                    bounds['objectBoundsCorners']
+                    if 'objectBoundsCorners' in bounds
+                    else None
+                ),
+                direction=object_metadata['direction'],
+                distance=(
+                    object_metadata['distanceXZ'] / MAX_MOVE_DISTANCE
+                ),  # DEPRECATED
+                distance_in_steps=(
+                    object_metadata['distanceXZ'] / MAX_MOVE_DISTANCE
+                ),
+                distance_in_world=(object_metadata['distance']),
+                held=object_metadata['isPickedUp'],
+                mass=object_metadata['mass'],
+                material_list=material_list,
+                position=object_metadata['position'],
+                rotation=object_metadata['rotation'],
+                shape=object_metadata['shape'],
+                texture_color_list=object_metadata['colorsFromMaterials'],
+                visible=(
+                    object_metadata['visibleInCamera'] or
+                    object_metadata['isPickedUp']
+                ),
+            )
+        )
 
     def retrieve_pose(self, scene_event):
         # TODO MCS-305 Return pose from Unity in step output object
@@ -591,27 +791,56 @@ class MCS_Controller_AI2THOR(MCS_Controller):
         return scene_event.metadata['agent']['position']
 
     def retrieve_return_status(self, scene_event):
-        # TODO MCS-47 Need to implement all proper step statuses on the Unity side
+        # TODO MCS-47 Need to implement all proper step statuses on the Unity
+        # side
         return_status = MCS_Return_Status.UNDEFINED.name
 
         try:
             if scene_event.metadata['lastActionStatus']:
-                return_status = MCS_Return_Status[scene_event.metadata['lastActionStatus']].name
+                return_status = MCS_Return_Status[
+                    scene_event.metadata['lastActionStatus']
+                ].name
         except KeyError:
-            print("Return status " + scene_event.metadata['lastActionStatus'] + " is not currently supported.")
+            print(
+                "Return status " +
+                scene_event.metadata['lastActionStatus'] +
+                " is not currently supported.")
         finally:
             return return_status
 
     def retrieve_structural_object_list(self, scene_event):
-        mode = self._config[self.CONFIG_METADATA_MODE] if self.CONFIG_METADATA_MODE in self._config else ''
+        mode = (
+            self._config[self.CONFIG_METADATA_MODE]
+            if self.CONFIG_METADATA_MODE in self._config
+            else ''
+        )
 
         if mode == self.CONFIG_METADATA_MODE_FULL:
-            return sorted([self.retrieve_object_output(object_metadata, self.retrieve_object_colors(scene_event)) for \
-                    object_metadata in scene_event.metadata['structuralObjects']], key=lambda x: x.uuid)
+            return sorted(
+                [
+                    self.retrieve_object_output(
+                        object_metadata,
+                        self.retrieve_object_colors(scene_event),
+                    )
+                    for object_metadata in scene_event.metadata[
+                        'structuralObjects'
+                    ]
+                ],
+                key=lambda x: x.uuid
+            )
 
-        return sorted([self.retrieve_object_output(object_metadata, self.retrieve_object_colors(scene_event)) for \
-                object_metadata in scene_event.metadata['structuralObjects'] if object_metadata['visibleInCamera']], \
-                key=lambda x: x.uuid)
+        return sorted(
+            [
+                self.retrieve_object_output(
+                    object_metadata, self.retrieve_object_colors(scene_event)
+                )
+                for object_metadata in scene_event.metadata[
+                    'structuralObjects'
+                ]
+                if object_metadata['visibleInCamera']
+            ],
+            key=lambda x: x.uuid
+        )
 
     def save_images(self, scene_event):
         image_list = []
@@ -630,45 +859,70 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             object_mask_list.append(object_mask)
 
             if self.__debug_to_file and self.__output_folder is not None:
-                step_plus_substep_index = 0 if self.__step_number == 0 else ((self.__step_number - 1) * 5) + (index + 1)
+                step_plus_substep_index = 0 if self.__step_number == 0 else (
+                    (self.__step_number - 1) * 5) + (index + 1)
                 suffix = '_' + str(step_plus_substep_index) + '.png'
-                scene_image.save(fp=self.__output_folder + 'frame_image' + suffix)
-                depth_mask.save(fp=self.__output_folder + 'depth_mask' + suffix)
-                object_mask.save(fp=self.__output_folder + 'object_mask' + suffix)
+                scene_image.save(fp=self.__output_folder +
+                                 'frame_image' + suffix)
+                depth_mask.save(fp=self.__output_folder +
+                                'depth_mask' + suffix)
+                object_mask.save(fp=self.__output_folder +
+                                 'object_mask' + suffix)
 
             if self.__s3_client:
                 in_memory_file = io.BytesIO()
                 scene_image.save(fp=in_memory_file, format='png')
                 in_memory_file.seek(0)
-                s3_folder = (self._config[self.CONFIG_SAVE_IMAGES_TO_S3_FOLDER] + '/') if \
-                        self.CONFIG_SAVE_IMAGES_TO_S3_FOLDER in self._config else ''
-                team_prefix = (self._config[self.CONFIG_TEAM] + '_') if self.CONFIG_TEAM in self._config else ''
-                s3_file_name = s3_folder + team_prefix + self.__scene_configuration['name'].replace('.json', '') + \
-                        '_' + str(self.__step_number) + '_' + str(index + 1) + '_' + self.generate_time() + '.png'
-                print('SAVE TO S3 BUCKET ' + self._config[self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET] + ': ' + s3_file_name)
-                self.__s3_client.upload_fileobj(in_memory_file, self._config[self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET], \
-                        s3_file_name, ExtraArgs={'ACL': 'public-read', 'ContentType': 'image/png'})
+                s3_folder = (
+                    (self._config[self.CONFIG_SAVE_IMAGES_TO_S3_FOLDER] + '/')
+                    if self.CONFIG_SAVE_IMAGES_TO_S3_FOLDER in self._config
+                    else ''
+                )
+                team_prefix = (self._config[self.CONFIG_TEAM] +
+                               '_') if self.CONFIG_TEAM in self._config else ''
+                s3_file_name = s3_folder + team_prefix + \
+                    self.__scene_configuration['name'].replace('.json', '') + \
+                    '_' + str(self.__step_number) + '_' + \
+                    str(index + 1) + '_' + self.generate_time() + '.png'
+                print('SAVE TO S3 BUCKET ' +
+                      self._config[self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET] +
+                      ': ' + s3_file_name)
+                self.__s3_client.upload_fileobj(
+                    in_memory_file,
+                    self._config[self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET],
+                    s3_file_name,
+                    ExtraArgs={
+                        'ACL': 'public-read',
+                        'ContentType': 'image/png',
+                    }
+                )
 
         return image_list, depth_mask_list, object_mask_list
 
     def wrap_output(self, scene_event):
         if self.__debug_to_file and self.__output_folder is not None:
-            with open(self.__output_folder + 'ai2thor_output_' + str(self.__step_number) + '.json', 'w') as json_file:
+            with open(self.__output_folder + 'ai2thor_output_' +
+                      str(self.__step_number) + '.json', 'w') as json_file:
                 json.dump({
                     "metadata": scene_event.metadata
                 }, json_file, sort_keys=True, indent=4)
 
-        image_list, depth_mask_list, object_mask_list = self.save_images(scene_event)
+        image_list, depth_mask_list, object_mask_list = self.save_images(
+            scene_event)
 
         objects = scene_event.metadata.get('objects', None)
         agent = scene_event.metadata.get('agent', None)
         step_output = self.restrict_step_output_metadata(MCS_Step_Output(
-            action_list=self.retrieve_action_list(self._goal, self.__step_number),
+            action_list=self.retrieve_action_list(
+                self._goal, self.__step_number),
             camera_aspect_ratio=(self.SCREEN_WIDTH, self.SCREEN_HEIGHT),
-            camera_clipping_planes=(scene_event.metadata.get('clippingPlaneNear', 0.0), \
-                    scene_event.metadata.get('clippingPlaneFar', 0.0)),
+            camera_clipping_planes=(
+                scene_event.metadata.get('clippingPlaneNear', 0.0),
+                scene_event.metadata.get('clippingPlaneFar', 0.0),
+            ),
             camera_field_of_view=scene_event.metadata.get('fov', 0.0),
-            camera_height=scene_event.metadata.get('cameraPosition', {}).get('y', 0.0),
+            camera_height=scene_event.metadata.get(
+                'cameraPosition', {}).get('y', 0.0),
             depth_mask_list=depth_mask_list,
             goal=self._goal,
             head_tilt=self.retrieve_head_tilt(scene_event),
@@ -681,7 +935,8 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             reward=MCS_Reward.calculate_reward(self._goal, objects, agent),
             rotation=self.retrieve_rotation(scene_event),
             step_number=self.__step_number,
-            structural_object_list=self.retrieve_structural_object_list(scene_event)
+            structural_object_list=self.retrieve_structural_object_list(
+                scene_event)
         ))
 
         self.__head_tilt = step_output.head_tilt
@@ -690,11 +945,13 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             print("RETURN STATUS: " + step_output.return_status)
             print("OBJECTS: " + str(len(step_output.object_list)) + " TOTAL")
             if len(step_output.object_list) > 0:
-                for line in MCS_Util.generate_pretty_object_output(step_output.object_list):
+                for line in MCS_Util.generate_pretty_object_output(
+                        step_output.object_list):
                     print("    " + line)
 
         if self.__debug_to_file and self.__output_folder is not None:
-            with open(self.__output_folder + 'mcs_output_' + str(self.__step_number) + '.json', 'w') as json_file:
+            with open(self.__output_folder + 'mcs_output_' +
+                      str(self.__step_number) + '.json', 'w') as json_file:
                 json_file.write(str(step_output))
 
         return step_output
@@ -707,14 +964,15 @@ class MCS_Controller_AI2THOR(MCS_Controller):
             logs=True,
             renderDepthImage=True,
             renderObjectImage=True,
-            # Yes, in AI2-THOR, the player's reach appears to be governed by the "visibilityDistance", confusingly...
+            # Yes, in AI2-THOR, the player's reach appears to be
+            # governed by the "visibilityDistance", confusingly...
             visibilityDistance=MAX_REACH_DISTANCE,
             **kwargs
         )
 
         if self.__debug_to_file and self.__output_folder is not None:
-            with open(self.__output_folder + 'ai2thor_input_' + str(self.__step_number) + '.json', 'w') as json_file:
+            with open(self.__output_folder + 'ai2thor_input_' +
+                      str(self.__step_number) + '.json', 'w') as json_file:
                 json.dump(step_data, json_file, sort_keys=True, indent=4)
 
         return step_data
-

--- a/python_api/machine_common_sense/mcs_goal.py
+++ b/python_api/machine_common_sense/mcs_goal.py
@@ -1,5 +1,6 @@
 from .mcs_util import MCS_Util
 
+
 class MCS_Goal:
     """
     Defines attributes of an MCS goal.
@@ -7,24 +8,34 @@ class MCS_Goal:
     Attributes
     ----------
     action_list : list of lists of strings, or None
-        The list of actions that are available for the scene at each step (outer list index).  Each inner list item is
-        a list of action strings. For example, ['MoveAhead','RotateLook,rotation=180'] restricts the actions to either
-        'MoveAhead' or 'RotateLook' with the 'rotation' parameter set to 180. An action_list of None means that all
-        actions are always available. An empty inner list means that all actions are available for that specific step.
+        The list of actions that are available for the scene at each step
+        (outer list index).  Each inner list item is a list of action strings.
+        For example, ['MoveAhead','RotateLook,rotation=180'] restricts the
+        actions to either 'MoveAhead' or 'RotateLook' with the 'rotation'
+        parameter set to 180. An action_list of None means that all
+        actions are always available. An empty inner list means that all
+        actions are available for that specific step.
     category : string
-        The category that describes this goal and the properties in its metadata.
+        The category that describes this goal and the properties in its
+        metadata.
     description : string
-        A human-readable sentence describing this goal and containing the target task(s) and object(s).
+        A human-readable sentence describing this goal and containing
+        the target task(s) and object(s).
     domain_list : list of strings
-        The list of MCS "core domains" associated with this goal (for the visualization interface).
+        The list of MCS "core domains" associated with this goal (for the
+        visualization interface).
     info_list : list
-        The list of information for the visualization interface associated with this goal.
+        The list of information for the visualization interface associated
+        with this goal.
     last_preview_phase_step : integer
-        The last step of the preview phase of this scene (scripted in its configuration), if any. Default: 0
+        The last step of the preview phase of this scene (scripted in its
+        configuration), if any. Default: 0
     last_step : integer
-        The last step of this scene. This scene will automatically end following this step.
+        The last step of this scene. This scene will automatically end
+        following this step.
     type_list : list of strings
-        The list of types associated with this goal (for the visualization interface).
+        The list of types associated with this goal (for the
+        visualization interface).
     metadata : dict
         The metadata specific to this goal.
     """
@@ -55,4 +66,3 @@ class MCS_Goal:
 
     def __str__(self):
         return MCS_Util.class_to_str(self)
-

--- a/python_api/machine_common_sense/mcs_goal_category.py
+++ b/python_api/machine_common_sense/mcs_goal_category.py
@@ -1,5 +1,6 @@
 from enum import Enum, unique
 
+
 @unique
 class MCS_Goal_Category(Enum):
     RETRIEVAL = "retrieval"

--- a/python_api/machine_common_sense/mcs_material.py
+++ b/python_api/machine_common_sense/mcs_material.py
@@ -1,5 +1,6 @@
 from enum import Enum, unique
 
+
 @unique
 class MCS_Material(Enum):
     CERAMIC = "CERAMIC"
@@ -17,4 +18,3 @@ class MCS_Material(Enum):
     UNDEFINED = "UNDEFINED"
     WAX = "WAX"
     WOOD = "WOOD"
-

--- a/python_api/machine_common_sense/mcs_object.py
+++ b/python_api/machine_common_sense/mcs_object.py
@@ -1,4 +1,3 @@
-from .mcs_material import MCS_Material
 from .mcs_util import MCS_Util
 
 
@@ -11,19 +10,25 @@ class MCS_Object(object):
     uuid : string
         The unique ID of this object, used with some actions.
     color : dict
-        The "r", "g", and "b" pixel values of this object in images from the MCS_Step_Output's "object_mask_list".
+        The "r", "g", and "b" pixel values of this object in images from the
+        MCS_Step_Output's "object_mask_list".
     dimensions : dict
-        The dimensions of this object in the environment's 3D global coordinate system as a list of 8 points (dicts
-        with "x", "y", and "z").
+        The dimensions of this object in the environment's 3D global
+        coordinate system as a list of 8 points (dicts with "x", "y", and "z").
     direction : dict
-        The normalized direction vector of "x", "y", and "z" degrees between your position and this object's.
-        Use "x" and "y" as "rotation" and "horizon" params (respectively) in a "RotateLook" action to face this object.
+        The normalized direction vector of "x", "y", and "z" degrees between
+        your position and this object's.
+        Use "x" and "y" as "rotation" and "horizon" params (respectively) in
+        a "RotateLook" action to face this object.
     distance : float
-        DEPRECATED. Same as distance_in_steps. Please use distance_in_steps or distance_in_world.
+        DEPRECATED. Same as distance_in_steps. Please use distance_in_steps
+        or distance_in_world.
     distance_in_steps : float
-        The distance from you to this object in number of steps ("Move" actions) on the 2D X/Z movement grid.
+        The distance from you to this object in number of steps ("Move"
+        actions) on the 2D X/Z movement grid.
     distance_in_world : float
-        The distance from you to this object in the environment's 3D global coordinate system.
+        The distance from you to this object in the environment's 3D global
+        coordinate system.
     held : boolean
         Whether you are holding this object.
     mass : float
@@ -31,9 +36,11 @@ class MCS_Object(object):
     material_list : list of strings
         Haptic feedback.  The material(s) of this object.  See MCS_Material.
     position : dict
-        The "x", "y", and "z" coordinates for the global position of the center of this object's 3D model.
+        The "x", "y", and "z" coordinates for the global position of the
+        center of this object's 3D model.
     rotation : dict
-        This object's rotation angles around the "x", "y", and "z" axes in degrees.
+        This object's rotation angles around the "x", "y", and "z" axes
+        in degrees.
     shape : string
         This object's shape in plain English.
     texture_color_list : list of strings
@@ -73,9 +80,10 @@ class MCS_Object(object):
         self.position = {} if position is None else position
         self.rotation = {} if rotation is None else rotation
         self.shape = shape
-        self.texture_color_list = [] if texture_color_list is None else texture_color_list
+        self.texture_color_list = (
+            [] if texture_color_list is None else texture_color_list
+        )
         self.visible = visible
 
     def __str__(self):
         return MCS_Util.class_to_str(self)
-

--- a/python_api/machine_common_sense/mcs_pose.py
+++ b/python_api/machine_common_sense/mcs_pose.py
@@ -1,9 +1,9 @@
 from enum import Enum, unique
 
+
 @unique
 class MCS_Pose(Enum):
     CRAWLING = "CRAWLING"
     LYING = "LYING"
     STANDING = "STANDING"
     UNDEFINED = "UNDEFINED"
-

--- a/python_api/machine_common_sense/mcs_return_status.py
+++ b/python_api/machine_common_sense/mcs_return_status.py
@@ -1,5 +1,6 @@
 from enum import Enum, unique
 
+
 @unique
 class MCS_Return_Status(Enum):
     HAND_IS_FULL = "HAND_IS_FULL"
@@ -18,4 +19,3 @@ class MCS_Return_Status(Enum):
     UNDEFINED = "UNDEFINED"
     WRONG_POSE = "WRONG_POSE"
     FAILED = "FAILED"
-

--- a/python_api/machine_common_sense/mcs_scene_history.py
+++ b/python_api/machine_common_sense/mcs_scene_history.py
@@ -1,4 +1,3 @@
-from .mcs_step_output import MCS_Step_Output
 from .mcs_util import MCS_Util
 
 
@@ -19,4 +18,3 @@ class MCS_Scene_History(object):
 
     def __str__(self):
         return MCS_Util.class_to_str(self)
-

--- a/python_api/machine_common_sense/mcs_step_output.py
+++ b/python_api/machine_common_sense/mcs_step_output.py
@@ -3,52 +3,69 @@ from .mcs_pose import MCS_Pose
 from .mcs_return_status import MCS_Return_Status
 from .mcs_util import MCS_Util
 
+
 class MCS_Step_Output:
     """
-    Defines attributes of the output from a single step in the MCS 3D environment.
+    Defines attributes of the output from a single step in the MCS 3D
+    environment.
 
     Attributes
     ----------
     action_list : list of strings
-        The list of all actions that are available for the next step. May be a subset of all possible actions. See
-        MCS_Action.
+        The list of all actions that are available for the next step.
+        May be a subset of all possible actions. See MCS_Action.
     camera_aspect_ratio : (float, float)
-        The player camera's aspect ratio. This will remain constant for the whole scene.
+        The player camera's aspect ratio. This will remain constant for the
+        whole scene.
     camera_clipping_planes : (float, float)
-        The player camera's near and far clipping planes. This will remain constant for the whole scene.
+        The player camera's near and far clipping planes. This will remain
+        constant for the whole scene.
     camera_field_of_view : float
-        The player camera's field of view. This will remain constant for the whole scene.
+        The player camera's field of view. This will remain constant for
+        the whole scene.
     camera_height : float
-        The player camera's height. This will change if the player uses actions like "LieDown", "Sit", or "Crouch".
+        The player camera's height. This will change if the player uses
+        actions like "LieDown", "Sit", or "Crouch".
     depth_mask_list : list of Pillow.Image objects
-        The list of depth mask images from the scene after the last action and physics simulation were run.
-        This is normally a list with five images, where the physics simulation has unpaused and paused again
-        for a little bit between each image, and the final image is the state of the environment before your
-        next action. The MCS_Step_Output object returned from a call to controller.start_scene will normally
-        have a list with only one image, except for a scene with a scripted Preview Phase. A pixel value of
-        255 translates to 25 (the far clipping plane) in the environment's global coordinate system.
+        The list of depth mask images from the scene after the last
+        action and physics simulation were run.
+        This is normally a list with five images, where the physics simulation
+        has unpaused and paused again for a little bit between each image,
+        and the final image is the state of the environment before your
+        next action. The MCS_Step_Output object returned from a call to
+        controller.start_scene will normally have a list with only one image,
+        except for a scene with a scripted Preview Phase. A pixel value of
+        255 translates to 25 (the far clipping plane) in the environment's
+        global coordinate system.
     goal : MCS_Goal or None
         The goal for the whole scene.  Will be None in "Exploration" scenes.
     head_tilt : float
-        How far your head is tilted up/down in degrees (between 90 and -90).  Changed by setting the horizon parameter
-        in a "RotateLook" action.
+        How far your head is tilted up/down in degrees (between 90 and -90).
+        Changed by setting the horizon parameter in a "RotateLook" action.
     image_list : list of Pillow.Image objects
-        The list of images from the scene after the last action and physics simulation were run. This is
-        normally a list with five images, where the physics simulation has unpaused and paused again for a
-        little bit between each image, and the final image is the state of the environment before your next
-        action. The MCS_Step_Output object returned from a call to controller.start_scene will normally have
-        a list with only one image, except for a scene with a scripted Preview Phase.
+        The list of images from the scene after the last action and physics
+        simulation were run. This is normally a list with five images, where
+        the physics simulation has unpaused and paused again for a little
+        bit between each image, and the final image is the state of the
+        environment before your next action. The MCS_Step_Output object
+        returned from a call to controller.start_scene will normally have a
+        listwith only one image, except for a scene with a scripted Preview
+        Phase.
     object_list : list of MCS_Object objects
-        The list of metadata for all the interactive objects in the scene. For metadata on structural objects like
-        walls, please see structural_object_list
+        The list of metadata for all the interactive objects in the scene. For
+        metadata on structural objects like walls, please see
+        structural_object_list
     object_mask_list : list of Pillow.Image objects
-        The list of object mask (instance segmentation) images from the scene after the last action and
-        physics simulation were run. This is normally a list with five images, where the physics simulation
-        has unpaused and paused again for a little bit between each image, and the final image is the state
-        of the environment before your next action. The MCS_Step_Output object returned from a call to
-        controller.start_scene will normally have a list with only one image, except for a scene with a
-        scripted Preview Phase. The color of each object in the mask corresponds to the "color" property
-        in its MCS_Object object.
+        The list of object mask (instance segmentation) images from the scene
+        after the last action and physics simulation were run. This is
+        normally a list with five images, where the physics simulation
+        has unpaused and paused again for a little bit between each image,
+        and the final image is the state of the environment before your next
+        action. The MCS_Step_Output object returned from a call to
+        controller.start_scene will normally have a list with only one image,
+        except for a scene with a scripted Preview Phase. The color of each
+        object in the mask corresponds to the "color" property in its
+        MCS_Object object.
     pose : string
         Your current pose.  See MCS_Pose.
     position : dict
@@ -60,9 +77,11 @@ class MCS_Step_Output:
     rotation : float
         Your current rotation angle in degrees.
     step_number : integer
-        The step number of your last action, recorded since you started the current scene.
+        The step number of your last action, recorded since you started the
+        current scene.
     structural_object_list : list of MCS_Object objects
-        The list of metadata for all the structural objects (like walls) in the scene.
+        The list of metadata for all the structural objects (like walls) in
+        the scene.
     """
 
     def __init__(
@@ -87,23 +106,33 @@ class MCS_Step_Output:
         structural_object_list=None
     ):
         self.action_list = [] if action_list is None else action_list
-        self.camera_aspect_ratio = (0.0, 0.0) if camera_aspect_ratio is None else camera_aspect_ratio
-        self.camera_clipping_planes = (0.0, 0.0) if camera_clipping_planes is None else camera_clipping_planes
+        self.camera_aspect_ratio = (
+            0.0, 0.0) if camera_aspect_ratio is None else camera_aspect_ratio
+        self.camera_clipping_planes = (
+            (0.0, 0.0)
+            if camera_clipping_planes is None
+            else camera_clipping_planes
+        )
         self.camera_field_of_view = camera_field_of_view
         self.camera_height = camera_height
-        self.depth_mask_list = [] if depth_mask_list is None else depth_mask_list
+        self.depth_mask_list = (
+            [] if depth_mask_list is None else depth_mask_list
+        )
         self.goal = MCS_Goal() if goal is None else goal
         self.head_tilt = head_tilt
         self.image_list = [] if image_list is None else image_list
         self.object_list = [] if object_list is None else object_list
-        self.object_mask_list = [] if object_mask_list is None else object_mask_list
+        self.object_mask_list = (
+            [] if object_mask_list is None else object_mask_list
+        )
         self.pose = pose
         self.position = {} if position is None else position
         self.return_status = return_status
         self.reward = reward
         self.rotation = rotation
         self.step_number = step_number
-        self.structural_object_list = [] if structural_object_list is None else structural_object_list
+        self.structural_object_list = [
+        ] if structural_object_list is None else structural_object_list
 
     def __str__(self):
         return MCS_Util.class_to_str(self)

--- a/python_api/machine_common_sense/mcs_util.py
+++ b/python_api/machine_common_sense/mcs_util.py
@@ -1,6 +1,7 @@
 from .mcs_action import MCS_Action
 from .mcs_material import MCS_Material
 
+
 class MCS_Util:
     """
     Defines utility functions for MCS classes.
@@ -27,11 +28,23 @@ class MCS_Util:
         this_indent = " " * MCS_Util.NUMBER_OF_SPACES * depth
         next_indent = " " * MCS_Util.NUMBER_OF_SPACES * (depth + 1)
         text_list = []
-        props = {prop_key:prop_value for prop_key, prop_value in vars(input_class).items() if not \
-                prop_key.startswith('_') or callable(prop_value)}
+        props = {
+            prop_key: prop_value
+            for prop_key, prop_value in vars(input_class).items()
+            if not prop_key.startswith('_') or callable(prop_value)
+        }
         for prop_key, prop_value in props.items():
-            text_list.append(next_indent + "\"" + prop_key + "\": " + MCS_Util.value_to_str(prop_value, depth + 1))
-        return "{}" if len(text_list) == 0 else "{\n" + (",\n").join(text_list) + "\n" + this_indent + "}"
+            text_list.append(
+                next_indent +
+                "\"" +
+                prop_key +
+                "\": " +
+                MCS_Util.value_to_str(
+                    prop_value,
+                    depth +
+                    1))
+        return "{}" if len(text_list) == 0 else "{\n" + \
+            (",\n").join(text_list) + "\n" + this_indent + "}"
 
     """
     Transforms the given list of MCS_Object objects into a list of strings.
@@ -48,13 +61,32 @@ class MCS_Util:
     @staticmethod
     def generate_pretty_object_output(object_list):
         # TODO What else should we show here?
-        titles = ["OBJECT ID", "SHAPE", "COLORS", "HELD", "POSITION (WORLD)", "DIMENSIONS (WORLD)", \
-                "DISTANCE (WORLD)", "DIRECTION (WORLD)"]
-        rows = [titles] + [[metadata.uuid, metadata.shape, ", ".join(metadata.texture_color_list), metadata.held, \
-                MCS_Util.vector_to_string(metadata.position), MCS_Util.vector_to_string(metadata.dimensions), \
-                metadata.distance_in_world, MCS_Util.vector_to_string(metadata.direction)] for metadata in object_list]
-        widths = [max(len(str(row[i])) for row in rows) for i in range(0, len(titles))]
-        return [("  ".join(str(row[i]).ljust(widths[i]) for i in range(0, len(row)))) for row in rows]
+        titles = [
+            "OBJECT ID",
+            "SHAPE",
+            "COLORS",
+            "HELD",
+            "POSITION (WORLD)",
+            "DIMENSIONS (WORLD)",
+            "DISTANCE (WORLD)",
+            "DIRECTION (WORLD)"]
+        rows = [titles] + [
+            [
+                metadata.uuid,
+                metadata.shape,
+                ", ".join(metadata.texture_color_list),
+                metadata.held,
+                MCS_Util.vector_to_string(metadata.position),
+                MCS_Util.vector_to_string(metadata.dimensions),
+                metadata.distance_in_world,
+                MCS_Util.vector_to_string(metadata.direction)
+            ]
+            for metadata in object_list
+        ]
+        widths = [max(len(str(row[i])) for row in rows)
+                  for i in range(0, len(titles))]
+        return [("  ".join(str(row[i]).ljust(widths[i])
+                           for i in range(0, len(row)))) for row in rows]
 
     """
     Transforms the given input string into an action string and parameter dict.
@@ -67,9 +99,11 @@ class MCS_Util:
     Returns
     -------
     string
-        The action string, or None if the given input had an error transforming the action string.
+        The action string, or None if the given input had an error
+        transforming the action string.
     dict
-        The parameter dict, or None if the given input had an error transforming parameters.
+        The parameter dict, or None if the given input had an error
+        transforming parameters.
     """
     @staticmethod
     def input_to_action_and_params(input_str):
@@ -77,8 +111,8 @@ class MCS_Util:
         action = input_split[0]
 
         try:
-            validate_action = MCS_Action(action).name
-        except:
+            validate_action = MCS_Action(action).name  # noqa: F841
+        except BaseException:
             return None, {}
 
         if len(input_split) < 2:
@@ -93,13 +127,14 @@ class MCS_Util:
                     params[paramKey.strip()] = float(paramValue.strip())
                 else:
                     params[paramKey.strip()] = paramValue.strip()
-        except:
+        except BaseException:
             return action, None
 
         return action, params
 
     """
-    Returns if the given value is within the given min and max; if not, returns the given default.
+    Returns if the given value is within the given min and max; if not,
+    returns the given default.
 
     Parameters
     ----------
@@ -112,7 +147,8 @@ class MCS_Util:
     default_value : number
         The default value.
     label : string
-        A label for the input value.  If given, and if the input value is not within the range, will print an error.
+        A label for the input value.  If given, and if the input value is not
+        within the range, will print an error.
 
     Returns
     -------
@@ -122,9 +158,18 @@ class MCS_Util:
     def is_in_range(value, min_value, max_value, default_value, label=None):
         if value > max_value or value < min_value:
             if label is not None:
-                print('Value of ' + label + 'needs to be between ' + str(min_value) + \
-                    ' and ' + str(max_value) + '. Current value: ' + str(value) + \
-                    '. Will be reset to ' + str(default_value) + '.')
+                print(
+                    'Value of ' +
+                    label +
+                    'needs to be between ' +
+                    str(min_value) +
+                    ' and ' +
+                    str(max_value) +
+                    '. Current value: ' +
+                    str(value) +
+                    '. Will be reset to ' +
+                    str(default_value) +
+                    '.')
             return default_value
         return value
 
@@ -136,7 +181,8 @@ class MCS_Util:
     value :
         The input value.
     label : string
-        A label for the input value.  If given, and if the input value is not a number, will print an error.
+        A label for the input value.  If given, and if the input value is not
+        a number, will print an error.
 
     Returns
     -------
@@ -149,7 +195,10 @@ class MCS_Util:
             return True
         except ValueError:
             if label is not None:
-                print('Value of ' + label + 'needs to be a number. Will be set to 0.')
+                print(
+                    'Value of ' +
+                    label +
+                    'needs to be a number. Will be set to 0.')
             return False
 
     """
@@ -175,13 +224,28 @@ class MCS_Util:
         if isinstance(input_value, dict):
             text_list = []
             for dict_key, dict_value in input_value.items():
-                text_list.append(next_indent + "\"" + dict_key + "\": " + MCS_Util.value_to_str(dict_value, depth + 1))
-            return "{}" if len(text_list) == 0 else "{\n" + (",\n").join(text_list) + "\n" + this_indent + "}"
+                text_list.append(
+                    next_indent +
+                    "\"" +
+                    dict_key +
+                    "\": " +
+                    MCS_Util.value_to_str(
+                        dict_value,
+                        depth +
+                        1))
+            return "{}" if len(text_list) == 0 else "{\n" + \
+                (",\n").join(text_list) + "\n" + this_indent + "}"
         if isinstance(input_value, list) or isinstance(input_value, tuple):
             text_list = []
             for list_item in list(input_value):
-                text_list.append(next_indent + MCS_Util.value_to_str(list_item, depth + 1))
-            return "[]" if len(text_list) == 0 else "[\n" + (",\n").join(text_list) + "\n" + this_indent + "]"
+                text_list.append(
+                    next_indent +
+                    MCS_Util.value_to_str(
+                        list_item,
+                        depth +
+                        1))
+            return "[]" if len(text_list) == 0 else "[\n" + \
+                (",\n").join(text_list) + "\n" + this_indent + "]"
         if isinstance(input_value, bool):
             return "true" if input_value else "false"
         if isinstance(input_value, str):
@@ -202,11 +266,26 @@ class MCS_Util:
     """
     @staticmethod
     def vector_to_string(vector):
-        return ('(' + str(vector['x']) + ',' + str(vector['y']) + ',' + str(vector['z']) + ')') if vector is not None \
-                and 'x' in vector and 'y' in vector and 'z' in vector else 'None'
+        return (
+            (
+                '(' +
+                str(vector['x']) +
+                ',' +
+                str(vector['y']) +
+                ',' +
+                str(vector['z']) +
+                ')'
+            )
+            if vector is not None and
+            'x' in vector and
+            'y' in vector and
+            'z' in vector
+            else 'None'
+        )
 
     """
-    Returns whether the given string can be successfully converted into an MCS_Material enum.
+    Returns whether the given string can be successfully converted into an
+    MCS_Material enum.
 
     Parameters
     ----------
@@ -220,8 +299,7 @@ class MCS_Util:
     @staticmethod
     def verify_material_enum_string(enum_string):
         try:
-            enum_instance = MCS_Material[enum_string.upper()]
+            enum_instance = MCS_Material[enum_string.upper()]  # noqa: F841
             return True
         except KeyError:
             return False
-

--- a/python_api/machine_common_sense/run_mcs_environment.py
+++ b/python_api/machine_common_sense/run_mcs_environment.py
@@ -2,8 +2,10 @@ import sys
 from machine_common_sense.mcs import MCS
 
 if len(sys.argv) < 3:
-    print('Usage: python run_mcs_environment.py <mcs_unity_build_file> <mcs_config_json_file>')
+    print('Usage: python run_mcs_environment.py <mcs_unity_build_file> '
+          '<mcs_config_json_file>')
     sys.exit()
+
 
 def run_scene(controller, config_data):
     output = controller.start_scene(config_data)
@@ -20,11 +22,18 @@ def run_scene(controller, config_data):
     output = controller.step('PickupObject', objectId="apple_a")
     output = controller.step('Pass')
     output = controller.step('RotateLook', rotation=0, horizon=-30)
-    output = controller.step('ThrowObject', objectId="apple_a", force=1, objectDirectionX=1, objectDirectionY=0, objectDirectionZ=2)
+    output = controller.step(
+        'ThrowObject',
+        objectId="apple_a",
+        force=1,
+        objectDirectionX=1,
+        objectDirectionY=0,
+        objectDirectionZ=2)
     output = controller.step('RotateLook', rotation=20, horizon=0)
     output = controller.step('Pass')
     output = controller.step('Pass')
-    output = controller.step('Pass')
+    output = controller.step('Pass')  # noqa: F841
+
 
 if __name__ == "__main__":
     config_data, status = MCS.load_config_json_file(sys.argv[2])
@@ -36,13 +45,13 @@ if __name__ == "__main__":
     debug = 'terminal' if sys.argv[3] is None else True
     enable_noise = 'terminal' if sys.argv[4] is None else False
 
-    controller = MCS.create_controller(sys.argv[1], debug=debug, enable_noise=enable_noise)
+    controller = MCS.create_controller(
+        sys.argv[1], debug=debug, enable_noise=enable_noise)
 
     config_file_path = sys.argv[2]
-    config_file_name = config_file_path[config_file_path.rfind('/')+1:]
+    config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     # TODO: Read name directly from JSON in config file
     config_data['name'] = config_file_name[0:config_file_name.find('.')]
 
     run_scene(controller, config_data)
-

--- a/python_api/machine_common_sense/run_mcs_eval_samples.py
+++ b/python_api/machine_common_sense/run_mcs_eval_samples.py
@@ -6,6 +6,7 @@ if len(sys.argv) < 2:
     print('Usage: python run_mcs_eval_samples.py <mcs_unity_build_file>')
     sys.exit()
 
+
 def run_scene(file_name, action_list):
     config_data, status = MCS.load_config_json_file(file_name)
 
@@ -14,7 +15,7 @@ def run_scene(file_name, action_list):
         return
 
     config_file_path = file_name
-    config_file_name = config_file_path[config_file_path.rfind('/')+1:]
+    config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():
         config_data['name'] = config_file_name[0:config_file_name.find('.')]
@@ -24,7 +25,8 @@ def run_scene(file_name, action_list):
     output = controller.step('Pass')
 
     for action in action_list:
-        output = controller.step(action)
+        output = controller.step(action)  # noqa: F841
+
 
 if __name__ == "__main__":
     controller = MCS.create_controller(sys.argv[1], debug=True)
@@ -123,4 +125,3 @@ if __name__ == "__main__":
         'RotateLook,horizon=30',
         'PickupObject,objectId=bowl_1'
     ])
-

--- a/python_api/machine_common_sense/run_mcs_human_input.py
+++ b/python_api/machine_common_sense/run_mcs_human_input.py
@@ -13,18 +13,25 @@ from machine_common_sense.mcs_util import MCS_Util
 commandList = []
 
 # class to contain possible commands and keys
+
+
 class command:
     def __init__(self, name, key, desc):
         self.name = name
         self.key = key
         self.desc = desc
 
+
 class HumanInputShell(cmd.Cmd):
 
     prompt = '(command)->'
 
-    def __init__(self, input_controller, input_previous_output, input_config_data):
-        super(HumanInputShell,self).__init__()
+    def __init__(
+            self,
+            input_controller,
+            input_previous_output,
+            input_config_data):
+        super(HumanInputShell, self).__init__()
 
         self.controller = input_controller
         self.previous_output = input_previous_output
@@ -34,52 +41,63 @@ class HumanInputShell(cmd.Cmd):
         return line
 
     def postcmd(self, stopFlag, line) -> bool:
-        print('===============================================================================')
+        print('================================================='
+              '==============================')
         return stopFlag
-        
 
     def default(self, line):
 
-        if self.previous_output.action_list is not None and len(self.previous_output.action_list) < len(commandList):
+        if self.previous_output.action_list is not None and len(
+                self.previous_output.action_list) < len(commandList):
             print('Only actions available during this step:')
             for action in self.previous_output.action_list:
                 print('  ' + action)
         else:
             print('All actions are available during this step.')
 
-        if self.previous_output.action_list is not None and len(self.previous_output.action_list) == 1:
+        if self.previous_output.action_list is not None and len(
+                self.previous_output.action_list) == 1:
             print('Automatically selecting the only available action...')
             userInput = self.previous_output.action_list[1]
         else:
             userInput = line.split(',')
 
-        # Check for shortcut key, if attempted shortcut key, map and check valid key
+        # Check for shortcut key, if attempted shortcut key, map and check
+        # valid key
         try:
             if len(userInput[0]) == 1:
-                userInput[0] = MCS_Action[MCS_Action_Keys(userInput[0] ).name].value
-        except:
-            print("You entered an invalid shortcut key, please try again. (Type 'help' to display commands again)")
+                userInput[0] = MCS_Action[MCS_Action_Keys(
+                    userInput[0]).name].value
+        except BaseException:
+            print(
+                "You entered an invalid shortcut key, please try again. "
+                "(Type 'help' to display commands again)")
             print("You entered: " + userInput[0])
             return
 
         if userInput and userInput[0].lower() == 'exit':
             self.do_exit(line)
-            return 
+            return
         if userInput and userInput[0].lower() == 'help':
             self.do_help(line)
             return
         if userInput and userInput[0].lower() == 'reset':
             self.do_reset(line)
-            return 
-            
-        action, params = MCS_Util.input_to_action_and_params(','.join(userInput))
+            return
+
+        action, params = MCS_Util.input_to_action_and_params(
+            ','.join(userInput))
 
         if action is None:
-            print("You entered an invalid command, please try again.  (Type 'help' to display commands again)")
+            print(
+                "You entered an invalid command, please try again.  "
+                "(Type 'help' to display commands again)")
             return
 
         if params is None:
-            print("ERROR: Parameters should be separated by commas, and look like this example: rotation=45")
+            print(
+                "ERROR: Parameters should be separated by commas, and "
+                "look like this example: rotation=45")
             return
 
         output = self.controller.step(action, **params)
@@ -95,7 +113,8 @@ class HumanInputShell(cmd.Cmd):
         print("Resets the scene.")
 
     def help_shortcut_key_mode(self):
-        print("Toggles on mode where the user can execute single key commands without hitting enter.")
+        print("Toggles on mode where the user can execute single key "
+              "commands without hitting enter.")
 
     def do_exit(self, args) -> bool:
         print("Exiting Human Input Mode\n")
@@ -110,32 +129,41 @@ class HumanInputShell(cmd.Cmd):
     def do_shortcut_key_mode(self, args):
         print("Entering shortcut mode...")
         print("Press key 'e' to exit\n")
-        list_of_mcs_action_keys = [mcs_action_key.value for mcs_action_key in MCS_Action_Keys]
+        list_of_mcs_action_keys = [
+            mcs_action_key.value for mcs_action_key in MCS_Action_Keys]
 
         while True:
             char = getch.__call__()
             print('\n(shortcut-command)->', char)
-            if char == 'e': # exit shortcut key mode
+            if char == 'e':  # exit shortcut key mode
                 break
             elif char in list_of_mcs_action_keys:
                 self.default(char)
-        
-
 
 
 # Define all the possible human input commands
 def build_commands():
     for action in MCS_Action:
-        commandList.append(command(action.value, MCS_Action_Keys[action.name].value, MCS_Action_API_DESC[action.name].value))
+        commandList.append(command(action.value,
+                                   MCS_Action_Keys[action.name].value,
+                                   MCS_Action_API_DESC[action.name].value))
 
 # Display all the possible commands to the user along with key mappings
+
+
 def print_commands():
     print(" ")
     print("--------------- Available Commands ---------------")
     print(" ")
 
     for commandListItem in commandList:
-        print("- " + commandListItem.name + " (ShortcutKey=" + commandListItem.key + "): " + commandListItem.desc)
+        print(
+            "- " +
+            commandListItem.name +
+            " (ShortcutKey=" +
+            commandListItem.key +
+            "): " +
+            commandListItem.desc)
 
     print(" ")
     print("---------------- Example Commands ----------------")
@@ -148,7 +176,8 @@ def print_commands():
     print("Enter 'print' to print the commands again.")
     print("Enter 'reset' to reset the scene.")
     print("Enter 'exit' to exit the program.")
-    print("Enter 'shortcut_key_mode' to be able to enter Commands without hitting enter.")
+    print("Enter 'shortcut_key_mode' to be able to enter Commands "
+          "without hitting enter.")
     print(" ")
     print("----------------- Features -----------------------")
     print("Up/Down arrow keys go through the command history")
@@ -156,7 +185,7 @@ def print_commands():
     print("------------------ End Commands ------------------")
     print(" ")
 
-        
+
 # Run scene loaded in the config data
 def run_scene(controller, config_data):
     build_commands()
@@ -170,19 +199,36 @@ def run_scene(controller, config_data):
     sys.exit()
 
 
-def main(argv): 
-    
+def main(argv):
+
     parser = argparse.ArgumentParser(description='Run MCS')
     required_group = parser.add_argument_group(title='required arguments')
 
-    required_group.add_argument('mcs_unity_build_file', help='Path to MCS unity build file')
-    required_group.add_argument('mcs_config_json_file', help='MCS JSON scene configuration file to load')
+    required_group.add_argument(
+        'mcs_unity_build_file',
+        help='Path to MCS unity build file')
+    required_group.add_argument(
+        'mcs_config_json_file',
+        help='MCS JSON scene configuration file to load')
 
-    parser.add_argument('-d','--debug', default=True, help='True or False on whether to debug files [default=True]')
-    parser.add_argument('-n','--noise', default=False, help='True or False on whether to enable noise in MCS [default=True]')
-    parser.add_argument('-s','--seed', type=int, default=None, help='Seed(integer) for the random number generator [default=None]')
+    parser.add_argument(
+        '-d',
+        '--debug',
+        default=True,
+        help='True or False on whether to debug files [default=True]')
+    parser.add_argument(
+        '-n',
+        '--noise',
+        default=False,
+        help='True or False on whether to enable noise in MCS [default=True]')
+    parser.add_argument(
+        '-s',
+        '--seed',
+        type=int,
+        default=None,
+        help='Seed(integer) for the random number generator [default=None]')
     args = parser.parse_args(argv[1:])
-    
+
     if not isinstance(args.debug, bool):
         if args.debug.lower() != 'true' and args.debug.lower() != 'false':
             print('Debug files must be <True> or <False>')
@@ -192,7 +238,6 @@ def main(argv):
                 args.debug = False
             else:
                 args.debug = True
-
 
     if not isinstance(args.noise, bool):
         if args.noise.lower() != 'true' and args.noise.lower() != 'false':
@@ -214,16 +259,21 @@ def main(argv):
     enable_noise = args.noise
     seed_val = args.seed
 
-    controller = MCS.create_controller(sys.argv[1], debug=debug, enable_noise=enable_noise, seed=seed_val)
+    controller = MCS.create_controller(
+        sys.argv[1],
+        debug=debug,
+        enable_noise=enable_noise,
+        seed=seed_val)
 
     config_file_path = sys.argv[2]
-    config_file_name = config_file_path[config_file_path.rfind('/')+1:]
+    config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():
         config_data['name'] = config_file_name[0:config_file_name.find('.')]
 
-    if controller != None:
+    if controller is not None:
         run_scene(controller, config_data)
+
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/python_api/machine_common_sense/run_mcs_init_scenes.py
+++ b/python_api/machine_common_sense/run_mcs_init_scenes.py
@@ -3,7 +3,8 @@ import sys
 from machine_common_sense.mcs import MCS
 
 if len(sys.argv) < 4:
-    print('Usage: python run_mcs_init_scenes.py <mcs_unity_build_file> <json_input_folder> <image_output_folder>')
+    print('Usage: python run_mcs_init_scenes.py <mcs_unity_build_file> '
+          '<json_input_folder> <image_output_folder>')
     sys.exit()
 
 if __name__ == "__main__":
@@ -22,14 +23,20 @@ if __name__ == "__main__":
             continue
 
         if 'name' not in config_data.keys():
-            config_data['name'] = json_file_name[json_file_name.rfind('/')+1:json_file_name.rfind('.')]
+            config_data['name'] = json_file_name[json_file_name.rfind(
+                '/') + 1:json_file_name.rfind('.')]
 
         output = controller.start_scene(config_data)
 
-        print('Saving initialization output (scene image and metadata) of JSON config file ' + config_data['name'])
+        print(
+            'Saving initialization output (scene image and metadata) of ' +
+            'JSON config file ' + config_data['name'])
 
-        with open(output_folder + config_data['name'] + '.json', 'w') as output_json_file:
+        with open(output_folder + config_data['name'] +
+                  '.json', 'w') as output_json_file:
             output_json_file.write(str(output))
 
-        output.image_list[0].save(fp=output_folder + config_data['name'] + '.png')
-
+        output.image_list[0].save(
+            fp=output_folder +
+            config_data['name'] +
+            '.png')

--- a/python_api/machine_common_sense/run_mcs_intphys_samples.py
+++ b/python_api/machine_common_sense/run_mcs_intphys_samples.py
@@ -6,6 +6,7 @@ if len(sys.argv) < 2:
     print('Usage: python run_mcs_intphys_samples.py <mcs_unity_build_file>')
     sys.exit()
 
+
 def run_scene(file_name):
     config_data, status = MCS.load_config_json_file(file_name)
 
@@ -14,7 +15,7 @@ def run_scene(file_name):
         return
 
     config_file_path = file_name
-    config_file_name = config_file_path[config_file_path.rfind('/')+1:]
+    config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():
         config_data['name'] = config_file_name[0:config_file_name.find('.')]
@@ -30,6 +31,7 @@ def run_scene(file_name):
         action = output.action_list[len(output.action_list) - 1]
         output = controller.step(action)
 
+
 if __name__ == "__main__":
     controller = MCS.create_controller(sys.argv[1], debug=True)
 
@@ -39,12 +41,12 @@ if __name__ == "__main__":
     run_scene('../scenes/intphys_gravity_quartet_1D_implausible.json')
     run_scene('../scenes/intphys_object_permanence_quartet_1A_plausible.json')
     run_scene('../scenes/intphys_object_permanence_quartet_1B_plausible.json')
-    run_scene('../scenes/intphys_object_permanence_quartet_1C_implausible.json')
-    run_scene('../scenes/intphys_object_permanence_quartet_1D_implausible.json')
+    run_scene('../scenes/intphys_object_permanence_quartet_1C_implausible.json')  # noqa: E501
+    run_scene('../scenes/intphys_object_permanence_quartet_1D_implausible.json')  # noqa: E501
     run_scene('../scenes/intphys_object_permanence_quartet_2A_plausible.json')
     run_scene('../scenes/intphys_object_permanence_quartet_2B_plausible.json')
-    run_scene('../scenes/intphys_object_permanence_quartet_2C_implausible.json')
-    run_scene('../scenes/intphys_object_permanence_quartet_2D_implausible.json')
+    run_scene('../scenes/intphys_object_permanence_quartet_2C_implausible.json')  # noqa: E501
+    run_scene('../scenes/intphys_object_permanence_quartet_2D_implausible.json')  # noqa: E501
     run_scene('../scenes/intphys_shape_constancy_quartet_1A_plausible.json')
     run_scene('../scenes/intphys_shape_constancy_quartet_1B_plausible.json')
     run_scene('../scenes/intphys_shape_constancy_quartet_1C_implausible.json')
@@ -53,12 +55,19 @@ if __name__ == "__main__":
     run_scene('../scenes/intphys_shape_constancy_quartet_2B_plausible.json')
     run_scene('../scenes/intphys_shape_constancy_quartet_2C_implausible.json')
     run_scene('../scenes/intphys_shape_constancy_quartet_2D_implausible.json')
-    run_scene('../scenes/intphys_spatio_temporal_continuity_quartet_1A_plausible.json')
-    run_scene('../scenes/intphys_spatio_temporal_continuity_quartet_1B_plausible.json')
-    run_scene('../scenes/intphys_spatio_temporal_continuity_quartet_1C_implausible.json')
-    run_scene('../scenes/intphys_spatio_temporal_continuity_quartet_1D_implausible.json')
-    run_scene('../scenes/intphys_spatio_temporal_continuity_quartet_2A_plausible.json')
-    run_scene('../scenes/intphys_spatio_temporal_continuity_quartet_2B_plausible.json')
-    run_scene('../scenes/intphys_spatio_temporal_continuity_quartet_2C_implausible.json')
-    run_scene('../scenes/intphys_spatio_temporal_continuity_quartet_2D_implausible.json')
-
+    run_scene(
+        '../scenes/intphys_spatio_temporal_continuity_quartet_1A_plausible.json')  # noqa: E501
+    run_scene(
+        '../scenes/intphys_spatio_temporal_continuity_quartet_1B_plausible.json')  # noqa: E501
+    run_scene(
+        '../scenes/intphys_spatio_temporal_continuity_quartet_1C_implausible.json')  # noqa: E501
+    run_scene(
+        '../scenes/intphys_spatio_temporal_continuity_quartet_1D_implausible.json')  # noqa: E501
+    run_scene(
+        '../scenes/intphys_spatio_temporal_continuity_quartet_2A_plausible.json')  # noqa: E501
+    run_scene(
+        '../scenes/intphys_spatio_temporal_continuity_quartet_2B_plausible.json')  # noqa: E501
+    run_scene(
+        '../scenes/intphys_spatio_temporal_continuity_quartet_2C_implausible.json')  # noqa: E501
+    run_scene(
+        '../scenes/intphys_spatio_temporal_continuity_quartet_2D_implausible.json')  # noqa: E501

--- a/python_api/machine_common_sense/run_mcs_just_pass.py
+++ b/python_api/machine_common_sense/run_mcs_just_pass.py
@@ -2,7 +2,8 @@ import sys
 from machine_common_sense.mcs import MCS
 
 if len(sys.argv) < 3:
-    print('Usage: python run_mcs_just_pass.py <mcs_unity_build_file> <mcs_config_json_file>')
+    print('Usage: python run_mcs_just_pass.py <mcs_unity_build_file> '
+          '<mcs_config_json_file>')
     sys.exit()
 
 if __name__ == "__main__":
@@ -15,7 +16,7 @@ if __name__ == "__main__":
     controller = MCS.create_controller(sys.argv[1], debug=True)
 
     config_file_path = sys.argv[2]
-    config_file_name = config_file_path[config_file_path.rfind('/')+1:]
+    config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():
         config_data['name'] = config_file_name[0:config_file_name.find('.')]
@@ -29,4 +30,3 @@ if __name__ == "__main__":
 
     for i in range(1, last_step + 1):
         output = controller.step('Pass')
-

--- a/python_api/machine_common_sense/run_mcs_just_rotate.py
+++ b/python_api/machine_common_sense/run_mcs_just_rotate.py
@@ -1,10 +1,10 @@
 import sys
-import time
 
 from machine_common_sense.mcs import MCS
 
 if len(sys.argv) < 3:
-    print('Usage: python run_mcs_just_rotate.py <mcs_unity_build_file> <mcs_config_json_file>')
+    print('Usage: python run_mcs_just_rotate.py <mcs_unity_build_file> '
+          '<mcs_config_json_file>')
     sys.exit()
 
 if __name__ == "__main__":
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     controller = MCS.create_controller(sys.argv[1], debug=True)
 
     config_file_path = sys.argv[2]
-    config_file_name = config_file_path[config_file_path.rfind('/')+1:]
+    config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():
         config_data['name'] = config_file_name[0:config_file_name.find('.')]

--- a/python_api/machine_common_sense/run_mcs_last_action.py
+++ b/python_api/machine_common_sense/run_mcs_last_action.py
@@ -3,7 +3,8 @@ import sys
 from machine_common_sense.mcs import MCS
 
 if len(sys.argv) < 3:
-    print('Usage: python run_mcs_just_pass.py <mcs_unity_build_file> <mcs_config_json_file>')
+    print('Usage: python run_mcs_just_pass.py <mcs_unity_build_file> '
+          '<mcs_config_json_file>')
     sys.exit()
 
 if __name__ == "__main__":
@@ -16,7 +17,7 @@ if __name__ == "__main__":
     controller = MCS.create_controller(sys.argv[1], debug=True)
 
     config_file_path = sys.argv[2]
-    config_file_name = config_file_path[config_file_path.rfind('/')+1:]
+    config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():
         config_data['name'] = config_file_name[0:config_file_name.find('.')]
@@ -31,4 +32,3 @@ if __name__ == "__main__":
     for i in range(output.step_number + 1, last_step + 1):
         action = output.action_list[len(output.action_list) - 1]
         output = controller.step(action)
-

--- a/python_api/machine_common_sense/run_mcs_scene_timer.py
+++ b/python_api/machine_common_sense/run_mcs_scene_timer.py
@@ -4,9 +4,9 @@ import sys
 import time
 
 from machine_common_sense.mcs import MCS
-from machine_common_sense.mcs import MCS
 
 DEFAULT_STEP_COUNT = 20
+
 
 def run_scene(controller, file_name):
     config_data, status = MCS.load_config_json_file(file_name)
@@ -16,7 +16,7 @@ def run_scene(controller, file_name):
         return
 
     config_file_path = file_name
-    config_file_name = config_file_path[config_file_path.rfind('/')+1:]
+    config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():
         config_data['name'] = config_file_name[0:config_file_name.find('.')]
@@ -40,19 +40,30 @@ def run_scene(controller, file_name):
 
     return step_time_list
 
+
 def main():
     if len(sys.argv) < 3:
-        print('Usage: python mcs_run_scene_timer.py <mcs_unity_build_file> <scene_configuration_dir> <debug=False>')
+        print('Usage: python run_mcs_scene_timer.py <mcs_unity_build_file> '
+              '<scene_configuration_dir> <debug=False>')
         sys.exit()
 
-    file_list = [os.path.join(sys.argv[2], file_name) for file_name in os.listdir(sys.argv[2]) if \
-            os.path.isfile(os.path.join(sys.argv[2], file_name)) and os.path.splitext(file_name)[1] == '.json']
-    file_list.sort()
+    file_list = sorted(
+        [
+            os.path.join(sys.argv[2], file_name)
+            for file_name in os.listdir(sys.argv[2])
+            if os.path.isfile(os.path.join(sys.argv[2], file_name)) and
+            os.path.splitext(file_name)[1] == '.json'
+        ]
+    )
 
     debug = sys.argv[3] if len(sys.argv) > 3 else False
 
-    print(f'FOUND {len(file_list)} SCENE CONFIGURATION FILES... STARTING THE MCS UNITY APP...')
-    controller = MCS.create_controller(sys.argv[1], debug=(True if debug == 'true' else debug))
+    print(
+        f'FOUND {len(file_list)} SCENE CONFIGURATION FILES... '
+        f'STARTING THE MCS UNITY APP...')
+    controller = MCS.create_controller(
+        sys.argv[1], debug=(
+            True if debug == 'true' else debug))
 
     scene_time_list = []
     step_time_list_list = []
@@ -63,7 +74,8 @@ def main():
     step_time_sum_list = []
 
     for i in range(0, len(file_list)):
-        print('================================================================================')
+        print('========================================================='
+              '=======================')
         print(f'RUNNING FILE {(i + 1)}: {file_list[i]}')
         start = time.perf_counter()
         step_time_list = run_scene(controller, file_list[i])
@@ -76,15 +88,21 @@ def main():
         step_time_min_list.append(min(step_time_list))
         step_time_sum_list.append(sum(step_time_list))
 
-    print('================================================================================')
-    print(f'RAN {len(file_list)} SCENES WITH {sum(step_time_len_list)} TOTAL STEPS IN {sum(scene_time_list):0.4f} SECONDS')
-    print(f'Average single step took {statistics.mean(step_time_avg_list):0.4f} seconds')
+    print('===================================================='
+          '============================')
+    print(f'RAN {len(file_list)} SCENES WITH {sum(step_time_len_list)} '
+          f'TOTAL STEPS IN {sum(scene_time_list):0.4f} SECONDS')
+    print(
+        f'Average single step took {statistics.mean(step_time_avg_list):0.4f} '
+        f'seconds')
     print(f'Longest single step took {max(step_time_max_list):0.4f} seconds')
     print(f'Shortest single step took {min(step_time_min_list):0.4f} seconds')
-    print(f'Average single scene took {statistics.mean(scene_time_list):0.4f} seconds')
+    print(
+        f'Average single scene took {statistics.mean(scene_time_list):0.4f} '
+        f'seconds')
     print(f'Longest single scene took {max(scene_time_list):0.4f} seconds')
     print(f'Shortest single scene took {min(scene_time_list):0.4f} seconds')
 
+
 if __name__ == "__main__":
     main()
-

--- a/python_api/requirements.txt
+++ b/python_api/requirements.txt
@@ -1,3 +1,6 @@
 ai2thor == 2.2.0
 numpy
 Pillow
+autopep8
+flake8
+pre-commit

--- a/python_api/test/mock_mcs_controller_ai2thor.py
+++ b/python_api/test/mock_mcs_controller_ai2thor.py
@@ -2,7 +2,6 @@ import ai2thor.server
 import numpy
 
 from machine_common_sense.mcs_controller_ai2thor import MCS_Controller_AI2THOR
-from machine_common_sense.mcs_step_output import MCS_Step_Output
 
 MOCK_VARIABLES = {
     'event_count': 5,
@@ -29,6 +28,7 @@ MOCK_VARIABLES = {
     }
 }
 
+
 class Mock_AI2THOR_Controller():
     def __init__(self):
         self.__last_step_data = None
@@ -40,12 +40,16 @@ class Mock_AI2THOR_Controller():
         event = ai2thor.server.Event(metadata)
         event.frame = MOCK_VARIABLES['frame'].copy()
         event.depth_frame = MOCK_VARIABLES['depth_frame'].copy()
-        event.instance_segmentation_frame = MOCK_VARIABLES['instance_segmentation_frame'].copy()
-        output = ai2thor.server.MultiAgentEvent(0, [event for _ in range(0, MOCK_VARIABLES['event_count'])])
+        event.instance_segmentation_frame = MOCK_VARIABLES[
+            'instance_segmentation_frame'
+        ].copy()
+        output = ai2thor.server.MultiAgentEvent(
+            0, [event for _ in range(0, MOCK_VARIABLES['event_count'])])
         return output
 
     def get_last_step_data(self):
         return self.__last_step_data
+
 
 class Mock_MCS_Controller_AI2THOR(MCS_Controller_AI2THOR):
 
@@ -62,4 +66,3 @@ class Mock_MCS_Controller_AI2THOR(MCS_Controller_AI2THOR):
 
     def set_goal(self, goal):
         self._goal = goal
-

--- a/python_api/test/test_mcs.py
+++ b/python_api/test/test_mcs.py
@@ -2,6 +2,7 @@ import unittest
 
 from machine_common_sense.mcs import MCS
 
+
 class Test_MCS(unittest.TestCase):
 
     def test_create_controller(self):
@@ -30,8 +31,8 @@ class Test_MCS(unittest.TestCase):
                         "x": 0.25,
                         "y": 0.25,
                         "z": 0.25
-                    }   
-                }],     
+                    }
+                }],
                 "forces": [{
                     "stepBegin": 1,
                     "stepEnd": 1,
@@ -40,19 +41,26 @@ class Test_MCS(unittest.TestCase):
                         "y": 0,
                         "z": 0
                     }
-                }]  
-            }]      
+                }]
+            }]
         }
         self.assertEqual(actual, expected)
         self.assertEqual(status, None)
 
     def test_load_config_file_json_is_invalid(self):
-        actual, status = MCS.load_config_json_file("test/test_scene_invalid.json")
+        actual, status = MCS.load_config_json_file(
+            "test/test_scene_invalid.json")
         self.assertEqual(actual, {})
-        self.assertEqual(status, "The given file 'test/test_scene_invalid.json' does not contain valid JSON.")
+        self.assertEqual(
+            status,
+            "The given file 'test/test_scene_invalid.json' does not " +
+            "contain valid JSON."
+        )
 
     def test_load_config_file_json_is_missing(self):
-        actual, status = MCS.load_config_json_file("test/test_scene_missing.json")
+        actual, status = MCS.load_config_json_file(
+            "test/test_scene_missing.json")
         self.assertEqual(actual, {})
-        self.assertEqual(status, "The given file 'test/test_scene_missing.json' cannot be found.")
-
+        self.assertEqual(
+            status,
+            "The given file 'test/test_scene_missing.json' cannot be found.")

--- a/python_api/test/test_mcs_controller_ai2thor.py
+++ b/python_api/test/test_mcs_controller_ai2thor.py
@@ -1,27 +1,33 @@
-import mock
 import numpy
-from PIL import Image
 from types import SimpleNamespace
 import unittest
 
-from machine_common_sense.mcs_action import MCS_Action
-from machine_common_sense.mcs_controller_ai2thor import MCS_Controller_AI2THOR, MAX_MOVE_DISTANCE, MAX_REACH_DISTANCE
+from machine_common_sense.mcs_controller_ai2thor import (
+    MCS_Controller_AI2THOR,
+    MAX_MOVE_DISTANCE,
+    MAX_REACH_DISTANCE
+)
 from machine_common_sense.mcs_goal import MCS_Goal
 from machine_common_sense.mcs_object import MCS_Object
 from machine_common_sense.mcs_pose import MCS_Pose
 from machine_common_sense.mcs_return_status import MCS_Return_Status
 from machine_common_sense.mcs_step_output import MCS_Step_Output
-from .mock_mcs_controller_ai2thor import Mock_MCS_Controller_AI2THOR, MOCK_VARIABLES
+from .mock_mcs_controller_ai2thor import (
+    Mock_MCS_Controller_AI2THOR,
+    MOCK_VARIABLES
+)
+
 
 class Test_MCS_Controller_AI2THOR(unittest.TestCase):
 
     def setUp(self):
         self.controller = Mock_MCS_Controller_AI2THOR()
-        self.controller.set_config({ 'metadata': '' })
+        self.controller.set_config({'metadata': ''})
 
     def create_mock_scene_event(self, mock_scene_event_data):
-        # Wrap the dict in a SimpleNamespace object to permit property access with dotted notation since the actual
-        # variable is a class, not a dict.
+        # Wrap the dict in a SimpleNamespace object to permit property access
+        # with dotted notation since the actual variable is a class, not a
+        # dict.
         return SimpleNamespace(**mock_scene_event_data)
 
     def create_retrieve_object_list_scene_event(self):
@@ -71,7 +77,16 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                     "isPickedUp": False,
                     "mass": 12.34,
                     "objectBounds": {
-                        "objectBoundsCorners": ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
+                        "objectBoundsCorners": [
+                            "p1",
+                            "p2",
+                            "p3",
+                            "p4",
+                            "p5",
+                            "p6",
+                            "p7",
+                            "p8",
+                        ]
                     },
                     "objectId": "testId2",
                     "position": {
@@ -99,7 +114,16 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                     "isPickedUp": False,
                     "mass": 34.56,
                     "objectBounds": {
-                        "objectBoundsCorners": ["pA", "pB", "pC", "pD", "pE", "pF", "pG", "pH"]
+                        "objectBoundsCorners": [
+                            "pA",
+                            "pB",
+                            "pC",
+                            "pD",
+                            "pE",
+                            "pF",
+                            "pG",
+                            "pH",
+                        ]
                     },
                     "objectId": "testId3",
                     "position": {
@@ -168,7 +192,16 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                     "isPickedUp": False,
                     "mass": 12.34,
                     "objectBounds": {
-                        "objectBoundsCorners": ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
+                        "objectBoundsCorners": [
+                            "p1",
+                            "p2",
+                            "p3",
+                            "p4",
+                            "p5",
+                            "p6",
+                            "p7",
+                            "p8",
+                        ]
                     },
                     "objectId": "testId",
                     "position": {
@@ -196,7 +229,16 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                     "isPickedUp": False,
                     "mass": 34.56,
                     "objectBounds": {
-                        "objectBoundsCorners": ["pA", "pB", "pC", "pD", "pE", "pF", "pG", "pH"]
+                        "objectBoundsCorners": [
+                            "pA",
+                            "pB",
+                            "pC",
+                            "pD",
+                            "pE",
+                            "pF",
+                            "pG",
+                            "pH",
+                        ]
                     },
                     "objectId": "testIdHidden",
                     "position": {
@@ -225,7 +267,16 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                     "isPickedUp": False,
                     "mass": 56.78,
                     "objectBounds": {
-                        "objectBoundsCorners": ["p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18"]
+                        "objectBoundsCorners": [
+                            "p11",
+                            "p12",
+                            "p13",
+                            "p14",
+                            "p15",
+                            "p16",
+                            "p17",
+                            "p18",
+                        ]
                     },
                     "objectId": "testWallId",
                     "position": {
@@ -253,7 +304,16 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                     "isPickedUp": False,
                     "mass": 78.90,
                     "objectBounds": {
-                        "objectBoundsCorners": ["pAA", "pBB", "pCC", "pDD", "pEE", "pFF", "pGG", "pHH"]
+                        "objectBoundsCorners": [
+                            "pAA",
+                            "pBB",
+                            "pCC",
+                            "pDD",
+                            "pEE",
+                            "pFF",
+                            "pGG",
+                            "pHH",
+                        ]
                     },
                     "objectId": "testWallIdHidden",
                     "position": {
@@ -302,73 +362,116 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
     def test_start_scene(self):
         output = self.controller.start_scene({'name': 'test name'})
         self.assertIsNotNone(output)
-        self.assertEqual(output.action_list, MCS_Controller_AI2THOR.ACTION_LIST)
-        self.assertEqual(output.return_status, MOCK_VARIABLES['metadata']['lastActionStatus'])
+        self.assertEqual(
+            output.action_list,
+            MCS_Controller_AI2THOR.ACTION_LIST)
+        self.assertEqual(output.return_status,
+                         MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, 0)
         self.assertEqual(output.step_number, 0)
         self.assertEqual(str(output.goal), str(MCS_Goal()))
         self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.depth_mask_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.object_mask_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.object_list), len(MOCK_VARIABLES['metadata']['objects']))
-        self.assertEqual(len(output.structural_object_list), len(MOCK_VARIABLES['metadata']['structuralObjects']))
+        self.assertEqual(len(output.depth_mask_list),
+                         MOCK_VARIABLES['event_count'])
+        self.assertEqual(len(output.object_mask_list),
+                         MOCK_VARIABLES['event_count'])
+        self.assertEqual(len(output.object_list),
+                         len(MOCK_VARIABLES['metadata']['objects']))
+        self.assertEqual(len(output.structural_object_list),
+                         len(MOCK_VARIABLES['metadata']['structuralObjects']))
 
         output = self.controller.start_scene({'name': 'test name'})
         self.assertIsNotNone(output)
-        self.assertEqual(output.action_list, MCS_Controller_AI2THOR.ACTION_LIST)
-        self.assertEqual(output.return_status, MOCK_VARIABLES['metadata']['lastActionStatus'])
+        self.assertEqual(
+            output.action_list,
+            MCS_Controller_AI2THOR.ACTION_LIST)
+        self.assertEqual(output.return_status,
+                         MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, 0)
         self.assertEqual(output.step_number, 0)
         self.assertEqual(str(output.goal), str(MCS_Goal()))
         self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.depth_mask_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.object_mask_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.object_list), len(MOCK_VARIABLES['metadata']['objects']))
-        self.assertEqual(len(output.structural_object_list), len(MOCK_VARIABLES['metadata']['structuralObjects']))
+        self.assertEqual(len(output.depth_mask_list),
+                         MOCK_VARIABLES['event_count'])
+        self.assertEqual(len(output.object_mask_list),
+                         MOCK_VARIABLES['event_count'])
+        self.assertEqual(len(output.object_list),
+                         len(MOCK_VARIABLES['metadata']['objects']))
+        self.assertEqual(len(output.structural_object_list),
+                         len(MOCK_VARIABLES['metadata']['structuralObjects']))
 
     def test_start_scene_preview_phase(self):
         last_preview_phase_step = 5
         output = self.controller.start_scene({'name': 'test name', 'goal': {
-            'last_preview_phase_step': last_preview_phase_step }
+            'last_preview_phase_step': last_preview_phase_step}
         })
         self.assertIsNotNone(output)
-        self.assertEqual(output.action_list, MCS_Controller_AI2THOR.ACTION_LIST)
-        self.assertEqual(output.return_status, MOCK_VARIABLES['metadata']['lastActionStatus'])
+        self.assertEqual(
+            output.action_list,
+            MCS_Controller_AI2THOR.ACTION_LIST)
+        self.assertEqual(output.return_status,
+                         MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, 0)
         self.assertEqual(output.step_number, 5)
-        self.assertEqual(str(output.goal), str(MCS_Goal(last_preview_phase_step=5)))
-        self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'] * (last_preview_phase_step + 1))
-        self.assertEqual(len(output.depth_mask_list), MOCK_VARIABLES['event_count'] * (last_preview_phase_step + 1))
-        self.assertEqual(len(output.object_mask_list), MOCK_VARIABLES['event_count'] * (last_preview_phase_step + 1))
-        self.assertEqual(len(output.object_list), len(MOCK_VARIABLES['metadata']['objects']))
-        self.assertEqual(len(output.structural_object_list), len(MOCK_VARIABLES['metadata']['structuralObjects']))
+        self.assertEqual(str(output.goal), str(
+            MCS_Goal(last_preview_phase_step=5)))
+        self.assertEqual(
+            len(output.image_list),
+            MOCK_VARIABLES['event_count'] * (last_preview_phase_step + 1),
+        )
+        self.assertEqual(
+            len(output.depth_mask_list),
+            MOCK_VARIABLES['event_count'] * (last_preview_phase_step + 1),
+        )
+        self.assertEqual(
+            len(output.object_mask_list),
+            MOCK_VARIABLES['event_count'] * (last_preview_phase_step + 1),
+        )
+        self.assertEqual(len(output.object_list),
+                         len(MOCK_VARIABLES['metadata']['objects']))
+        self.assertEqual(len(output.structural_object_list),
+                         len(MOCK_VARIABLES['metadata']['structuralObjects']))
 
     def test_step(self):
         output = self.controller.step('MoveAhead')
         self.assertIsNotNone(output)
-        self.assertEqual(output.action_list, MCS_Controller_AI2THOR.ACTION_LIST)
-        self.assertEqual(output.return_status, MOCK_VARIABLES['metadata']['lastActionStatus'])
+        self.assertEqual(
+            output.action_list,
+            MCS_Controller_AI2THOR.ACTION_LIST)
+        self.assertEqual(output.return_status,
+                         MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, 0)
         self.assertEqual(output.step_number, 1)
         self.assertEqual(str(output.goal), str(MCS_Goal()))
         self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.depth_mask_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.object_mask_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.object_list), len(MOCK_VARIABLES['metadata']['objects']))
-        self.assertEqual(len(output.structural_object_list), len(MOCK_VARIABLES['metadata']['structuralObjects']))
+        self.assertEqual(len(output.depth_mask_list),
+                         MOCK_VARIABLES['event_count'])
+        self.assertEqual(len(output.object_mask_list),
+                         MOCK_VARIABLES['event_count'])
+        self.assertEqual(len(output.object_list),
+                         len(MOCK_VARIABLES['metadata']['objects']))
+        self.assertEqual(len(output.structural_object_list),
+                         len(MOCK_VARIABLES['metadata']['structuralObjects']))
 
         output = self.controller.step('MoveAhead')
         self.assertIsNotNone(output)
-        self.assertEqual(output.action_list, MCS_Controller_AI2THOR.ACTION_LIST)
-        self.assertEqual(output.return_status, MOCK_VARIABLES['metadata']['lastActionStatus'])
+        self.assertEqual(
+            output.action_list,
+            MCS_Controller_AI2THOR.ACTION_LIST)
+        self.assertEqual(output.return_status,
+                         MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, 0)
         self.assertEqual(output.step_number, 2)
         self.assertEqual(str(output.goal), str(MCS_Goal()))
         self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.depth_mask_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.object_mask_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.object_list), len(MOCK_VARIABLES['metadata']['objects']))
-        self.assertEqual(len(output.structural_object_list), len(MOCK_VARIABLES['metadata']['structuralObjects']))
+        self.assertEqual(len(output.depth_mask_list),
+                         MOCK_VARIABLES['event_count'])
+        self.assertEqual(len(output.object_mask_list),
+                         MOCK_VARIABLES['event_count'])
+        self.assertEqual(len(output.object_list),
+                         len(MOCK_VARIABLES['metadata']['objects']))
+        self.assertEqual(len(output.structural_object_list),
+                         len(MOCK_VARIABLES['metadata']['structuralObjects']))
 
     def test_step_last_step(self):
         self.controller.set_goal(MCS_Goal(last_step=0))
@@ -393,7 +496,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         output = self.controller.step('MoveAhead')
         self.assertIsNone(output)
 
-        self.controller.set_goal(MCS_Goal(action_list=[['MoveAhead'], ['MoveBack']]))
+        self.controller.set_goal(
+            MCS_Goal(
+                action_list=[
+                    ['MoveAhead'],
+                    ['MoveBack']]))
         output = self.controller.step('MoveAhead')
         self.assertIsNotNone(output)
         output = self.controller.step('MoveAhead')
@@ -401,210 +508,307 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
 
     def test_step_validate_parameters_move(self):
         self.controller.step('MoveAhead', amount=1)
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MoveAhead', \
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='MoveAhead',
                 moveMagnitude=MAX_MOVE_DISTANCE))
 
         self.controller.step('MoveAhead', amount=0.1)
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MoveAhead', \
-                moveMagnitude=0.1 * MAX_MOVE_DISTANCE))
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='MoveAhead',
+                moveMagnitude=0.1 *
+                MAX_MOVE_DISTANCE))
 
         self.controller.step('MoveAhead', amount=1.5)
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MoveAhead', \
-                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT * MAX_MOVE_DISTANCE))
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='MoveAhead',
+                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT *
+                MAX_MOVE_DISTANCE))
 
         self.controller.step('MoveAhead', amount=-1)
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MoveAhead', \
-                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT * MAX_MOVE_DISTANCE))
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='MoveAhead',
+                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT *
+                MAX_MOVE_DISTANCE))
 
     def test_step_validate_parameters_rotate(self):
         self.controller.step('RotateLook', rotation=12, horizon=34)
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='RotateLook', \
-                horizon=34, rotation={'y': 12}))
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='RotateLook',
+                horizon=34,
+                rotation={
+                    'y': 12}))
 
         self.controller.step('RotateLook', rotation=-12, horizon=-34)
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='RotateLook', \
-                horizon=-34, rotation={'y': -12}))
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='RotateLook',
+                horizon=-34,
+                rotation={
+                    'y': -12}))
 
     def test_step_validate_parameters_force_object(self):
         self.controller.step('PushObject', force=1, objectId='test_id_1')
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='PushObject', \
-                moveMagnitude=MCS_Controller_AI2THOR.MAX_BABY_FORCE, objectId='test_id_1'))
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='PushObject',
+                moveMagnitude=MCS_Controller_AI2THOR.MAX_BABY_FORCE,
+                objectId='test_id_1'))
 
         self.controller.step('PushObject', force=0.1, objectId='test_id_1')
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='PushObject', \
-                moveMagnitude=0.1 * MCS_Controller_AI2THOR.MAX_BABY_FORCE, objectId='test_id_1'))
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='PushObject',
+                moveMagnitude=0.1 *
+                MCS_Controller_AI2THOR.MAX_BABY_FORCE,
+                objectId='test_id_1'))
 
         self.controller.step('PushObject', force=1.5, objectId='test_id_1')
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='PushObject', \
-                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT * MCS_Controller_AI2THOR.MAX_BABY_FORCE, \
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='PushObject',
+                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT *
+                MCS_Controller_AI2THOR.MAX_BABY_FORCE,
                 objectId='test_id_1'))
 
         self.controller.step('PushObject', force=-1, objectId='test_id_1')
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='PushObject', \
-                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT * MCS_Controller_AI2THOR.MAX_BABY_FORCE, \
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='PushObject',
+                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT *
+                MCS_Controller_AI2THOR.MAX_BABY_FORCE,
                 objectId='test_id_1'))
 
-        self.controller.step('PushObject', force=1, objectDirectionX=1, objectDirectionY=2, objectDirectionZ=3)
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='PushObject', \
-                moveMagnitude=MCS_Controller_AI2THOR.MAX_BABY_FORCE, objectDirection={'x': 1, 'y': 2, 'z': 3}))
+        self.controller.step(
+            'PushObject',
+            force=1,
+            objectDirectionX=1,
+            objectDirectionY=2,
+            objectDirectionZ=3)
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='PushObject',
+                moveMagnitude=MCS_Controller_AI2THOR.MAX_BABY_FORCE,
+                objectDirection={
+                    'x': 1,
+                    'y': 2,
+                    'z': 3}))
 
     def test_step_validate_parameters_open_close(self):
-        self.controller.step('OpenObject', amount=1, objectId='test_id_1', receptacleObjectId='test_id_2')
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MCSOpenObject', \
-                moveMagnitude=1, objectId='test_id_1', receptacleObjectId='test_id_2'))
-
-        self.controller.step('OpenObject', amount=0.1, objectId='test_id_1', receptacleObjectId='test_id_2')
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MCSOpenObject', \
-                moveMagnitude=0.1, objectId='test_id_1', receptacleObjectId='test_id_2'))
-
-        self.controller.step('OpenObject', amount=1.5, objectId='test_id_1', receptacleObjectId='test_id_2')
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MCSOpenObject', \
-                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT, objectId='test_id_1', \
+        self.controller.step(
+            'OpenObject',
+            amount=1,
+            objectId='test_id_1',
+            receptacleObjectId='test_id_2')
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='MCSOpenObject',
+                moveMagnitude=1,
+                objectId='test_id_1',
                 receptacleObjectId='test_id_2'))
 
-        self.controller.step('OpenObject', amount=-1, objectId='test_id_1', receptacleObjectId='test_id_2')
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MCSOpenObject', \
-                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT, objectId='test_id_1', \
+        self.controller.step(
+            'OpenObject',
+            amount=0.1,
+            objectId='test_id_1',
+            receptacleObjectId='test_id_2')
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='MCSOpenObject',
+                moveMagnitude=0.1,
+                objectId='test_id_1',
                 receptacleObjectId='test_id_2'))
 
-        self.controller.step('OpenObject', amount=1, objectDirectionX=1, objectDirectionY=2, objectDirectionZ=3, \
-                receptacleObjectDirectionX=4, receptacleObjectDirectionY=5, receptacleObjectDirectionZ=6)
-        self.assertEquals(self.controller.get_last_step_data(), self.create_step_data(action='MCSOpenObject', \
-                moveMagnitude=1, objectDirection={'x': 1, 'y': 2, 'z': 3}, \
-                receptacleObjectDirection={'x': 4, 'y': 5, 'z': 6}))
+        self.controller.step(
+            'OpenObject',
+            amount=1.5,
+            objectId='test_id_1',
+            receptacleObjectId='test_id_2')
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='MCSOpenObject',
+                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT,
+                objectId='test_id_1',
+                receptacleObjectId='test_id_2'))
+
+        self.controller.step(
+            'OpenObject',
+            amount=-1,
+            objectId='test_id_1',
+            receptacleObjectId='test_id_2')
+        self.assertEquals(
+            self.controller.get_last_step_data(),
+            self.create_step_data(
+                action='MCSOpenObject',
+                moveMagnitude=MCS_Controller_AI2THOR.DEFAULT_AMOUNT,
+                objectId='test_id_1',
+                receptacleObjectId='test_id_2'))
+
+        self.controller.step(
+            'OpenObject',
+            amount=1,
+            objectDirectionX=1,
+            objectDirectionY=2,
+            objectDirectionZ=3,
+            receptacleObjectDirectionX=4,
+            receptacleObjectDirectionY=5,
+            receptacleObjectDirectionZ=6)
+        self.assertEquals(
+            self.controller.get_last_step_data(), self.create_step_data(
+                action='MCSOpenObject', moveMagnitude=1, objectDirection={
+                    'x': 1, 'y': 2, 'z': 3}, receptacleObjectDirection={
+                    'x': 4, 'y': 5, 'z': 6}))
 
     def test_restrict_goal_output_metadata(self):
         goal = MCS_Goal(metadata={
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
         actual = self.controller.restrict_goal_output_metadata(goal)
         self.assertEqual(actual.metadata, {
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
 
     def test_restrict_goal_output_metadata_full(self):
-        self.controller.set_config({ 'metadata': 'full' })
+        self.controller.set_config({'metadata': 'full'})
         goal = MCS_Goal(metadata={
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
         actual = self.controller.restrict_goal_output_metadata(goal)
         self.assertEqual(actual.metadata, {
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
 
     def test_restrict_goal_output_metadata_no_navigation(self):
-        self.controller.set_config({ 'metadata': 'no_navigation' })
+        self.controller.set_config({'metadata': 'no_navigation'})
         goal = MCS_Goal(metadata={
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
         actual = self.controller.restrict_goal_output_metadata(goal)
         self.assertEqual(actual.metadata, {
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
 
     def test_restrict_goal_output_metadata_no_vision(self):
-        self.controller.set_config({ 'metadata': 'no_vision' })
+        self.controller.set_config({'metadata': 'no_vision'})
         goal = MCS_Goal(metadata={
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
         actual = self.controller.restrict_goal_output_metadata(goal)
         self.assertEqual(actual.metadata, {
-            'target': { 'image': None },
-            'target_1': { 'image': None },
-            'target_2': { 'image': None }
+            'target': {'image': None},
+            'target_1': {'image': None},
+            'target_2': {'image': None}
         })
 
     def test_restrict_goal_output_metadata_none(self):
-        self.controller.set_config({ 'metadata': 'none' })
+        self.controller.set_config({'metadata': 'none'})
         goal = MCS_Goal(metadata={
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
         actual = self.controller.restrict_goal_output_metadata(goal)
         self.assertEqual(actual.metadata, {
-            'target': { 'image': None },
-            'target_1': { 'image': None },
-            'target_2': { 'image': None }
+            'target': {'image': None},
+            'target_1': {'image': None},
+            'target_2': {'image': None}
         })
 
     def test_restrict_object_output_metadata(self):
         test_object = MCS_Object(
-            color={ 'r': 1, 'g': 2, 'b': 3 },
-            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            color={'r': 1, 'g': 2, 'b': 3},
+            dimensions={'x': 1, 'y': 2, 'z': 3},
             distance=12.34,
             distance_in_steps=34.56,
             distance_in_world=56.78,
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 },
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9},
             shape='sofa',
             texture_color_list=['c1', 'c2']
         )
         actual = self.controller.restrict_object_output_metadata(test_object)
-        self.assertEqual(actual.color, { 'r': 1, 'g': 2, 'b': 3 })
-        self.assertEqual(actual.dimensions, { 'x': 1, 'y': 2, 'z': 3 })
+        self.assertEqual(actual.color, {'r': 1, 'g': 2, 'b': 3})
+        self.assertEqual(actual.dimensions, {'x': 1, 'y': 2, 'z': 3})
         self.assertEqual(actual.distance, 12.34)
         self.assertEqual(actual.distance_in_steps, 34.56)
         self.assertEqual(actual.distance_in_world, 56.78)
-        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
-        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+        self.assertEqual(actual.position, {'x': 4, 'y': 5, 'z': 6})
+        self.assertEqual(actual.rotation, {'x': 7, 'y': 8, 'z': 9})
         self.assertEqual(actual.shape, 'sofa')
         self.assertEqual(actual.texture_color_list, ['c1', 'c2'])
 
     def test_restrict_object_output_metadata_full(self):
-        self.controller.set_config({ 'metadata': 'full' })
+        self.controller.set_config({'metadata': 'full'})
         test_object = MCS_Object(
-            color={ 'r': 1, 'g': 2, 'b': 3 },
-            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            color={'r': 1, 'g': 2, 'b': 3},
+            dimensions={'x': 1, 'y': 2, 'z': 3},
             distance=12.34,
             distance_in_steps=34.56,
             distance_in_world=56.78,
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 },
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9},
             shape='sofa',
             texture_color_list=['c1', 'c2']
         )
         actual = self.controller.restrict_object_output_metadata(test_object)
-        self.assertEqual(actual.color, { 'r': 1, 'g': 2, 'b': 3 })
-        self.assertEqual(actual.dimensions, { 'x': 1, 'y': 2, 'z': 3 })
+        self.assertEqual(actual.color, {'r': 1, 'g': 2, 'b': 3})
+        self.assertEqual(actual.dimensions, {'x': 1, 'y': 2, 'z': 3})
         self.assertEqual(actual.distance, 12.34)
         self.assertEqual(actual.distance_in_steps, 34.56)
         self.assertEqual(actual.distance_in_world, 56.78)
-        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
-        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+        self.assertEqual(actual.position, {'x': 4, 'y': 5, 'z': 6})
+        self.assertEqual(actual.rotation, {'x': 7, 'y': 8, 'z': 9})
         self.assertEqual(actual.shape, 'sofa')
         self.assertEqual(actual.texture_color_list, ['c1', 'c2'])
 
     def test_restrict_object_output_metadata_no_navigation(self):
-        self.controller.set_config({ 'metadata': 'no_navigation' })
+        self.controller.set_config({'metadata': 'no_navigation'})
         test_object = MCS_Object(
-            color={ 'r': 1, 'g': 2, 'b': 3 },
-            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            color={'r': 1, 'g': 2, 'b': 3},
+            dimensions={'x': 1, 'y': 2, 'z': 3},
             distance=12.34,
             distance_in_steps=34.56,
             distance_in_world=56.78,
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 },
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9},
             shape='sofa',
             texture_color_list=['c1', 'c2']
         )
         actual = self.controller.restrict_object_output_metadata(test_object)
-        self.assertEqual(actual.color, { 'r': 1, 'g': 2, 'b': 3 })
-        self.assertEqual(actual.dimensions, { 'x': 1, 'y': 2, 'z': 3 })
+        self.assertEqual(actual.color, {'r': 1, 'g': 2, 'b': 3})
+        self.assertEqual(actual.dimensions, {'x': 1, 'y': 2, 'z': 3})
         self.assertEqual(actual.distance, 12.34)
         self.assertEqual(actual.distance_in_steps, 34.56)
         self.assertEqual(actual.distance_in_world, 56.78)
@@ -614,15 +818,15 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.texture_color_list, ['c1', 'c2'])
 
     def test_restrict_object_output_metadata_no_vision(self):
-        self.controller.set_config({ 'metadata': 'no_vision' })
+        self.controller.set_config({'metadata': 'no_vision'})
         test_object = MCS_Object(
-            color={ 'r': 1, 'g': 2, 'b': 3 },
-            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            color={'r': 1, 'g': 2, 'b': 3},
+            dimensions={'x': 1, 'y': 2, 'z': 3},
             distance=12.34,
             distance_in_steps=34.56,
             distance_in_world=56.78,
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 },
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9},
             shape='sofa',
             texture_color_list=['c1', 'c2']
         )
@@ -632,21 +836,21 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.distance, None)
         self.assertEqual(actual.distance_in_steps, None)
         self.assertEqual(actual.distance_in_world, None)
-        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
-        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+        self.assertEqual(actual.position, {'x': 4, 'y': 5, 'z': 6})
+        self.assertEqual(actual.rotation, {'x': 7, 'y': 8, 'z': 9})
         self.assertEqual(actual.shape, None)
         self.assertEqual(actual.texture_color_list, None)
 
     def test_restrict_object_output_metadata_none(self):
-        self.controller.set_config({ 'metadata': 'none' })
+        self.controller.set_config({'metadata': 'none'})
         test_object = MCS_Object(
-            color={ 'r': 1, 'g': 2, 'b': 3 },
-            dimensions={ 'x': 1, 'y': 2, 'z': 3 },
+            color={'r': 1, 'g': 2, 'b': 3},
+            dimensions={'x': 1, 'y': 2, 'z': 3},
             distance=12.34,
             distance_in_steps=34.56,
             distance_in_world=56.78,
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 },
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9},
             shape='sofa',
             texture_color_list=['c1', 'c2']
         )
@@ -669,8 +873,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             camera_height=6,
             depth_mask_list=[7],
             object_mask_list=[8],
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9}
         )
         actual = self.controller.restrict_step_output_metadata(step)
         self.assertEqual(actual.camera_aspect_ratio, (1, 2))
@@ -679,11 +883,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.camera_height, 6)
         self.assertEqual(actual.depth_mask_list, [7])
         self.assertEqual(actual.object_mask_list, [8])
-        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
-        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+        self.assertEqual(actual.position, {'x': 4, 'y': 5, 'z': 6})
+        self.assertEqual(actual.rotation, {'x': 7, 'y': 8, 'z': 9})
 
     def test_restrict_step_output_metadata_full(self):
-        self.controller.set_config({ 'metadata': 'full' })
+        self.controller.set_config({'metadata': 'full'})
         step = MCS_Step_Output(
             camera_aspect_ratio=(1, 2),
             camera_clipping_planes=(3, 4),
@@ -691,8 +895,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             camera_height=6,
             depth_mask_list=[7],
             object_mask_list=[8],
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9}
         )
         actual = self.controller.restrict_step_output_metadata(step)
         self.assertEqual(actual.camera_aspect_ratio, (1, 2))
@@ -701,11 +905,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.camera_height, 6)
         self.assertEqual(actual.depth_mask_list, [7])
         self.assertEqual(actual.object_mask_list, [8])
-        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
-        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+        self.assertEqual(actual.position, {'x': 4, 'y': 5, 'z': 6})
+        self.assertEqual(actual.rotation, {'x': 7, 'y': 8, 'z': 9})
 
     def test_restrict_step_output_metadata_no_navigation(self):
-        self.controller.set_config({ 'metadata': 'no_navigation' })
+        self.controller.set_config({'metadata': 'no_navigation'})
         step = MCS_Step_Output(
             camera_aspect_ratio=(1, 2),
             camera_clipping_planes=(3, 4),
@@ -713,8 +917,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             camera_height=6,
             depth_mask_list=[7],
             object_mask_list=[8],
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9}
         )
         actual = self.controller.restrict_step_output_metadata(step)
         self.assertEqual(actual.camera_aspect_ratio, (1, 2))
@@ -727,7 +931,7 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.rotation, None)
 
     def test_restrict_step_output_metadata_no_vision(self):
-        self.controller.set_config({ 'metadata': 'no_vision' })
+        self.controller.set_config({'metadata': 'no_vision'})
         step = MCS_Step_Output(
             camera_aspect_ratio=(1, 2),
             camera_clipping_planes=(3, 4),
@@ -735,8 +939,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             camera_height=6,
             depth_mask_list=[7],
             object_mask_list=[8],
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9}
         )
         actual = self.controller.restrict_step_output_metadata(step)
         self.assertEqual(actual.camera_aspect_ratio, None)
@@ -745,11 +949,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.camera_height, None)
         self.assertEqual(actual.depth_mask_list, [])
         self.assertEqual(actual.object_mask_list, [])
-        self.assertEqual(actual.position, { 'x': 4, 'y': 5, 'z': 6 })
-        self.assertEqual(actual.rotation, { 'x': 7, 'y': 8, 'z': 9 })
+        self.assertEqual(actual.position, {'x': 4, 'y': 5, 'z': 6})
+        self.assertEqual(actual.rotation, {'x': 7, 'y': 8, 'z': 9})
 
     def test_restrict_step_output_metadata_none(self):
-        self.controller.set_config({ 'metadata': 'none' })
+        self.controller.set_config({'metadata': 'none'})
         step = MCS_Step_Output(
             camera_aspect_ratio=(1, 2),
             camera_clipping_planes=(3, 4),
@@ -757,8 +961,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             camera_height=6,
             depth_mask_list=[7],
             object_mask_list=[8],
-            position={ 'x': 4, 'y': 5, 'z': 6 },
-            rotation={ 'x': 7, 'y': 8, 'z': 9 }
+            position={'x': 4, 'y': 5, 'z': 6},
+            rotation={'x': 7, 'y': 8, 'z': 9}
         )
         actual = self.controller.restrict_step_output_metadata(step)
         self.assertEqual(actual.camera_aspect_ratio, None)
@@ -771,21 +975,66 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.rotation, None)
 
     def test_retrieve_action_list(self):
-        self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(), 0), self.controller.ACTION_LIST)
-        self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(action_list=[]), 0), \
-                self.controller.ACTION_LIST)
-        self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(action_list=[[]]), 0), \
-                self.controller.ACTION_LIST)
-        self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(action_list=[['MoveAhead',\
-                'RotateLook,rotation=180']]), 0), ['MoveAhead', 'RotateLook,rotation=180'])
-        self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(action_list=[['MoveAhead',\
-                'RotateLook,rotation=180']]), 1), self.controller.ACTION_LIST)
-        self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(action_list=[['MoveAhead',\
-                'RotateLook,rotation=180'], []]), 1), self.controller.ACTION_LIST)
-        self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(action_list=[[],['MoveAhead',\
-                'RotateLook,rotation=180']]), 0), self.controller.ACTION_LIST)
-        self.assertEqual(self.controller.retrieve_action_list(MCS_Goal(action_list=[[],['MoveAhead',\
-                'RotateLook,rotation=180']]), 1), ['MoveAhead', 'RotateLook,rotation=180'])
+        self.assertEqual(
+            self.controller.retrieve_action_list(
+                MCS_Goal(), 0), self.controller.ACTION_LIST)
+        self.assertEqual(
+            self.controller.retrieve_action_list(
+                MCS_Goal(
+                    action_list=[]),
+                0),
+            self.controller.ACTION_LIST)
+        self.assertEqual(
+            self.controller.retrieve_action_list(
+                MCS_Goal(
+                    action_list=[[]]),
+                0),
+            self.controller.ACTION_LIST)
+        self.assertEqual(
+            self.controller.retrieve_action_list(
+                MCS_Goal(
+                    action_list=[['MoveAhead', 'RotateLook,rotation=180']]
+                ),
+                0,
+            ),
+            ['MoveAhead', 'RotateLook,rotation=180']
+        )
+        self.assertEqual(
+            self.controller.retrieve_action_list(
+                MCS_Goal(
+                    action_list=[['MoveAhead', 'RotateLook,rotation=180']]
+                ),
+                1,
+            ),
+            self.controller.ACTION_LIST
+        )
+        self.assertEqual(
+            self.controller.retrieve_action_list(
+                MCS_Goal(
+                    action_list=[['MoveAhead', 'RotateLook,rotation=180'], []]
+                ),
+                1,
+            ),
+            self.controller.ACTION_LIST
+        )
+        self.assertEqual(
+            self.controller.retrieve_action_list(
+                MCS_Goal(
+                    action_list=[[], ['MoveAhead', 'RotateLook,rotation=180']]
+                ),
+                0,
+            ),
+            self.controller.ACTION_LIST
+        )
+        self.assertEqual(
+            self.controller.retrieve_action_list(
+                MCS_Goal(
+                    action_list=[[], ['MoveAhead', 'RotateLook,rotation=180']]
+                ),
+                1,
+            ),
+            ['MoveAhead', 'RotateLook,rotation=180']
+        )
 
     def test_retrieve_goal(self):
         goal_1 = self.controller.retrieve_goal({})
@@ -813,7 +1062,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
 
         goal_3 = self.controller.retrieve_goal({
             "goal": {
-                "action_list": [["action1"], [], ["action2", "action3", "action4"]],
+                "action_list": [
+                    ["action1"],
+                    [],
+                    ["action2", "action3", "action4"]
+                ],
                 "category": "test category",
                 "description": "test description",
                 "domain_list": ["domain1", "domain2"],
@@ -825,7 +1078,10 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                 }
             }
         })
-        self.assertEqual(goal_3.action_list, [["action1"], [], ["action2", "action3", "action4"]])
+        self.assertEqual(
+            goal_3.action_list, [
+                ["action1"], [], [
+                    "action2", "action3", "action4"]])
         self.assertEqual(goal_3.category, "test category")
         self.assertEqual(goal_3.description, "test description")
         self.assertEqual(goal_3.domain_list, ["domain1", "domain2"])
@@ -838,68 +1094,68 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         })
 
     def test_retrieve_goal_with_config_metadata(self):
-        self.controller.set_config({ 'metadata': 'full' })
+        self.controller.set_config({'metadata': 'full'})
         actual = self.controller.retrieve_goal({
             'goal': {
                 'metadata': {
-                    'target': { 'image': [0] },
-                    'target_1': { 'image': [1] },
-                    'target_2': { 'image': [2] }
+                    'target': {'image': [0]},
+                    'target_1': {'image': [1]},
+                    'target_2': {'image': [2]}
                 }
             }
         })
         self.assertEqual(actual.metadata, {
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
 
-        self.controller.set_config({ 'metadata': 'no_navigation' })
+        self.controller.set_config({'metadata': 'no_navigation'})
         actual = self.controller.retrieve_goal({
             'goal': {
                 'metadata': {
-                    'target': { 'image': [0] },
-                    'target_1': { 'image': [1] },
-                    'target_2': { 'image': [2] }
+                    'target': {'image': [0]},
+                    'target_1': {'image': [1]},
+                    'target_2': {'image': [2]}
                 }
             }
         })
         self.assertEqual(actual.metadata, {
-            'target': { 'image': [0] },
-            'target_1': { 'image': [1] },
-            'target_2': { 'image': [2] }
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
         })
 
-        self.controller.set_config({ 'metadata': 'no_vision' })
+        self.controller.set_config({'metadata': 'no_vision'})
         actual = self.controller.retrieve_goal({
             'goal': {
                 'metadata': {
-                    'target': { 'image': [0] },
-                    'target_1': { 'image': [1] },
-                    'target_2': { 'image': [2] }
+                    'target': {'image': [0]},
+                    'target_1': {'image': [1]},
+                    'target_2': {'image': [2]}
                 }
             }
         })
         self.assertEqual(actual.metadata, {
-            'target': { 'image': None },
-            'target_1': { 'image': None },
-            'target_2': { 'image': None }
+            'target': {'image': None},
+            'target_1': {'image': None},
+            'target_2': {'image': None}
         })
 
-        self.controller.set_config({ 'metadata': 'none' })
+        self.controller.set_config({'metadata': 'none'})
         actual = self.controller.retrieve_goal({
             'goal': {
                 'metadata': {
-                    'target': { 'image': [0] },
-                    'target_1': { 'image': [1] },
-                    'target_2': { 'image': [2] }
+                    'target': {'image': [0]},
+                    'target_1': {'image': [1]},
+                    'target_2': {'image': [2]}
                 }
             }
         })
         self.assertEqual(actual.metadata, {
-            'target': { 'image': None },
-            'target_1': { 'image': None },
-            'target_2': { 'image': None }
+            'target': {'image': None},
+            'target_1': {'image': None},
+            'target_2': {'image': None}
         })
 
     def test_retrieve_head_tilt(self):
@@ -910,7 +1166,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                 }
             }
         }
-        actual = self.controller.retrieve_head_tilt(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_head_tilt(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(actual, 12.34)
 
         mock_scene_event_data = {
@@ -920,12 +1177,14 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
                 }
             }
         }
-        actual = self.controller.retrieve_head_tilt(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_head_tilt(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(actual, -56.78)
 
     def test_retrieve_object_list(self):
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
-        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_object_list(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(len(actual), 2)
 
         self.assertEqual(actual[0].uuid, "testId1")
@@ -946,8 +1205,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[0].held, True)
         self.assertEqual(actual[0].mass, 1)
         self.assertEqual(actual[0].material_list, [])
-        self.assertEqual(actual[0].position, { "x": 1, "y": 1, "z": 2 })
-        self.assertEqual(actual[0].rotation, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[0].position, {"x": 1, "y": 1, "z": 2})
+        self.assertEqual(actual[0].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[0].shape, 'shape1')
         self.assertEqual(actual[0].texture_color_list, ['c1'])
         self.assertEqual(actual[0].visible, True)
@@ -958,7 +1217,9 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             "g": 76,
             "b": 54
         })
-        self.assertEqual(actual[1].dimensions, ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
+        self.assertEqual(
+            actual[1].dimensions, [
+                "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
         self.assertEqual(actual[1].direction, {
             "x": 90,
             "y": -30,
@@ -970,16 +1231,17 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[1].held, False)
         self.assertEqual(actual[1].mass, 12.34)
         self.assertEqual(actual[1].material_list, ["METAL", "PLASTIC"])
-        self.assertEqual(actual[1].position, { "x": 1, "y": 2, "z": 3 })
-        self.assertEqual(actual[1].rotation, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[1].position, {"x": 1, "y": 2, "z": 3})
+        self.assertEqual(actual[1].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[1].shape, 'shape2')
         self.assertEqual(actual[1].texture_color_list, ['c2', 'c3'])
         self.assertEqual(actual[1].visible, True)
 
     def test_retrieve_object_list_with_config_metadata_full(self):
-        self.controller.set_config({ 'metadata': 'full' })
+        self.controller.set_config({'metadata': 'full'})
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
-        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_object_list(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(len(actual), 3)
 
         self.assertEqual(actual[0].uuid, "testId1")
@@ -1000,8 +1262,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[0].held, True)
         self.assertEqual(actual[0].mass, 1)
         self.assertEqual(actual[0].material_list, [])
-        self.assertEqual(actual[0].position, { "x": 1, "y": 1, "z": 2 })
-        self.assertEqual(actual[0].rotation, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[0].position, {"x": 1, "y": 1, "z": 2})
+        self.assertEqual(actual[0].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[0].shape, 'shape1')
         self.assertEqual(actual[0].texture_color_list, ['c1'])
         self.assertEqual(actual[0].visible, True)
@@ -1012,7 +1274,9 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             "g": 76,
             "b": 54
         })
-        self.assertEqual(actual[1].dimensions, ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
+        self.assertEqual(
+            actual[1].dimensions, [
+                "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
         self.assertEqual(actual[1].direction, {
             "x": 90,
             "y": -30,
@@ -1024,8 +1288,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[1].held, False)
         self.assertEqual(actual[1].mass, 12.34)
         self.assertEqual(actual[1].material_list, ["METAL", "PLASTIC"])
-        self.assertEqual(actual[1].position, { "x": 1, "y": 2, "z": 3 })
-        self.assertEqual(actual[1].rotation, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[1].position, {"x": 1, "y": 2, "z": 3})
+        self.assertEqual(actual[1].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[1].shape, 'shape2')
         self.assertEqual(actual[1].texture_color_list, ['c2', 'c3'])
         self.assertEqual(actual[1].visible, True)
@@ -1036,7 +1300,9 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             "g": 102,
             "b": 103
         })
-        self.assertEqual(actual[2].dimensions, ["pA", "pB", "pC", "pD", "pE", "pF", "pG", "pH"])
+        self.assertEqual(
+            actual[2].dimensions, [
+                "pA", "pB", "pC", "pD", "pE", "pF", "pG", "pH"])
         self.assertEqual(actual[2].direction, {
             "x": -90,
             "y": 180,
@@ -1048,16 +1314,17 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[2].held, False)
         self.assertEqual(actual[2].mass, 34.56)
         self.assertEqual(actual[2].material_list, ["WOOD"])
-        self.assertEqual(actual[2].position, { "x": -3, "y": -2, "z": -1 })
-        self.assertEqual(actual[2].rotation ,{ "x": 11, "y": 12, "z": 13 })
+        self.assertEqual(actual[2].position, {"x": -3, "y": -2, "z": -1})
+        self.assertEqual(actual[2].rotation, {"x": 11, "y": 12, "z": 13})
         self.assertEqual(actual[2].shape, 'shape3')
         self.assertEqual(actual[2].texture_color_list, [])
         self.assertEqual(actual[2].visible, False)
 
     def test_retrieve_object_list_with_config_metadata_no_navigation(self):
-        self.controller.set_config({ 'metadata': 'no_navigation' })
+        self.controller.set_config({'metadata': 'no_navigation'})
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
-        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_object_list(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(len(actual), 2)
 
         self.assertEqual(actual[0].uuid, "testId1")
@@ -1090,7 +1357,9 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             "g": 76,
             "b": 54
         })
-        self.assertEqual(actual[1].dimensions, ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
+        self.assertEqual(
+            actual[1].dimensions, [
+                "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
         self.assertEqual(actual[1].direction, {
             "x": 90,
             "y": -30,
@@ -1109,9 +1378,10 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[1].visible, True)
 
     def test_retrieve_object_list_with_config_metadata_no_vision(self):
-        self.controller.set_config({ 'metadata': 'no_vision' })
+        self.controller.set_config({'metadata': 'no_vision'})
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
-        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_object_list(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(len(actual), 2)
 
         self.assertEqual(actual[0].uuid, "testId1")
@@ -1124,8 +1394,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[0].held, True)
         self.assertEqual(actual[0].mass, 1)
         self.assertEqual(actual[0].material_list, [])
-        self.assertEqual(actual[0].position, { "x": 1, "y": 1, "z": 2 })
-        self.assertEqual(actual[0].rotation, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[0].position, {"x": 1, "y": 1, "z": 2})
+        self.assertEqual(actual[0].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[0].shape, None)
         self.assertEqual(actual[0].texture_color_list, None)
         self.assertEqual(actual[0].visible, True)
@@ -1140,16 +1410,17 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual[1].held, False)
         self.assertEqual(actual[1].mass, 12.34)
         self.assertEqual(actual[1].material_list, ["METAL", "PLASTIC"])
-        self.assertEqual(actual[1].position, { "x": 1, "y": 2, "z": 3 })
-        self.assertEqual(actual[1].rotation, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(actual[1].position, {"x": 1, "y": 2, "z": 3})
+        self.assertEqual(actual[1].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[1].shape, None)
         self.assertEqual(actual[1].texture_color_list, None)
         self.assertEqual(actual[1].visible, True)
 
     def test_retrieve_object_list_with_config_metadata_none(self):
-        self.controller.set_config({ 'metadata': 'none' })
+        self.controller.set_config({'metadata': 'none'})
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
-        actual = self.controller.retrieve_object_list(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_object_list(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(len(actual), 2)
 
         self.assertEqual(actual[0].uuid, "testId1")
@@ -1195,7 +1466,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             }
         }
 
-        actual = self.controller.retrieve_return_status(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_return_status(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(actual, MCS_Return_Status.SUCCESSFUL.name)
 
         mock_scene_event_data = {
@@ -1204,7 +1476,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             }
         }
 
-        actual = self.controller.retrieve_return_status(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_return_status(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(actual, MCS_Return_Status.FAILED.name)
 
         mock_scene_event_data = {
@@ -1213,7 +1486,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             }
         }
 
-        actual = self.controller.retrieve_return_status(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_return_status(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(actual, MCS_Return_Status.UNDEFINED.name)
 
         mock_scene_event_data = {
@@ -1222,7 +1496,8 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             }
         }
 
-        actual = self.controller.retrieve_return_status(self.create_mock_scene_event(mock_scene_event_data))
+        actual = self.controller.retrieve_return_status(
+            self.create_mock_scene_event(mock_scene_event_data))
         self.assertEqual(actual, MCS_Return_Status.UNDEFINED.name)
 
     def test_save_images(self):
@@ -1238,8 +1513,13 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             })]
         }
 
-        image_list, depth_mask_list, object_mask_list = self.controller.save_images(self.create_mock_scene_event(
-            mock_scene_event_data))
+        (
+            image_list,
+            depth_mask_list,
+            object_mask_list,
+        ) = self.controller.save_images(
+            self.create_mock_scene_event(mock_scene_event_data)
+        )
 
         self.assertEqual(len(image_list), 1)
         self.assertEqual(len(depth_mask_list), 1)
@@ -1270,9 +1550,13 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             })]
         }
 
-        image_list, depth_mask_list, object_mask_list = self.controller.save_images(self.create_mock_scene_event(
-            mock_scene_event_data))
-
+        (
+            image_list,
+            depth_mask_list,
+            object_mask_list
+        ) = self.controller.save_images(
+            self.create_mock_scene_event(mock_scene_event_data)
+        )
         self.assertEqual(len(image_list), 2)
         self.assertEqual(len(depth_mask_list), 2)
         self.assertEqual(len(object_mask_list), 2)
@@ -1286,8 +1570,14 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(numpy.array(object_mask_list[1]), object_mask_data_2)
 
     def test_wrap_output(self):
-        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
-        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+        (
+            mock_scene_event_data,
+            image_data,
+            depth_mask_data,
+            object_mask_data
+        ) = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(
+            self.create_mock_scene_event(mock_scene_event_data))
 
         self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
@@ -1297,9 +1587,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(str(actual.goal), str(MCS_Goal()))
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.pose, MCS_Pose.STANDING.value)
-        self.assertEqual(actual.position, { 'x': 0.12, 'y': -0.23, 'z': 4.5 })
+        self.assertEqual(actual.position, {'x': 0.12, 'y': -0.23, 'z': 4.5})
         self.assertEqual(actual.rotation, 2.222)
-        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(
+            actual.return_status,
+            MCS_Return_Status.SUCCESSFUL.value)
         self.assertEqual(actual.step_number, 0)
 
         self.assertEqual(len(actual.object_list), 1)
@@ -1309,7 +1601,9 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             "g": 34,
             "b": 56
         })
-        self.assertEqual(actual.object_list[0].dimensions, ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
+        self.assertEqual(
+            actual.object_list[0].dimensions, [
+                "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
         self.assertEqual(actual.object_list[0].direction, {
             "x": 90,
             "y": -30,
@@ -1321,8 +1615,12 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.object_list[0].held, False)
         self.assertEqual(actual.object_list[0].mass, 12.34)
         self.assertEqual(actual.object_list[0].material_list, ["WOOD"])
-        self.assertEqual(actual.object_list[0].position, { "x": 10, "y": 11, "z": 12 })
-        self.assertEqual(actual.object_list[0].rotation, { "x": 1, "y": 2, "z": 3 })
+        self.assertEqual(
+            actual.object_list[0].position, {
+                "x": 10, "y": 11, "z": 12})
+        self.assertEqual(
+            actual.object_list[0].rotation, {
+                "x": 1, "y": 2, "z": 3})
         self.assertEqual(actual.object_list[0].shape, 'shape')
         self.assertEqual(actual.object_list[0].texture_color_list, ['c1'])
         self.assertEqual(actual.object_list[0].visible, True)
@@ -1334,35 +1632,60 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
             "g": 102,
             "b": 103
         })
-        self.assertEqual(actual.structural_object_list[0].dimensions, ["p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18"])
+        self.assertEqual(
+            actual.structural_object_list[0].dimensions,
+            ["p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18"]
+        )
         self.assertEqual(actual.structural_object_list[0].direction, {
             "x": 180,
             "y": -60,
             "z": 0
         })
         self.assertEqual(actual.structural_object_list[0].distance, 4.4)
-        self.assertEqual(actual.structural_object_list[0].distance_in_steps, 4.4)
-        self.assertEqual(actual.structural_object_list[0].distance_in_world, 2.5)
+        self.assertEqual(
+            actual.structural_object_list[0].distance_in_steps, 4.4)
+        self.assertEqual(
+            actual.structural_object_list[0].distance_in_world, 2.5)
         self.assertEqual(actual.structural_object_list[0].held, False)
         self.assertEqual(actual.structural_object_list[0].mass, 56.78)
-        self.assertEqual(actual.structural_object_list[0].material_list, ["CERAMIC"])
-        self.assertEqual(actual.structural_object_list[0].position, { "x": 20, "y": 21, "z": 22 })
-        self.assertEqual(actual.structural_object_list[0].rotation, { "x": 4, "y": 5, "z": 6 })
+        self.assertEqual(
+            actual.structural_object_list[0].material_list,
+            ["CERAMIC"])
+        self.assertEqual(
+            actual.structural_object_list[0].position, {
+                "x": 20, "y": 21, "z": 22})
+        self.assertEqual(
+            actual.structural_object_list[0].rotation, {
+                "x": 4, "y": 5, "z": 6})
         self.assertEqual(actual.structural_object_list[0].shape, 'structure')
-        self.assertEqual(actual.structural_object_list[0].texture_color_list, ['c2'])
+        self.assertEqual(
+            actual.structural_object_list[0].texture_color_list,
+            ['c2'])
         self.assertEqual(actual.structural_object_list[0].visible, True)
 
         self.assertEqual(len(actual.depth_mask_list), 1)
         self.assertEqual(len(actual.image_list), 1)
         self.assertEqual(len(actual.object_mask_list), 1)
-        self.assertEqual(numpy.array(actual.depth_mask_list[0]), depth_mask_data)
+        self.assertEqual(
+            numpy.array(
+                actual.depth_mask_list[0]),
+            depth_mask_data)
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
-        self.assertEqual(numpy.array(actual.object_mask_list[0]), object_mask_data)
+        self.assertEqual(
+            numpy.array(
+                actual.object_mask_list[0]),
+            object_mask_data)
 
     def test_wrap_output_with_config_metadata_full(self):
-        self.controller.set_config({ 'metadata': 'full' })
-        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
-        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+        self.controller.set_config({'metadata': 'full'})
+        (
+            mock_scene_event_data,
+            image_data,
+            depth_mask_data,
+            object_mask_data
+        ) = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(
+            self.create_mock_scene_event(mock_scene_event_data))
 
         self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
@@ -1372,9 +1695,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(str(actual.goal), str(MCS_Goal()))
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.pose, MCS_Pose.STANDING.value)
-        self.assertEqual(actual.position, { 'x': 0.12, 'y': -0.23, 'z': 4.5 })
+        self.assertEqual(actual.position, {'x': 0.12, 'y': -0.23, 'z': 4.5})
         self.assertEqual(actual.rotation, 2.222)
-        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(
+            actual.return_status,
+            MCS_Return_Status.SUCCESSFUL.value)
         self.assertEqual(actual.step_number, 0)
 
         # Correct object metadata properties tested elsewhere
@@ -1384,14 +1709,26 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(len(actual.depth_mask_list), 1)
         self.assertEqual(len(actual.image_list), 1)
         self.assertEqual(len(actual.object_mask_list), 1)
-        self.assertEqual(numpy.array(actual.depth_mask_list[0]), depth_mask_data)
+        self.assertEqual(
+            numpy.array(
+                actual.depth_mask_list[0]),
+            depth_mask_data)
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
-        self.assertEqual(numpy.array(actual.object_mask_list[0]), object_mask_data)
+        self.assertEqual(
+            numpy.array(
+                actual.object_mask_list[0]),
+            object_mask_data)
 
     def test_wrap_output_with_config_metadata_no_navigation(self):
-        self.controller.set_config({ 'metadata': 'no_navigation' })
-        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
-        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+        self.controller.set_config({'metadata': 'no_navigation'})
+        (
+            mock_scene_event_data,
+            image_data,
+            depth_mask_data,
+            object_mask_data
+        ) = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(
+            self.create_mock_scene_event(mock_scene_event_data))
 
         self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
@@ -1403,7 +1740,9 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.pose, MCS_Pose.STANDING.value)
         self.assertEqual(actual.position, None)
         self.assertEqual(actual.rotation, None)
-        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(
+            actual.return_status,
+            MCS_Return_Status.SUCCESSFUL.value)
         self.assertEqual(actual.step_number, 0)
 
         # Correct object metadata properties tested elsewhere
@@ -1413,14 +1752,26 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(len(actual.depth_mask_list), 1)
         self.assertEqual(len(actual.image_list), 1)
         self.assertEqual(len(actual.object_mask_list), 1)
-        self.assertEqual(numpy.array(actual.depth_mask_list[0]), depth_mask_data)
+        self.assertEqual(
+            numpy.array(
+                actual.depth_mask_list[0]),
+            depth_mask_data)
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
-        self.assertEqual(numpy.array(actual.object_mask_list[0]), object_mask_data)
+        self.assertEqual(
+            numpy.array(
+                actual.object_mask_list[0]),
+            object_mask_data)
 
     def test_wrap_output_with_config_metadata_no_vision(self):
-        self.controller.set_config({ 'metadata': 'no_vision' })
-        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
-        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+        self.controller.set_config({'metadata': 'no_vision'})
+        (
+            mock_scene_event_data,
+            image_data,
+            depth_mask_data,
+            object_mask_data
+        ) = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(
+            self.create_mock_scene_event(mock_scene_event_data))
 
         self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
         self.assertEqual(actual.camera_aspect_ratio, None)
@@ -1430,9 +1781,11 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(str(actual.goal), str(MCS_Goal()))
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.pose, MCS_Pose.STANDING.value)
-        self.assertEqual(actual.position, { 'x': 0.12, 'y': -0.23, 'z': 4.5 })
+        self.assertEqual(actual.position, {'x': 0.12, 'y': -0.23, 'z': 4.5})
         self.assertEqual(actual.rotation, 2.222)
-        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(
+            actual.return_status,
+            MCS_Return_Status.SUCCESSFUL.value)
         self.assertEqual(actual.step_number, 0)
 
         # Correct object metadata properties tested elsewhere
@@ -1444,9 +1797,15 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 0)
 
     def test_wrap_output_with_config_metadata_none(self):
-        self.controller.set_config({ 'metadata': 'none' })
-        mock_scene_event_data, image_data, depth_mask_data, object_mask_data = self.create_wrap_output_scene_event()
-        actual = self.controller.wrap_output(self.create_mock_scene_event(mock_scene_event_data))
+        self.controller.set_config({'metadata': 'none'})
+        (
+            mock_scene_event_data,
+            image_data,
+            depth_mask_data,
+            object_mask_data
+        ) = self.create_wrap_output_scene_event()
+        actual = self.controller.wrap_output(
+            self.create_mock_scene_event(mock_scene_event_data))
 
         self.assertEqual(actual.action_list, self.controller.ACTION_LIST)
         self.assertEqual(actual.camera_aspect_ratio, None)
@@ -1458,7 +1817,9 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(actual.pose, MCS_Pose.STANDING.value)
         self.assertEqual(actual.position, None)
         self.assertEqual(actual.rotation, None)
-        self.assertEqual(actual.return_status, MCS_Return_Status.SUCCESSFUL.value)
+        self.assertEqual(
+            actual.return_status,
+            MCS_Return_Status.SUCCESSFUL.value)
         self.assertEqual(actual.step_number, 0)
 
         # Correct object metadata properties tested elsewhere
@@ -1470,7 +1831,10 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 0)
 
     def test_wrap_step(self):
-        actual = self.controller.wrap_step(action="TestAction", numberProperty=1234, stringProperty="test_property")
+        actual = self.controller.wrap_step(
+            action="TestAction",
+            numberProperty=1234,
+            stringProperty="test_property")
         expected = {
             "action": "TestAction",
             "continuous": True,
@@ -1494,4 +1858,3 @@ class Test_MCS_Controller_AI2THOR(unittest.TestCase):
 
         currentNoise = self.controller.generate_noise()
         self.assertTrue(minValue <= currentNoise <= maxValue)
-

--- a/python_api/test/test_mcs_goal.py
+++ b/python_api/test/test_mcs_goal.py
@@ -49,7 +49,7 @@ class Test_Default_MCS_Goal(unittest.TestCase):
 
     def test_last_step(self):
         self.assertIsNone(self.goal.last_step)
-        
+
     def test_type_list(self):
         self.assertEqual(len(self.goal.type_list), 0)
         self.assertIsInstance(self.goal.type_list, list)

--- a/python_api/test/test_mcs_object.py
+++ b/python_api/test/test_mcs_object.py
@@ -2,7 +2,6 @@ import unittest
 import textwrap
 
 from machine_common_sense.mcs_object import MCS_Object
-from machine_common_sense.mcs_material import MCS_Material
 
 
 class Test_Default_MCS_Object(unittest.TestCase):
@@ -41,7 +40,7 @@ class Test_Default_MCS_Object(unittest.TestCase):
     def test_color(self):
         self.assertFalse(self.mcs_object.color)
         self.assertIsInstance(self.mcs_object.color, dict)
-        
+
     def test_dimensions(self):
         self.assertFalse(self.mcs_object.dimensions)
         self.assertIsInstance(self.mcs_object.dimensions, dict)
@@ -95,5 +94,5 @@ class Test_Default_MCS_Object(unittest.TestCase):
         self.assertFalse(self.mcs_object.visible)
 
     def test_str(self):
-        self.assertEqual(str(self.mcs_object), textwrap.dedent(self.str_output))
-
+        self.assertEqual(str(self.mcs_object),
+                         textwrap.dedent(self.str_output))

--- a/python_api/test/test_mcs_reward.py
+++ b/python_api/test/test_mcs_reward.py
@@ -1,19 +1,14 @@
 import unittest
-import math
 import time
-import random
 
 from typing import Tuple
 from shapely import geometry
 
 from machine_common_sense.mcs_reward import MCS_Reward
 from machine_common_sense.mcs_goal import MCS_Goal
-from machine_common_sense.mcs_object import MCS_Object
-from machine_common_sense.mcs_util import MCS_Util
 
 
 class Test_MCS_Reward(unittest.TestCase):
-
 
     def setUp(self):
         self._start_at = time.time()
@@ -37,15 +32,18 @@ class Test_MCS_Reward(unittest.TestCase):
     def test_target_in_empty_object_list(self):
         obj_list = []
         target_id = ''
-        self.assertIsNone(MCS_Reward._MCS_Reward__get_object_from_list(obj_list, target_id))
+        self.assertIsNone(
+            MCS_Reward._MCS_Reward__get_object_from_list(
+                obj_list, target_id))
 
     def test_target_in_object_list(self):
         obj_list = []
         for i in range(10):
-            obj = {"objectId":str(i)}
+            obj = {"objectId": str(i)}
             obj_list.append(obj)
         target_id = '7'
-        results = MCS_Reward._MCS_Reward__get_object_from_list(obj_list, target_id)
+        results = MCS_Reward._MCS_Reward__get_object_from_list(
+            obj_list, target_id)
         self.assertTrue(results)
         self.assertIsInstance(results, dict)
         self.assertEqual(results['objectId'], target_id)
@@ -53,40 +51,51 @@ class Test_MCS_Reward(unittest.TestCase):
     def test_target_not_in_object_list(self):
         obj_list = []
         for i in range(10):
-            obj_list.append({"objectId":str(i)})
-        target_id = '111' # not in list
-        results = MCS_Reward._MCS_Reward__get_object_from_list(obj_list, target_id)
+            obj_list.append({"objectId": str(i)})
+        target_id = '111'  # not in list
+        results = MCS_Reward._MCS_Reward__get_object_from_list(
+            obj_list, target_id)
         self.assertIsNone(results)
 
     def test_duplicate_target_ids_in_list(self):
         obj_list = []
         for i in range(10):
-            obj_list.append({"objectId":str(i)})
+            obj_list.append({"objectId": str(i)})
         # add duplicate object
-        obj_list.append({"objectId":'7', "duplicate": True})
+        obj_list.append({"objectId": '7', "duplicate": True})
         target_id = '7'
-        results = MCS_Reward._MCS_Reward__get_object_from_list(obj_list, target_id)
+        results = MCS_Reward._MCS_Reward__get_object_from_list(
+            obj_list, target_id)
         self.assertTrue(results)
         self.assertIsInstance(results, dict)
         self.assertEqual(results['objectId'], target_id)
-        # expect that method still returns the first instance and not the duplicate
+        # expect that method still returns the first instance and not the
+        # duplicate
         self.assertFalse('duplicate' in results)
 
     def test_convert_object_to_planar_polygon(self):
         goal_object = {'objectBounds': {'objectBoundsCorners': []}}
         # create lower plane (y = 0)
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 0.0, 'z': 0.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 0.0, 'z': 1.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 0.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 1.0, 'y': 0.0, 'z': 0.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 1.0, 'y': 0.0, 'z': 1.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 1.0})
         # create upper plane (y = 1)
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 1.0, 'z': 0.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 1.0, 'z': 1.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 0.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 1.0, 'y': 1.0, 'z': 0.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 1.0, 'y': 1.0, 'z': 1.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 1.0})
 
         polygon = MCS_Reward._convert_object_to_planar_polygon(goal_object)
-        
+
         self.assertIsInstance(polygon, geometry.Polygon)
         self.assertEqual(len(list(polygon.exterior.coords)), 5)
         self.assertIsInstance(list(polygon.exterior.coords)[0], Tuple)
@@ -95,15 +104,23 @@ class Test_MCS_Reward(unittest.TestCase):
         goal_object = {'objectBounds': {'objectBoundsCorners': []}}
 
         # create lower plane (y = 0)
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 0.0, 'z': 0.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 0.0, 'z': 1.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 0.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 1.0, 'y': 0.0, 'z': 0.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 1.0, 'y': 0.0, 'z': 1.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 1.0})
         # create upper plane (y = 1) but shifted over x and z by 1
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 1.0, 'z': 1.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':2.0, 'y': 1.0, 'z': 1.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':2.0, 'y': 1.0, 'z': 2.0})
-        goal_object['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 1.0, 'z': 2.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 1.0, 'y': 1.0, 'z': 1.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 2.0, 'y': 1.0, 'z': 1.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 2.0, 'y': 1.0, 'z': 2.0})
+        goal_object['objectBounds']['objectBoundsCorners'].append(
+            {'x': 1.0, 'y': 1.0, 'z': 2.0})
 
         polygon = MCS_Reward._convert_object_to_planar_polygon(goal_object)
 
@@ -138,22 +155,33 @@ class Test_MCS_Reward(unittest.TestCase):
         goal.metadata['target'] = {'id': '0'}
         obj_list = []
         for i in range(10):
-            obj = {"objectId":str(i), "objectBounds": {"objectBoundsCorners": []}}
+            obj = {
+                "objectId": str(i),
+                "objectBounds": {
+                    "objectBoundsCorners": []}}
             # create lower plane (y = 0)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 0.0, 'z': 1.0})
             # create upper plane (y = 1)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 1.0, 'z': 1.0})
             obj['position'] = {'x': 0.0 + i, 'z': 0.0}
-            
+
             obj_list.append(obj)
 
-        agent = {'position': {'x':-0.9, 'y': 0.5, 'z':0.0}}
+        agent = {'position': {'x': -0.9, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 1)
         self.assertIsInstance(reward, int)
@@ -161,136 +189,172 @@ class Test_MCS_Reward(unittest.TestCase):
     def test_traversal_reward_large_object_inside(self):
         goal = MCS_Goal()
         goal.metadata['target'] = {'id': '0'}
-        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        obj = {"objectId": str(0), "objectBounds": {"objectBoundsCorners": []}}
         # create lower plane (y = 0)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 10.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 10.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 10.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 10.0})
         # create upper plane (y = 1)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 10.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 10.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 10.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 10.0})
         obj['position'] = {'x': 0.0, 'z': 0.0}
         obj_list = []
         obj_list.append(obj)
-        
+
         agent = {'position': {'x': 5.0, 'y': 0.5, 'z': 5.0}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 1)
-        self.assertIsInstance(reward, int) 
+        self.assertIsInstance(reward, int)
 
     def test_traversal_reward_large_object_long_side(self):
         goal = MCS_Goal()
         goal.metadata['target'] = {'id': '0'}
-        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        obj = {"objectId": str(0), "objectBounds": {"objectBoundsCorners": []}}
         # create lower plane (y = 0)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 1.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 1.0})
         # create upper plane (y = 1)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 1.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 1.0})
         obj['position'] = {'x': 0.0, 'z': 0.0}
         obj_list = []
         obj_list.append(obj)
-        
+
         agent = {'position': {'x': 10.1, 'y': 0.5, 'z': 1.1}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 1)
-        self.assertIsInstance(reward, int)        
+        self.assertIsInstance(reward, int)
 
     def test_traversal_reward_large_object_long_side_out_of_reach(self):
         goal = MCS_Goal()
         goal.metadata['target'] = {'id': '0'}
-        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        obj = {"objectId": str(0), "objectBounds": {"objectBoundsCorners": []}}
         # create lower plane (y = 0)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 1.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 1.0})
         # create upper plane (y = 1)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 1.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 1.0})
         obj['position'] = {'x': 0.0, 'z': 0.0}
         obj_list = []
         obj_list.append(obj)
-        
+
         agent = {'position': {'x': 11.1, 'y': 0.5, 'z': 1.1}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 0)
-        self.assertIsInstance(reward, int)   
+        self.assertIsInstance(reward, int)
 
     def test_traversal_reward_large_object_short_side(self):
         goal = MCS_Goal()
         goal.metadata['target'] = {'id': '0'}
-        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        obj = {"objectId": str(0), "objectBounds": {"objectBoundsCorners": []}}
         # create lower plane (y = 0)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 1.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 1.0})
         # create upper plane (y = 1)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 1.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 1.0})
         obj['position'] = {'x': 0.0, 'z': 0.0}
         obj_list = []
         obj_list.append(obj)
-        
+
         agent = {'position': {'x': -0.5, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 1)
-        self.assertIsInstance(reward, int)        
+        self.assertIsInstance(reward, int)
 
     def test_traversal_reward_large_object_short_side_out_of_reach(self):
         goal = MCS_Goal()
         goal.metadata['target'] = {'id': '0'}
-        obj = {"objectId":str(0), "objectBounds": {"objectBoundsCorners": []}}
+        obj = {"objectId": str(0), "objectBounds": {"objectBoundsCorners": []}}
         # create lower plane (y = 0)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 0.0, 'z': 1.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 0.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 0.0, 'z': 1.0})
         # create upper plane (y = 1)
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 0.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':10.0, 'y': 1.0, 'z': 1.0})
-        obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 0.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 10.0, 'y': 1.0, 'z': 1.0})
+        obj['objectBounds']['objectBoundsCorners'].append(
+            {'x': 0.0, 'y': 1.0, 'z': 1.0})
         obj['position'] = {'x': 0.0, 'z': 0.0}
         obj_list = []
         obj_list.append(obj)
-        
+
         agent = {'position': {'x': -1.5, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 0)
-        self.assertIsInstance(reward, int)     
+        self.assertIsInstance(reward, int)
 
     def test_traversal_reward_outside_agent_reach(self):
         goal = MCS_Goal()
         goal.metadata['target'] = {'id': '0'}
         obj_list = []
-        for i in range(10):
-            obj = {"objectId":str(i), "distanceXZ": 1.1}
-        agent = {'position': {'x':-0.9, 'y': 0.5, 'z':-1.0}}
+        agent = {'position': {'x': -0.9, 'y': 0.5, 'z': -1.0}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 0)
         self.assertIsInstance(reward, int)
 
     def test_traversal_reward_with_missing_target(self):
         goal = MCS_Goal()
-        goal.metadata['target'] = {'id': '111'} # missing target
+        goal.metadata['target'] = {'id': '111'}  # missing target
         obj_list = []
-        for i in range(10):
-            obj = {"objectId":str(i), "distanceXZ": 0.3 * i}
-        agent = {'position': {'x':-0.9, 'y': 0.5, 'z':0.0}}
+        agent = {'position': {'x': -0.9, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_traversal_reward(goal, obj_list, agent)
         self.assertEqual(reward, 0)
         self.assertIsInstance(reward, int)
@@ -302,20 +366,31 @@ class Test_MCS_Reward(unittest.TestCase):
         goal.metadata['relationship'] = []
         obj_list = []
         for i in range(10):
-            obj = {"objectId":str(i), "objectBounds": {"objectBoundsCorners": []}}
+            obj = {
+                "objectId": str(i),
+                "objectBounds": {
+                    "objectBoundsCorners": []}}
             # create lower plane (y = 0)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 0.0, 'z': 1.0})
             # create upper plane (y = 1)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 1.0, 'z': 1.0})
             obj['position'] = {'x': 0.5 + i, 'z': 0.5}
             obj_list.append(obj)
-        agent = {'position': {'x':-0.9, 'y': 0.5, 'z':0.0}}
+        agent = {'position': {'x': -0.9, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_transferral_reward(goal, obj_list, agent)
         self.assertEqual(reward, 0)
         self.assertIsInstance(reward, int)
@@ -327,20 +402,31 @@ class Test_MCS_Reward(unittest.TestCase):
         goal.metadata['relationship'] = ['target_1', 'next to', 'target_2']
         obj_list = []
         for i in range(10):
-            obj = {"objectId":str(i), "objectBounds": {"objectBoundsCorners": []}}
+            obj = {
+                "objectId": str(i),
+                "objectBounds": {
+                    "objectBoundsCorners": []}}
             # create lower plane (y = 0)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 0.0, 'z': 1.0})
             # create upper plane (y = 1)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 1.0, 'z': 1.0})
             obj['position'] = {'x': 0.5 + i, 'z': 0.5}
             obj_list.append(obj)
-        agent = {'position': {'x':-0.9, 'y': 0.5, 'z':0.0}}
+        agent = {'position': {'x': -0.9, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_transferral_reward(goal, obj_list, agent)
         self.assertEqual(reward, 1)
         self.assertIsInstance(reward, int)
@@ -352,20 +438,32 @@ class Test_MCS_Reward(unittest.TestCase):
         goal.metadata['relationship'] = ['target_1', 'next to', 'target_2']
         obj_list = []
         for i in range(10):
-            obj = {"objectId":str(i), "objectBounds": {"objectBoundsCorners": []}, "isPickedUp": True}
+            obj = {
+                "objectId": str(i),
+                "objectBounds": {
+                    "objectBoundsCorners": []},
+                "isPickedUp": True}
             # create lower plane (y = 0)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 0.0, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 0.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 0.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 0.0, 'z': 1.0})
             # create upper plane (y = 1)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0 + i, 'y': 1.0, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 1.0, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0 + i, 'y': 1.0, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0 + i, 'y': 1.0, 'z': 1.0})
             obj['position'] = {'x': 0.5 + i, 'z': 0.5}
             obj_list.append(obj)
-        agent = {'position': {'x':-0.9, 'y': 0.5, 'z':0.0}}
+        agent = {'position': {'x': -0.9, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_transferral_reward(goal, obj_list, agent)
         self.assertEqual(reward, 0)
         self.assertIsInstance(reward, int)
@@ -377,20 +475,31 @@ class Test_MCS_Reward(unittest.TestCase):
         goal.metadata['relationship'] = ['target_1', 'on top of', 'target_2']
         obj_list = []
         for i in range(10):
-            obj = {"objectId":str(i), "objectBounds": {"objectBoundsCorners": []}}
+            obj = {
+                "objectId": str(i),
+                "objectBounds": {
+                    "objectBoundsCorners": []}}
             # create lower plane (y = 0)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0 + i, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 0.0 + i, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 0.0 + i, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0 + i, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0, 'y': 0.0 + i, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0, 'y': 0.0 + i, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0, 'y': 0.0 + i, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0, 'y': 0.0 + i, 'z': 1.0})
             # create upper plane (y = 1) + i
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0 + i, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 1.0 + i, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 1.0 + i, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0 + i, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0, 'y': 1.0 + i, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0, 'y': 1.0 + i, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0, 'y': 1.0 + i, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0, 'y': 1.0 + i, 'z': 1.0})
             obj['position'] = {'x': 0.5, 'y': 0.0 + i, 'z': 0.5}
             obj_list.append(obj)
-        agent = {'position': {'x':-0.9, 'y': 0.5, 'z':0.0}}
+        agent = {'position': {'x': -0.9, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_transferral_reward(goal, obj_list, agent)
         self.assertEqual(reward, 1)
         self.assertIsInstance(reward, int)
@@ -398,24 +507,36 @@ class Test_MCS_Reward(unittest.TestCase):
     def test_transferral_reward_on_top_of_with_pickedup_object(self):
         goal = MCS_Goal()
         goal.metadata['target_1'] = {'id': '0'}
-        goal.metadata['target_2'] = {'id': '1'}        
+        goal.metadata['target_2'] = {'id': '1'}
         goal.metadata['relationship'] = ['target_1', 'on top of', 'target_2']
         obj_list = []
         for i in range(10):
-            obj = {"objectId":str(i), "objectBounds": {"objectBoundsCorners": []}, "isPickedUp": True}
+            obj = {
+                "objectId": str(i),
+                "objectBounds": {
+                    "objectBoundsCorners": []},
+                "isPickedUp": True}
             # create lower plane (y = 0)
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0 + i, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 0.0 + i, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 0.0 + i, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 0.0 + i, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0, 'y': 0.0 + i, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0, 'y': 0.0 + i, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0, 'y': 0.0 + i, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0, 'y': 0.0 + i, 'z': 1.0})
             # create upper plane (y = 1) + i
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0 + i, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 1.0 + i, 'z': 0.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':1.0, 'y': 1.0 + i, 'z': 1.0})
-            obj['objectBounds']['objectBoundsCorners'].append({'x':0.0, 'y': 1.0 + i, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0, 'y': 1.0 + i, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0, 'y': 1.0 + i, 'z': 0.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 1.0, 'y': 1.0 + i, 'z': 1.0})
+            obj['objectBounds']['objectBoundsCorners'].append(
+                {'x': 0.0, 'y': 1.0 + i, 'z': 1.0})
             obj['position'] = {'x': 0.5, 'y': 0.0 + i, 'z': 0.5}
             obj_list.append(obj)
-        agent = {'position': {'x':-0.9, 'y': 0.5, 'z':0.0}}
+        agent = {'position': {'x': -0.9, 'y': 0.5, 'z': 0.0}}
         reward = MCS_Reward._calc_transferral_reward(goal, obj_list, agent)
         self.assertEqual(reward, 0)
         self.assertIsInstance(reward, int)

--- a/python_api/test/test_mcs_step_output.py
+++ b/python_api/test/test_mcs_step_output.py
@@ -63,7 +63,8 @@ class Test_Default_MCS_Step_Output(unittest.TestCase):
         self.assertIsInstance(self.mcs_step_output.camera_aspect_ratio, tuple)
 
     def test_camera_clipping_planes(self):
-        self.assertIsInstance(self.mcs_step_output.camera_clipping_planes, tuple)
+        self.assertIsInstance(
+            self.mcs_step_output.camera_clipping_planes, tuple)
 
     def test_camera_field_of_view(self):
         self.assertIsInstance(self.mcs_step_output.camera_field_of_view, float)
@@ -77,7 +78,7 @@ class Test_Default_MCS_Step_Output(unittest.TestCase):
 
     def test_goal(self):
         self.assertIsInstance(self.mcs_step_output.goal, MCS_Goal)
-    
+
     def test_head_tilt(self):
         self.assertAlmostEqual(self.mcs_step_output.head_tilt, 0.0)
         self.assertIsInstance(self.mcs_step_output.head_tilt, float)
@@ -102,13 +103,15 @@ class Test_Default_MCS_Step_Output(unittest.TestCase):
         self.assertIsInstance(self.mcs_step_output.position, dict)
 
     def test_return_status(self):
-        self.assertEqual(self.mcs_step_output.return_status, MCS_Return_Status.UNDEFINED.value)
+        self.assertEqual(
+            self.mcs_step_output.return_status,
+            MCS_Return_Status.UNDEFINED.value)
         self.assertIsInstance(self.mcs_step_output.return_status, str)
 
     def test_reward(self):
         self.assertEqual(self.mcs_step_output.reward, 0)
         self.assertIsInstance(self.mcs_step_output.reward, int)
-        
+
     def test_rotation(self):
         self.assertAlmostEqual(self.mcs_step_output.rotation, 0.0)
         self.assertIsInstance(self.mcs_step_output.rotation, float)
@@ -119,7 +122,9 @@ class Test_Default_MCS_Step_Output(unittest.TestCase):
 
     def test_structural_object_list(self):
         self.assertFalse(self.mcs_step_output.structural_object_list)
-        self.assertIsInstance(self.mcs_step_output.structural_object_list, list)
+        self.assertIsInstance(
+            self.mcs_step_output.structural_object_list, list)
 
     def test_str(self):
-        self.assertEqual(str(self.mcs_step_output), textwrap.dedent(self.str_output))
+        self.assertEqual(str(self.mcs_step_output),
+                         textwrap.dedent(self.str_output))

--- a/python_api/test/test_mcs_util.py
+++ b/python_api/test/test_mcs_util.py
@@ -3,10 +3,12 @@ import unittest
 from machine_common_sense.mcs_object import MCS_Object
 from machine_common_sense.mcs_util import MCS_Util
 
+
 class My_Emptyclass:
 
     def __init__(self):
         pass
+
 
 class My_Subclass:
 
@@ -21,6 +23,7 @@ class My_Subclass:
 
     def __str__(self):
         return MCS_Util.class_to_str(self)
+
 
 class My_Class:
 
@@ -51,11 +54,12 @@ class My_Class:
     def my_function():
         pass
 
+
 class Test_MCS_Util(unittest.TestCase):
 
     def test_class_to_str_with_class(self):
         self.maxDiff = 10000
-        expected = "{\n    \"my_boolean\": true,\n    \"my_float\": 1.234,\n    \"my_integer\": 0,\n    \"my_string\": \"a\",\n    \"my_list\": [\n        1,\n        \"b\",\n        {\n            \"my_integer\": 2,\n            \"my_string\": \"c\",\n            \"my_list\": [\n                3,\n                \"d\"\n            ]\n        }\n    ],\n    \"my_dict\": {\n        \"my_integer\": 4,\n        \"my_string\": \"e\",\n        \"my_list\": [\n            5,\n            \"f\"\n        ],\n        \"my_dict\": {\n            \"my_integer\": 6,\n            \"my_string\": \"g\"\n        }\n    },\n    \"my_list_empty\": [],\n    \"my_dict_empty\": {},\n    \"my_subclass\": {\n        \"my_integer\": 7,\n        \"my_string\": \"h\",\n        \"my_list\": [\n            8,\n            \"i\"\n        ],\n        \"my_dict\": {\n            \"my_integer\": 9,\n            \"my_string\": \"j\"\n        }\n    }\n}"
+        expected = "{\n    \"my_boolean\": true,\n    \"my_float\": 1.234,\n    \"my_integer\": 0,\n    \"my_string\": \"a\",\n    \"my_list\": [\n        1,\n        \"b\",\n        {\n            \"my_integer\": 2,\n            \"my_string\": \"c\",\n            \"my_list\": [\n                3,\n                \"d\"\n            ]\n        }\n    ],\n    \"my_dict\": {\n        \"my_integer\": 4,\n        \"my_string\": \"e\",\n        \"my_list\": [\n            5,\n            \"f\"\n        ],\n        \"my_dict\": {\n            \"my_integer\": 6,\n            \"my_string\": \"g\"\n        }\n    },\n    \"my_list_empty\": [],\n    \"my_dict_empty\": {},\n    \"my_subclass\": {\n        \"my_integer\": 7,\n        \"my_string\": \"h\",\n        \"my_list\": [\n            8,\n            \"i\"\n        ],\n        \"my_dict\": {\n            \"my_integer\": 9,\n            \"my_string\": \"j\"\n        }\n    }\n}"  # noqa: E501
         self.assertEqual(MCS_Util.class_to_str(My_Class()), expected)
 
     def test_class_to_str_with_empty_class(self):
@@ -97,25 +101,32 @@ class Test_MCS_Util(unittest.TestCase):
             )
         ]
         self.assertEqual(MCS_Util.generate_pretty_object_output(object_list), [
-            'OBJECT ID        SHAPE  COLORS        HELD   POSITION (WORLD)  DIMENSIONS (WORLD)  DISTANCE (WORLD)     DIRECTION (WORLD)  ',
-            'id1                                   True   None              None                0                    None               ',
-            'really_long_id2  sofa   black, white  False  (1,2,3)           (4,5,6)             1234567890987654321  (10000,20000,30000)'
+            'OBJECT ID        SHAPE  COLORS        HELD   POSITION (WORLD)  DIMENSIONS (WORLD)  DISTANCE (WORLD)     DIRECTION (WORLD)  ',  # noqa: E501
+            'id1                                   True   None              None                0                    None               ',  # noqa: E501
+            'really_long_id2  sofa   black, white  False  (1,2,3)           (4,5,6)             1234567890987654321  (10000,20000,30000)'  # noqa: E501
         ])
 
     def test_input_to_action_and_params(self):
-        self.assertEqual(MCS_Util.input_to_action_and_params('MoveBack'), ('MoveBack', {}))
-        self.assertEqual(MCS_Util.input_to_action_and_params('RotateLook,rotation=12.34'), ('RotateLook', {
-            'rotation': 12.34
-        }))
-        self.assertEqual(MCS_Util.input_to_action_and_params('PickupObject,objectId=testId'), ('PickupObject', {
-            'objectId': 'testId'
-        }))
-        self.assertEqual(MCS_Util.input_to_action_and_params('PushObject,objectId=testId,force=12.34'), ('PushObject', {
-            'objectId': 'testId',
-            'force': 12.34
-        }))
-        self.assertEqual(MCS_Util.input_to_action_and_params('Foobar'), (None, {}))
-        self.assertEqual(MCS_Util.input_to_action_and_params('MoveBack,key:value'), ('MoveBack', None))
+        self.assertEqual(MCS_Util.input_to_action_and_params(
+            'MoveBack'), ('MoveBack', {}))
+        self.assertEqual(MCS_Util.input_to_action_and_params(
+            'RotateLook,rotation=12.34'), ('RotateLook', {'rotation': 12.34}))
+        self.assertEqual(
+            MCS_Util.input_to_action_and_params(
+                'PickupObject,objectId=testId'
+            ),
+            ('PickupObject', {'objectId': 'testId'})
+        )
+        self.assertEqual(
+            MCS_Util.input_to_action_and_params(
+                'PushObject,objectId=testId,force=12.34'
+            ),
+            ('PushObject', {'objectId': 'testId', 'force': 12.34})
+        )
+        self.assertEqual(
+            MCS_Util.input_to_action_and_params('Foobar'), (None, {}))
+        self.assertEqual(MCS_Util.input_to_action_and_params(
+            'MoveBack,key:value'), ('MoveBack', None))
 
     def test_is_in_range(self):
         self.assertEqual(MCS_Util.is_in_range(0, 0, 1, 1234), 0)
@@ -179,7 +190,8 @@ class Test_MCS_Util(unittest.TestCase):
 
     def test_value_to_str_with_list(self):
         self.assertEqual(MCS_Util.value_to_str([]), "[]")
-        self.assertEqual(MCS_Util.value_to_str([1, "a"]), "[\n    1,\n    \"a\"\n]")
+        self.assertEqual(MCS_Util.value_to_str(
+            [1, "a"]), "[\n    1,\n    \"a\"\n]")
 
     def test_value_to_str_with_string(self):
         self.assertEqual(MCS_Util.value_to_str(""), "\"\"")
@@ -198,4 +210,3 @@ class Test_MCS_Util(unittest.TestCase):
         self.assertEqual(MCS_Util.verify_material_enum_string('Plastic'), True)
         self.assertEqual(MCS_Util.verify_material_enum_string('Foobar'), False)
         self.assertEqual(MCS_Util.verify_material_enum_string(''), False)
-


### PR DESCRIPTION
Trying to move more towards the recommendations listed here: 
https://www.python.org/dev/peps/pep-0008/

[Flake8](https://flake8.pycqa.org/en/latest/) and [autopep8](https://pypi.org/project/autopep8/0.8/) have been added to the requirements.txt (be sure to install), and should be configured to work within the python_api/ project within vscode and on commit (should point out errors and autoformat files on save when possible). Most of our errors had to do with line length, and those sometimes have to be fixed by hand (yay). Some had to do with unused imports -- had some issues with these but I ran the unit tests and ran a scene as I went along to test and make sure things were still working, but if you wanted to take a closer look/retest things yourself, it will be much appreciated :)

I updated the READMEs, but once you reinstall the python_api/requirements.txt, you’ll need to run this to get the git hook setup:
```
pre-commit install 
```

For some of the trickier line length issues here and there that weren’t autoformatted, I used the code formatter black. I think it’s a neat tool, but its very opinionated and people either love it or hate it. I’ll link it here in case anyone’s curious/we might want to use it in the future: https://github.com/psf/black
