### PR TITLE
MCS-38 - Autoformatting on scene generator code

### DIFF
--- a/python_api/machine_common_sense/README.md
+++ b/python_api/machine_common_sense/README.md
@@ -89,11 +89,11 @@ flake8
 and
 
 ```
-autopep8 --in-place --aggressive --aggressive --recursive <directory>
+autopep8 --in-place --aggressive --recursive <directory>
 ```
 or
 ```
-autopep8 --in-place --aggressive --aggressive <file>
+autopep8 --in-place --aggressive <file>
 ```
 
 ## Making GIFs

--- a/scene_generator/.vscode/settings.json
+++ b/scene_generator/.vscode/settings.json
@@ -4,9 +4,7 @@
     "python.linting.lintOnSave": true,
     "python.linting.flake8Args": [
         "--ignore",
-        "E402,W504",
-        "--exclude",
-        "__init__.py"
+        "E402,W504"
     ],
     "python.formatting.provider": "autopep8",
     "python.formatting.autopep8Args": [

--- a/scene_generator/containers.py
+++ b/scene_generator/containers.py
@@ -7,14 +7,15 @@ import objects
 import util
 
 
-def put_object_in_container(obj_def: Dict[str, Any], obj: Dict[str, Any], container: Dict[str, Any], \
-        container_def: Dict[str, Any], area_index: int, rotation: Optional[float] = None) -> None:
+def put_object_in_container(obj_def: Dict[str, Any], obj: Dict[str, Any], container: Dict[str, Any],
+                            container_def: Dict[str, Any], area_index: int, rotation: Optional[float] = None) -> None:
 
     area = container_def['enclosedAreas'][area_index]
     obj['locationParent'] = container['id']
 
     obj['shows'][0]['position'] = area['position'].copy()
-    obj['shows'][0]['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def.get('positionY', 0)
+    obj['shows'][0]['position']['y'] += - \
+        (area['dimensions']['y'] / 2.0) + obj_def.get('positionY', 0)
 
     if 'rotation' not in obj['shows'][0]:
         obj['shows'][0]['rotation'] = geometry.ORIGIN.copy()
@@ -24,9 +25,10 @@ def put_object_in_container(obj_def: Dict[str, Any], obj: Dict[str, Any], contai
     # if it had a boundingBox, it's not valid any more
     obj.pop('boundingBox', None)
 
-    obj['shows'][0]['boundingBox'] = geometry.generate_object_bounds(obj_def['dimensions'], \
-            (obj_def['offset'] if 'offset' in obj_def else None), obj['shows'][0]['position'], \
-            obj['shows'][0]['rotation'])
+    obj['shows'][0]['boundingBox'] = geometry.generate_object_bounds(obj_def['dimensions'],
+                                                                     (
+        obj_def['offset'] if 'offset' in obj_def else None), obj['shows'][0]['position'],
+        obj['shows'][0]['rotation'])
 
 
 class Orientation(Enum):
@@ -34,20 +36,23 @@ class Orientation(Enum):
     FRONT_TO_BACK = auto()
 
 
-def put_objects_in_container(obj_def_a: Dict[str, Any], obj_a: Dict[str, Any], obj_def_b: Dict[str, Any], \
-        obj_b: Dict[str, Any], container: Dict[str, Any], container_def: Dict[str, Any], area_index: int, \
-        orientation: Orientation, rot_a: float, rot_b: float) -> None:
+def put_objects_in_container(obj_def_a: Dict[str, Any], obj_a: Dict[str, Any], obj_def_b: Dict[str, Any],
+                             obj_b: Dict[str, Any], container: Dict[str, Any], container_def: Dict[str, Any], area_index: int,
+                             orientation: Orientation, rot_a: float, rot_b: float) -> None:
     """Put two objects in the same enclosed area of a
     container. orientation determines how they are laid out with
     respect to each other within the container. rot_a and rot_b must
     be either 0 or 90.
     """
     if rot_a not in (0, 90):
-        raise ValueError('only 0 and 90 degree rotations supported for object a, not {rot_a}')
+        raise ValueError(
+            'only 0 and 90 degree rotations supported for object a, not {rot_a}')
     if rot_b not in (0, 90):
-        raise ValueError('only 0 and 90 degree rotations supported for object b, not {rot_b}')
+        raise ValueError(
+            'only 0 and 90 degree rotations supported for object b, not {rot_b}')
 
-    # TODO This function should probably verify that both objects can fit together inside the container...
+    # TODO This function should probably verify that both objects can fit
+    # together inside the container...
 
     area = container_def['enclosedAreas'][area_index]
     obj_a['locationParent'] = container['id']
@@ -83,24 +88,29 @@ def put_objects_in_container(obj_def_a: Dict[str, Any], obj_a: Dict[str, Any], o
         shows_b['position'] = area['position'].copy()
         shows_b['position']['z'] += height_b / 2.0
 
-    shows_a['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def_a.get('positionY', 0)
-    shows_b['position']['y'] += -(area['dimensions']['y'] / 2.0) + obj_def_b.get('positionY', 0)
-    shows_a['rotation'] = { 'y': rot_a }
-    shows_b['rotation'] = { 'y': rot_b }
+    shows_a['position']['y'] += - \
+        (area['dimensions']['y'] / 2.0) + obj_def_a.get('positionY', 0)
+    shows_b['position']['y'] += - \
+        (area['dimensions']['y'] / 2.0) + obj_def_b.get('positionY', 0)
+    shows_a['rotation'] = {'y': rot_a}
+    shows_b['rotation'] = {'y': rot_b}
 
     # any boundingBox they may have had is not valid any more
     shows_a.pop('boundingBox', None)
     shows_b.pop('boundingBox', None)
 
-    shows_a['boundingBox'] = geometry.generate_object_bounds(obj_def_a['dimensions'], \
-            (obj_def_a['offset'] if 'offset' in obj_def_a else None), shows_a['position'], \
-            shows_a['rotation'])
-    shows_b['boundingBox'] = geometry.generate_object_bounds(obj_def_b['dimensions'], \
-            (obj_def_b['offset'] if 'offset' in obj_def_b else None), shows_b['position'], \
-            shows_b['rotation'])
+    shows_a['boundingBox'] = geometry.generate_object_bounds(obj_def_a['dimensions'],
+                                                             (
+        obj_def_a['offset'] if 'offset' in obj_def_a else None), shows_a['position'],
+        shows_a['rotation'])
+    shows_b['boundingBox'] = geometry.generate_object_bounds(obj_def_b['dimensions'],
+                                                             (
+        obj_def_b['offset'] if 'offset' in obj_def_b else None), shows_b['position'],
+        shows_b['rotation'])
 
 
-def can_enclose(area: Dict[str, Any], target: Dict[str, Any]) -> Optional[float]:
+def can_enclose(area: Dict[str, Any],
+                target: Dict[str, Any]) -> Optional[float]:
     """iff each 'dimensions' of area is >= the corresponding dimension
     of target, returns 0 (degrees). Otherwise it returns 90 if
     target fits in area when it's rotated 90 degrees. Otherwise it
@@ -145,24 +155,27 @@ def how_can_contain(container: Dict[str, Any],
 
 def get_enclosable_containments(objs: Sequence[Dict[str, Any]],
                                 container_defs: Sequence[Dict[str, Any]] = None) \
-                                -> List[Tuple[Dict[str, Any], int, List[float]]]:
+        -> List[Tuple[Dict[str, Any], int, List[float]]]:
     """Return a list of object definitions for containers that can enclose all the pass objects objs."""
     if container_defs is None:
         container_defs = retrieve_enclosable_object_definition_list()
     valid_containments = []
     for container_def in container_defs:
-        possible_enclosable_definition_list = util.finalize_each_object_definition_choice(container_def)
+        possible_enclosable_definition_list = util.finalize_each_object_definition_choice(
+            container_def)
         for possible_enclosable_definition in possible_enclosable_definition_list:
-            containment = how_can_contain(possible_enclosable_definition, *objs)
+            containment = how_can_contain(
+                possible_enclosable_definition, *objs)
             if containment:
                 index, angles = containment
-                valid_containments.append((possible_enclosable_definition, index, angles))
+                valid_containments.append(
+                    (possible_enclosable_definition, index, angles))
     return valid_containments
 
 
 def _ea_can_contain_both(ea_def: Dict[str, Any],
                          obj_a: Dict[str, Any], obj_b: Dict[str, Any]) \
-                         -> Optional[Tuple[Orientation, float, float]]:
+        -> Optional[Tuple[Orientation, float, float]]:
     ax = obj_a['dimensions']['x']
     bx = obj_b['dimensions']['x']
     az = obj_a['dimensions']['z']
@@ -221,8 +234,8 @@ def _ea_can_contain_both(ea_def: Dict[str, Any],
 
 
 def _eas_can_contain_both(enclosed_areas: Sequence[Dict[str, Any]],
-                         obj_a: Dict[str, Any], obj_b: Dict[str, Any]) \
-                         -> Optional[Tuple[int, Orientation, float, float]]:
+                          obj_a: Dict[str, Any], obj_b: Dict[str, Any]) \
+        -> Optional[Tuple[int, Orientation, float, float]]:
     for i in range(len(enclosed_areas)):
         ea = enclosed_areas[i]
         result = _ea_can_contain_both(ea, obj_a, obj_b)
@@ -234,9 +247,11 @@ def _eas_can_contain_both(enclosed_areas: Sequence[Dict[str, Any]],
 
 def can_contain_both(container_def: Dict[str, Any], obj_a: Dict[str, Any], obj_b: Dict[str, Any]) \
         -> Optional[Tuple[Dict[str, Any], int, Orientation, float, float]]:
-    possible_enclosable_definition_list = util.finalize_each_object_definition_choice(container_def)
+    possible_enclosable_definition_list = util.finalize_each_object_definition_choice(
+        container_def)
     for possible_enclosable_definition in possible_enclosable_definition_list:
-        result = _eas_can_contain_both(possible_enclosable_definition['enclosedAreas'], obj_a, obj_b)
+        result = _eas_can_contain_both(
+            possible_enclosable_definition['enclosedAreas'], obj_a, obj_b)
         if result:
             index, orientation, angle_a, angle_b = result
             new_def = util.finalize_object_definition(container_def)
@@ -244,7 +259,8 @@ def can_contain_both(container_def: Dict[str, Any], obj_a: Dict[str, Any], obj_b
     return None
 
 
-# TODO Can we delete this function and just use get_enclosable_containments instead?
+# TODO Can we delete this function and just use
+# get_enclosable_containments instead?
 def find_suitable_enclosable_list(obj: Dict[str, Any], container_defs: Sequence[Dict[str, Any]] = None) -> \
         List[Dict[str, Any]]:
     """Find and return the list of enclosable receptacle definitions into which the given object can fit."""
@@ -252,11 +268,12 @@ def find_suitable_enclosable_list(obj: Dict[str, Any], container_defs: Sequence[
     if container_defs is None:
         container_defs = retrieve_enclosable_object_definition_list()
     for obj_def in container_defs:
-        possible_enclosable_definition_list = util.finalize_each_object_definition_choice(obj_def)
+        possible_enclosable_definition_list = util.finalize_each_object_definition_choice(
+            obj_def)
         for possible_enclosable_definition in possible_enclosable_definition_list:
             for area in possible_enclosable_definition['enclosedAreas']:
-                if (area['dimensions']['x'] >= obj['dimensions']['x'] and \
-                        area['dimensions']['y'] >= obj['dimensions']['y'] and \
+                if (area['dimensions']['x'] >= obj['dimensions']['x'] and
+                        area['dimensions']['y'] >= obj['dimensions']['y'] and
                         area['dimensions']['z'] >= obj['dimensions']['z']):
                     valid_defs.append(possible_enclosable_definition)
     return valid_defs
@@ -264,8 +281,9 @@ def find_suitable_enclosable_list(obj: Dict[str, Any], container_defs: Sequence[
 
 def retrieve_enclosable_object_definition_list() -> List[Dict[str, Any]]:
     output_list = []
-    for object_definition in util.retrieve_full_object_definition_list(objects.get('ALL')):
-        if 'enclosedAreas' in object_definition and len(object_definition['enclosedAreas']) > 0:
+    for object_definition in util.retrieve_full_object_definition_list(
+            objects.get('ALL')):
+        if 'enclosedAreas' in object_definition and len(
+                object_definition['enclosedAreas']) > 0:
             output_list.append(object_definition)
     return output_list
-

--- a/scene_generator/containers_test.py
+++ b/scene_generator/containers_test.py
@@ -13,29 +13,42 @@ PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS = ['duck_on_wheels', 'box_2', 'box_3']
 
 
 def test_put_object_in_container():
-    for obj_def in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
-        obj_location = geometry.calc_obj_pos({'x': 1, 'y': 0, 'z': 1}, [], obj_def)
+    for obj_def in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
+        obj_location = geometry.calc_obj_pos(
+            {'x': 1, 'y': 0, 'z': 1}, [], obj_def)
         obj = util.instantiate_object(obj_def, obj_location)
         obj_bounds = obj['shows'][0]['boundingBox']
 
         containments = get_enclosable_containments([obj_def])
-        if len(containments) == 0 and obj_def['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS:
-            print(f'pickupable object should have at least one containment: {obj_def}')
+        if len(
+                containments) == 0 and obj_def['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS:
+            print(
+                f'pickupable object should have at least one containment: {obj_def}')
             assert False
 
         for containment in containments:
             container_def, area_index, rotations = containment
-            container_location = geometry.calc_obj_pos({'x': -1, 'y': 0, 'z': -1}, [], container_def)
-            container = util.instantiate_object(container_def, container_location)
+            container_location = geometry.calc_obj_pos(
+                {'x': -1, 'y': 0, 'z': -1}, [], container_def)
+            container = util.instantiate_object(
+                container_def, container_location)
 
-            put_object_in_container(obj_def, obj, container, container_def, area_index, rotations[0])
+            put_object_in_container(
+                obj_def,
+                obj,
+                container,
+                container_def,
+                area_index,
+                rotations[0])
 
             assert obj['locationParent'] == container['id']
             assert obj['shows'][0]['position']['x'] == container_def['enclosedAreas'][0]['position']['x']
             expected_position_y = container_def['enclosedAreas'][0]['position']['y'] - \
-                    (container_def['enclosedAreas'][area_index]['dimensions']['y'] / 2.0) + \
-                    obj_def.get('positionY', 0)
-            assert obj['shows'][0]['position']['y'] == pytest.approx(expected_position_y)
+                (container_def['enclosedAreas'][area_index]['dimensions']['y'] / 2.0) + \
+                obj_def.get('positionY', 0)
+            assert obj['shows'][0]['position']['y'] == pytest.approx(
+                expected_position_y)
             assert obj['shows'][0]['position']['z'] == container_def['enclosedAreas'][0]['position']['z']
             assert obj['shows'][0]['rotation']
             assert obj['shows'][0]['boundingBox']
@@ -43,26 +56,32 @@ def test_put_object_in_container():
 
 
 def test_put_objects_in_container():
-    for obj_a_def in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
+    for obj_a_def in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
         obj_a_location = geometry.calc_obj_pos(geometry.ORIGIN, [], obj_a_def)
         obj_a = util.instantiate_object(obj_a_def, obj_a_location)
         obj_a_bounds = obj_a['shows'][0]['boundingBox']
 
-        for obj_b_def in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
-            obj_b_location = geometry.calc_obj_pos(geometry.ORIGIN, [], obj_b_def)
+        for obj_b_def in util.retrieve_full_object_definition_list(
+                objects.get('PICKUPABLE')):
+            obj_b_location = geometry.calc_obj_pos(
+                geometry.ORIGIN, [], obj_b_def)
             obj_b = util.instantiate_object(obj_b_def, obj_b_location)
             obj_b_bounds = obj_b['shows'][0]['boundingBox']
 
             containments = get_enclosable_containments([obj_a_def, obj_b_def])
             if len(containments) == 0 and obj_a_def['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS and \
                     obj_b_def['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS:
-                print(f'pair of pickupable objects should have at least one containment:\nobject_a={obj_a_def}\nobject_b={obj_b_def}')
+                print(
+                    f'pair of pickupable objects should have at least one containment:\nobject_a={obj_a_def}\nobject_b={obj_b_def}')
                 assert False
 
             for containment in containments:
                 container_def, area_index, rotations = containment
-                container_location = geometry.calc_obj_pos(geometry.ORIGIN, [], container_def)
-                container = util.instantiate_object(container_def, container_location)
+                container_location = geometry.calc_obj_pos(
+                    geometry.ORIGIN, [], container_def)
+                container = util.instantiate_object(
+                    container_def, container_location)
 
                 put_objects_in_container(obj_a_def, obj_a, obj_b_def, obj_b, container, container_def, area_index,
                                          Orientation.SIDE_BY_SIDE, rotations[0], rotations[1])
@@ -109,7 +128,8 @@ def test_how_can_contain():
             'z': 42
         }
     }
-    container_def = util.finalize_object_definition(retrieve_enclosable_object_definition_list()[0])
+    container_def = util.finalize_object_definition(
+        retrieve_enclosable_object_definition_list()[0])
     assert how_can_contain(container_def, small) is not None
     assert how_can_contain(container_def, big) is None
     assert how_can_contain(container_def, small, big) is None
@@ -137,16 +157,20 @@ def test_can_contain_both():
             'z': 42
         }
     }
-    container_def = util.finalize_object_definition(retrieve_enclosable_object_definition_list()[0])
+    container_def = util.finalize_object_definition(
+        retrieve_enclosable_object_definition_list()[0])
     assert can_contain_both(container_def, small1, small2) is not None
     assert can_contain_both(container_def, small1, big) is None
 
 
 def test_get_enclosable_containments():
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
         containments = get_enclosable_containments([target_definition])
-        if len(containments) == 0 and target_definition['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS:
-            print(f'pickupable object should have at least one containment: {target_definition}')
+        if len(
+                containments) == 0 and target_definition['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS:
+            print(
+                f'pickupable object should have at least one containment: {target_definition}')
             assert False
         for containment in containments:
             definition, index, angles = containment
@@ -170,7 +194,8 @@ def test_get_enclosable_containments_multiple_object():
             'z': 0.02
         }
     }
-    containments = get_enclosable_containments([target_definition_1, target_definition_2])
+    containments = get_enclosable_containments(
+        [target_definition_1, target_definition_2])
     assert len(containments) > 0
     for containment in containments:
         definition, index, angles = containment
@@ -180,10 +205,12 @@ def test_get_enclosable_containments_multiple_object():
 
 
 def test_find_suitable_enclosable_list():
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
         enclosable_list = find_suitable_enclosable_list(target_definition)
-        if len(enclosable_list) == 0 and target_definition['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS:
-            print(f'pickupable object should have at least one enclosable: {target_definition}')
+        if len(
+                enclosable_list) == 0 and target_definition['type'] not in PICKUPABLE_OBJECTS_WITHOUT_CONTAINMENTS:
+            print(
+                f'pickupable object should have at least one enclosable: {target_definition}')
             assert False
         assert True
-

--- a/scene_generator/geometry.py
+++ b/scene_generator/geometry.py
@@ -73,14 +73,26 @@ def collision(test_rect: List[Dict[str, float]], test_point: Dict[str, float]):
     B = test_rect[1]
     C = test_rect[2]
 
-    vectorAB = {'x': B['x'] - A['x'], 'y': B['y'] - A['y'], 'z': B['z'] - A['z']}
-    vectorBC = {'x': C['x'] - B['x'], 'y': C['y'] - B['y'], 'z': C['z'] - B['z']}
+    vectorAB = {
+        'x': B['x'] - A['x'],
+        'y': B['y'] - A['y'],
+        'z': B['z'] - A['z']}
+    vectorBC = {
+        'x': C['x'] - B['x'],
+        'y': C['y'] - B['y'],
+        'z': C['z'] - B['z']}
 
-    vectorAM = {'x': test_point['x'] - A['x'], 'y': test_point['y'] - A['y'], 'z': test_point['z'] - A['z']}
-    vectorBM = {'x': test_point['x'] - B['x'], 'y': test_point['y'] - B['y'], 'z': test_point['z'] - B['z']}
+    vectorAM = {
+        'x': test_point['x'] - A['x'],
+        'y': test_point['y'] - A['y'],
+        'z': test_point['z'] - A['z']}
+    vectorBM = {
+        'x': test_point['x'] - B['x'],
+        'y': test_point['y'] - B['y'],
+        'z': test_point['z'] - B['z']}
 
     return (0 <= dot_prod_dict(vectorAB, vectorAM) <= dot_prod_dict(vectorAB, vectorAB)) & (
-                0 <= dot_prod_dict(vectorBC, vectorBM) <= dot_prod_dict(vectorBC, vectorBC))
+        0 <= dot_prod_dict(vectorBC, vectorBM) <= dot_prod_dict(vectorBC, vectorBC))
 
 
 def calc_obj_coords(position_x: float, position_z: float, delta_x: float, delta_z: float, offset_x: float,
@@ -94,11 +106,15 @@ def calc_obj_coords(position_x: float, position_z: float, delta_x: float, delta_
     x_minus = -delta_x + offset_x
     z_plus = delta_z + offset_z
     z_minus = -delta_z + offset_z
-    
-    a = {'x': position_x + x_plus * rotate_cos - z_plus * rotate_sin, 'y': 0, 'z': position_z + x_plus * rotate_sin + z_plus * rotate_cos}
-    b = {'x': position_x + x_plus * rotate_cos - z_minus * rotate_sin, 'y': 0, 'z': position_z + x_plus * rotate_sin + z_minus * rotate_cos}
-    c = {'x': position_x + x_minus * rotate_cos - z_minus * rotate_sin, 'y': 0, 'z': position_z + x_minus * rotate_sin + z_minus * rotate_cos}
-    d = {'x': position_x + x_minus * rotate_cos - z_plus * rotate_sin, 'y': 0, 'z': position_z + x_minus * rotate_sin + z_plus * rotate_cos}
+
+    a = {'x': position_x + x_plus * rotate_cos - z_plus * rotate_sin,
+         'y': 0, 'z': position_z + x_plus * rotate_sin + z_plus * rotate_cos}
+    b = {'x': position_x + x_plus * rotate_cos - z_minus * rotate_sin,
+         'y': 0, 'z': position_z + x_plus * rotate_sin + z_minus * rotate_cos}
+    c = {'x': position_x + x_minus * rotate_cos - z_minus * rotate_sin,
+         'y': 0, 'z': position_z + x_minus * rotate_sin + z_minus * rotate_cos}
+    d = {'x': position_x + x_minus * rotate_cos - z_plus * rotate_sin,
+         'y': 0, 'z': position_z + x_minus * rotate_sin + z_plus * rotate_cos}
 
     return [a, b, c, d]
 
@@ -119,7 +135,7 @@ def calc_obj_pos(performer_position: Dict[str, float],
                  z_func: Callable[[], float] = random_position_z,
                  rotation_func: Callable[[], float] = random_rotation,
                  xz_func: Callable[[], Tuple[float, float]] = None) \
-                 -> Optional[Dict[str, Any]]:
+        -> Optional[Dict[str, Any]]:
     """Returns new object with rotation & position if we can place the
     object in the frame, None otherwise."""
 
@@ -139,7 +155,8 @@ def calc_obj_pos(performer_position: Dict[str, float],
     collision_rects = other_rects + [performer_rect]
     while tries < util.MAX_TRIES:
         rotation_x = (obj_def['rotation']['x'] if 'rotation' in obj_def else 0)
-        rotation_y = (obj_def['rotation']['y'] if 'rotation' in obj_def else 0) + rotation_func()
+        rotation_y = (obj_def['rotation']['y']
+                      if 'rotation' in obj_def else 0) + rotation_func()
         rotation_z = (obj_def['rotation']['z'] if 'rotation' in obj_def else 0)
         if xz_func is not None:
             new_x, new_z = xz_func()
@@ -148,15 +165,17 @@ def calc_obj_pos(performer_position: Dict[str, float],
             new_z = z_func()
 
         if new_x is not None and new_z is not None:
-            rect = calc_obj_coords(new_x, new_z, dx, dz, offset_x, offset_z, rotation_y)
-            if rect_within_room(rect) and not any(sat_entry(rect, other_rect) for other_rect in collision_rects):
+            rect = calc_obj_coords(
+                new_x, new_z, dx, dz, offset_x, offset_z, rotation_y)
+            if rect_within_room(rect) and not any(
+                    sat_entry(rect, other_rect) for other_rect in collision_rects):
                 break
         tries += 1
 
     if tries < util.MAX_TRIES:
         new_object = {
             'rotation': {'x': rotation_x, 'y': rotation_y, 'z': rotation_z},
-            'position':  {'x': new_x, 'y': obj_def.get('positionY', 0), 'z': new_z},
+            'position': {'x': new_x, 'y': obj_def.get('positionY', 0), 'z': new_z},
             'boundingBox': rect
         }
         other_rects.append(rect)
@@ -166,7 +185,8 @@ def calc_obj_pos(performer_position: Dict[str, float],
     return None
 
 
-def occluders_too_close(occluder: Dict[str, Any], x_position: float, x_scale: float) -> bool:
+def occluders_too_close(
+        occluder: Dict[str, Any], x_position: float, x_scale: float) -> bool:
     """Return True iff a new occluder at x_position with scale x_scale
     would be too close to existing occluder occluder."""
     existing_scale = occluder['shows'][0]['scale']['x']
@@ -177,7 +197,8 @@ def occluders_too_close(occluder: Dict[str, Any], x_position: float, x_scale: fl
 
 def position_distance(a: Dict[str, float], b: Dict[str, float]) -> float:
     """Compute the distance between two positions."""
-    return math.sqrt((a['x'] - b['x'])**2 + (a['y'] - b['y'])**2 + (a['z'] - b['z'])**2)
+    return math.sqrt((a['x'] - b['x'])**2 + (a['y'] -
+                                             b['y'])**2 + (a['z'] - b['z'])**2)
 
 
 def get_room_box() -> shapely.geometry.Polygon:
@@ -193,15 +214,18 @@ def get_visible_segment(performer_start: Dict[str, Dict[str, float]]) \
     """
     max_dimension = max(ROOM_X_MAX - ROOM_X_MIN, ROOM_Z_MAX - ROOM_Z_MIN)
     # make it long enough for the far end to be outside the room
-    view_segment = shapely.geometry.LineString([[0, MIN_FORWARD_VISIBILITY_DISTANCE], [0, max_dimension * 2]])
-    view_segment = affinity.rotate(view_segment, -performer_start['rotation']['y'], origin=(0, 0))
+    view_segment = shapely.geometry.LineString(
+        [[0, MIN_FORWARD_VISIBILITY_DISTANCE], [0, max_dimension * 2]])
+    view_segment = affinity.rotate(
+        view_segment, -performer_start['rotation']['y'], origin=(0, 0))
     view_segment = affinity.translate(view_segment, performer_start['position']['x'],
                                       performer_start['position']['z'])
     room = get_room_box()
 
     target_segment = room.intersection(view_segment)
     if target_segment.is_empty:
-        logging.debug(f'performer too close to the wall, cannot place object in front of it (performer location={performer_start})')
+        logging.debug(
+            f'performer too close to the wall, cannot place object in front of it (performer location={performer_start})')
         return None
     return target_segment
 
@@ -209,7 +233,7 @@ def get_visible_segment(performer_start: Dict[str, Dict[str, float]]) \
 def get_location_in_front_of_performer(performer_start: Dict[str, Dict[str, float]],
                                        target_def: Dict[str, Any],
                                        rotation_func: Callable[[], float] = random_rotation) \
-                                       -> Optional[Dict[str, Any]]:
+        -> Optional[Dict[str, Any]]:
     visible_segment = get_visible_segment(performer_start)
     if not visible_segment:
         return None
@@ -228,25 +252,33 @@ def get_location_in_back_of_performer(performer_start: Dict[str, Dict[str, float
     # First, find the part of the the room that's behind the performer
     # (i.e., the 180 degree arc in the opposite direction from its orientation)
     # if the performer were at the origin facing 0, this box would be behind it
-    rear_poly = shapely.geometry.box(-(ROOM_X_MAX - ROOM_X_MIN) / 2.0, -(ROOM_Z_MAX - ROOM_Z_MIN) / 2.0, \
-            (ROOM_X_MAX - ROOM_X_MIN) / 2.0, 0)
-    performer_point = shapely.geometry.Point(performer_start['position']['x'], performer_start['position']['z'])
-    rear_poly = affinity.translate(rear_poly, performer_point.x, performer_point.y)
-    rear_poly = affinity.rotate(rear_poly, -performer_start['rotation']['y'], origin=performer_point)
+    rear_poly = shapely.geometry.box(-(ROOM_X_MAX - ROOM_X_MIN) / 2.0, -(ROOM_Z_MAX - ROOM_Z_MIN) / 2.0,
+                                     (ROOM_X_MAX - ROOM_X_MIN) / 2.0, 0)
+    performer_point = shapely.geometry.Point(
+        performer_start['position']['x'],
+        performer_start['position']['z'])
+    rear_poly = affinity.translate(
+        rear_poly,
+        performer_point.x,
+        performer_point.y)
+    rear_poly = affinity.rotate(
+        rear_poly, -performer_start['rotation']['y'], origin=performer_point)
 
     # Restrict the rear bounds to the room's dimensions.
     rear_min_x = min(ROOM_X_MAX, max(ROOM_X_MIN, rear_poly.bounds[0]))
     rear_min_z = min(ROOM_Z_MAX, max(ROOM_Z_MIN, rear_poly.bounds[1]))
     rear_max_x = min(ROOM_X_MAX, max(ROOM_X_MIN, rear_poly.bounds[2]))
     rear_max_z = min(ROOM_Z_MAX, max(ROOM_Z_MIN, rear_poly.bounds[3]))
-    rear_poly = shapely.geometry.box(rear_min_x, rear_min_z, rear_max_x, rear_max_z)
+    rear_poly = shapely.geometry.box(
+        rear_min_x, rear_min_z, rear_max_x, rear_max_z)
 
     def compute_xz():
         # pick a random x within the polygon's bounding rectangle
         for _ in range(util.MAX_TRIES):
             x = util.random_real(rear_min_x, rear_max_x)
             # intersect a vertical line with the poly at that x
-            vertical_line = shapely.geometry.LineString([[x, rear_min_z], [x, rear_max_z]])
+            vertical_line = shapely.geometry.LineString(
+                [[x, rear_min_z], [x, rear_max_z]])
             target_segment = vertical_line.intersection(rear_poly)
             if not target_segment.is_empty:
                 break
@@ -262,11 +294,12 @@ def get_location_in_back_of_performer(performer_start: Dict[str, Dict[str, float
             location = target_segment.interpolate(fraction, normalized=True)
         return location.x, location.y
 
-    return calc_obj_pos(performer_start['position'], [], target_def, xz_func=compute_xz)
+    return calc_obj_pos(performer_start['position'], [
+    ], target_def, xz_func=compute_xz)
 
 
-def get_adjacent_location(obj_def: Dict[str, Any], target_definition: Dict[str, Any], target_location: Dict[str, Any], \
-        performer_start: Dict[str, Dict[str, float]], obstruct: bool = False) -> Optional[Dict[str, Any]]:
+def get_adjacent_location(obj_def: Dict[str, Any], target_definition: Dict[str, Any], target_location: Dict[str, Any],
+                          performer_start: Dict[str, Dict[str, float]], obstruct: bool = False) -> Optional[Dict[str, Any]]:
     """Find a location such that, if obj_def is instantiated there, it
     will be next to target. Ensures that the object at the new
     location will not overlap the performer start, if necessary trying
@@ -275,13 +308,15 @@ def get_adjacent_location(obj_def: Dict[str, Any], target_definition: Dict[str, 
     sides = list(range(4))
     random.shuffle(sides)
     for side in sides:
-        location = get_adjacent_location_on_side(obj_def, target_definition, target_location, performer_start, side, \
-                obstruct)
+        location = get_adjacent_location_on_side(obj_def, target_definition, target_location, performer_start, side,
+                                                 obstruct)
         if location:
-            # If obstruct, position the target so that the object is between it and the performer start.
+            # If obstruct, position the target so that the object is between it
+            # and the performer start.
             if obstruct:
                 location_poly = get_bounding_polygon(location)
-                if does_fully_obstruct_target(performer_start['position'], target_location, location_poly):
+                if does_fully_obstruct_target(
+                        performer_start['position'], target_location, location_poly):
                     return location
             else:
                 return location
@@ -295,8 +330,8 @@ class Side(IntEnum):
     FRONT = 3
 
 
-def get_adjacent_location_on_side(object_definition: Dict[str, Any], target_definition: Dict[str, Any], \
-        target_location: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], side: Side, obstruct: bool) -> \
+def get_adjacent_location_on_side(object_definition: Dict[str, Any], target_definition: Dict[str, Any],
+                                  target_location: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], side: Side, obstruct: bool) -> \
         Optional[Dict[str, Any]]:
     """Get a location such that, if object_definition is instantiated there, it will
     be next to target. Side determines on which side of target to
@@ -306,35 +341,50 @@ def get_adjacent_location_on_side(object_definition: Dict[str, Any], target_defi
     None is returned."
     """
     object_dimensions = object_definition['dimensions']
-    object_offset = object_definition['offset'] if 'offset' in object_definition else {'x': 0, 'z': 0}
+    object_offset = object_definition['offset'] if 'offset' in object_definition else {
+        'x': 0, 'z': 0}
     if obstruct and 'closedDimensions' in object_definition:
         object_dimensions = object_definition['closedDimensions']
         object_offset = object_definition['closedOffset'] if 'closedOffset' in object_definition else object_offset
-    target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
+    target_offset = target_definition['offset'] if 'offset' in target_definition else {
+        'x': 0, 'z': 0}
 
     distance_prop = 'x' if side in (0, 2) else 'z'
-    distance = object_dimensions[distance_prop] / 2.0 + target_definition['dimensions'][distance_prop] / 2.0 + MIN_GAP
+    distance = object_dimensions[distance_prop] / 2.0 + \
+        target_definition['dimensions'][distance_prop] / 2.0 + MIN_GAP
 
-    # Create a line pointing from the origin to the right, then rotate that line using the given side.
+    # Create a line pointing from the origin to the right, then rotate that
+    # line using the given side.
     separator_segment = shapely.geometry.LineString([[0, 0], [distance, 0]])
     separator_segment_rotation = -target_location['rotation']['y'] + 90 * side
-    separator_segment = affinity.rotate(separator_segment, -separator_segment_rotation, origin=(0, 0))
-    separator_segment = affinity.translate(separator_segment, (target_location['position']['x'] + target_offset['x']), \
-            (target_location['position']['z'] + target_offset['z']))
+    separator_segment = affinity.rotate(
+        separator_segment, -separator_segment_rotation, origin=(0, 0))
+    separator_segment = affinity.translate(separator_segment, (target_location['position']['x'] + target_offset['x']),
+                                           (target_location['position']['z'] + target_offset['z']))
 
     x = separator_segment.coords[1][0] - object_offset['x']
     z = separator_segment.coords[1][1] - object_offset['z']
     dx = object_dimensions['x'] / 2.0
     dz = object_dimensions['z'] / 2.0
-    rect = calc_obj_coords(x, z, dx, dz, object_offset['x'], object_offset['z'], target_location['rotation']['y'])
+    rect = calc_obj_coords(
+        x,
+        z,
+        dx,
+        dz,
+        object_offset['x'],
+        object_offset['z'],
+        target_location['rotation']['y'])
     poly = rect_to_poly(rect)
-    performer = shapely.geometry.Point(performer_start['position']['x'], performer_start['position']['z'])
-    target_rect = generate_object_bounds(target_definition['dimensions'], target_offset, \
-            target_location['position'], target_location['rotation'])
+    performer = shapely.geometry.Point(
+        performer_start['position']['x'],
+        performer_start['position']['z'])
+    target_rect = generate_object_bounds(target_definition['dimensions'], target_offset,
+                                         target_location['position'], target_location['rotation'])
     target_poly = rect_to_poly(target_rect)
     room = get_room_box()
 
-    if not poly.intersects(performer) and not poly.intersects(target_poly) and room.contains(poly):
+    if not poly.intersects(performer) and not poly.intersects(
+            target_poly) and room.contains(poly):
         location = {
             'position': {
                 'x': x,
@@ -353,7 +403,8 @@ def get_adjacent_location_on_side(object_definition: Dict[str, Any], target_defi
     return location
 
 
-def get_wider_and_taller_defs(obj_def: Dict[str, Any], obstruct_vision: bool) -> List[Tuple[Dict[str, Any], float]]:
+def get_wider_and_taller_defs(
+        obj_def: Dict[str, Any], obstruct_vision: bool) -> List[Tuple[Dict[str, Any], float]]:
     """Return all object definitions both taller and either wider or
     deeper. If wider (x-axis), angle 0 is returned; if deeper
     (z-axis), 90 degrees is returned. Objects returned may be equal in
@@ -362,15 +413,20 @@ def get_wider_and_taller_defs(obj_def: Dict[str, Any], obstruct_vision: bool) ->
     possible_defs = []
     bigger_defs = []
     for new_def in objects.get('ALL'):
-        possible_defs = possible_defs + util.finalize_each_object_definition_choice(new_def)
+        possible_defs = possible_defs + \
+            util.finalize_each_object_definition_choice(new_def)
     for big_def in possible_defs:
         # Only look at definitions with the obstruct property.
-        if 'obstruct' in big_def and big_def['obstruct'] == ('vision' if obstruct_vision else 'navigation'):
+        if 'obstruct' in big_def and big_def['obstruct'] == (
+                'vision' if obstruct_vision else 'navigation'):
             obj_dimensions = obj_def['closedDimensions'] if 'closedDimensions' in obj_def else obj_def['dimensions']
             big_dimensions = big_def['closedDimensions'] if 'closedDimensions' in big_def else big_def['dimensions']
-            cannot_walk_over = big_dimensions['y'] >= (PERFORMER_CAMERA_Y / 2.0)
-            # Only need a bigger Y dimension if the object must obstruct vision.
-            if cannot_walk_over and (not obstruct_vision or big_dimensions['y'] >= obj_dimensions['y']):
+            cannot_walk_over = big_dimensions['y'] >= (
+                PERFORMER_CAMERA_Y / 2.0)
+            # Only need a bigger Y dimension if the object must obstruct
+            # vision.
+            if cannot_walk_over and (
+                    not obstruct_vision or big_dimensions['y'] >= obj_dimensions['y']):
                 if big_dimensions['x'] >= obj_dimensions['x']:
                     bigger_defs.append((big_def, 0))
                 elif big_dimensions['z'] >= obj_dimensions['x']:
@@ -378,9 +434,11 @@ def get_wider_and_taller_defs(obj_def: Dict[str, Any], obstruct_vision: bool) ->
     return bigger_defs
 
 
-def get_bounding_polygon(object_or_location: Dict[str, Any]) -> shapely.geometry.Polygon:
+def get_bounding_polygon(
+        object_or_location: Dict[str, Any]) -> shapely.geometry.Polygon:
     if 'boundingBox' in object_or_location:
-        bounding_box: List[Dict[str, float]] = object_or_location['boundingBox']
+        bounding_box: List[Dict[str, float]
+                           ] = object_or_location['boundingBox']
         poly = rect_to_poly(bounding_box)
     else:
         show = object_or_location['shows'][0]
@@ -388,7 +446,8 @@ def get_bounding_polygon(object_or_location: Dict[str, Any]) -> shapely.geometry
             bounding_box: List[Dict[str, float]] = show['boundingBox']
             poly = rect_to_poly(bounding_box)
         else:
-            # TODO I think we need to consider the affect of the object's offsets on its poly here
+            # TODO I think we need to consider the affect of the object's
+            # offsets on its poly here
             x = show['position']['x']
             z = show['position']['z']
             dx = object_or_location['dimensions']['x'] / 2.0
@@ -398,7 +457,8 @@ def get_bounding_polygon(object_or_location: Dict[str, Any]) -> shapely.geometry
     return poly
 
 
-def are_adjacent(obj_a: Dict[str, Any], obj_b: Dict[str, Any], distance: float = MAX_OBJECTS_ADJACENT_DISTANCE) -> bool:
+def are_adjacent(obj_a: Dict[str, Any], obj_b: Dict[str, Any],
+                 distance: float = MAX_OBJECTS_ADJACENT_DISTANCE) -> bool:
     poly_a = get_bounding_polygon(obj_a)
     poly_b = get_bounding_polygon(obj_b)
     actual_distance = poly_a.distance(poly_b)
@@ -410,7 +470,8 @@ def rect_to_poly(rect: List[Dict[str, Any]]) -> shapely.geometry.Polygon:
     return shapely.geometry.Polygon(points)
 
 
-def find_performer_rect(performer_position: Dict[str, float]) -> List[Dict[str, float]]:
+def find_performer_rect(
+        performer_position: Dict[str, float]) -> List[Dict[str, float]]:
     return [
         {'x': performer_position['x'] - util.PERFORMER_HALF_WIDTH,
          'z': performer_position['z'] - util.PERFORMER_HALF_WIDTH},
@@ -427,13 +488,13 @@ def set_location_rotation(definition: Dict[str, Any], location: Dict[str, float]
         Dict[str, float]:
     """Updates the Y rotation and the bounding box of the given location and returns the location."""
     location['rotation']['y'] = rotation_y
-    location['boundingBox'] = generate_object_bounds(definition['dimensions'], \
-            (definition['offset'] if 'offset' in definition else None), location['position'], location['rotation'])
+    location['boundingBox'] = generate_object_bounds(definition['dimensions'],
+                                                     (definition['offset'] if 'offset' in definition else None), location['position'], location['rotation'])
     return location
 
 
-def generate_object_bounds(dimensions: Dict[str, float], offset: Dict[str, float], position: Dict[str, float], \
-        rotation: Dict[str, float]) -> List[Dict[str, float]]:
+def generate_object_bounds(dimensions: Dict[str, float], offset: Dict[str, float], position: Dict[str, float],
+                           rotation: Dict[str, float]) -> List[Dict[str, float]]:
     """Returns the bounds for the object with the given properties."""
     x = position['x']
     z = position['z']
@@ -444,33 +505,38 @@ def generate_object_bounds(dimensions: Dict[str, float], offset: Dict[str, float
     return calc_obj_coords(x, z, dx, dz, offset_x, offset_z, rotation['y'])
 
 
-def does_fully_obstruct_target(performer_start_position: Dict[str, float], target_or_location: Dict[str, Any], \
-        object_poly: shapely.geometry.Polygon) -> bool:
+def does_fully_obstruct_target(performer_start_position: Dict[str, float], target_or_location: Dict[str, Any],
+                               object_poly: shapely.geometry.Polygon) -> bool:
     """Returns whether the given object_poly obstructs each line between the given performer_start_position and
     all four corners of the given target object or location."""
 
-    return _does_obstruct_target_helper(performer_start_position, target_or_location, object_poly, fully=True)
+    return _does_obstruct_target_helper(
+        performer_start_position, target_or_location, object_poly, fully=True)
 
 
-def does_partly_obstruct_target(performer_start_position: Dict[str, float], target_or_location: Dict[str, Any], \
-        object_poly: shapely.geometry.Polygon) -> bool:
+def does_partly_obstruct_target(performer_start_position: Dict[str, float], target_or_location: Dict[str, Any],
+                                object_poly: shapely.geometry.Polygon) -> bool:
     """Returns whether the given object_poly obstructs one line between the given performer_start_position and
     the four corners of the given target object or location."""
 
-    return _does_obstruct_target_helper(performer_start_position, target_or_location, object_poly, fully=False)
+    return _does_obstruct_target_helper(
+        performer_start_position, target_or_location, object_poly, fully=False)
 
 
-def _does_obstruct_target_helper(performer_start_position: Dict[str, float], target_or_location: Dict[str, Any], \
-        object_poly: shapely.geometry.Polygon, fully: bool = False) -> bool:
+def _does_obstruct_target_helper(performer_start_position: Dict[str, float], target_or_location: Dict[str, Any],
+                                 object_poly: shapely.geometry.Polygon, fully: bool = False) -> bool:
 
     obstructing_corners = 0
-    performer_start_coordinates = (performer_start_position['x'], performer_start_position['z'])
+    performer_start_coordinates = (
+        performer_start_position['x'],
+        performer_start_position['z'])
     bounds = target_or_location['boundingBox'] if 'boundingBox' in target_or_location else \
-            (target_or_location['shows'][0]['boundingBox'] if 'shows' in target_or_location else [])
+        (target_or_location['shows'][0]['boundingBox']
+         if 'shows' in target_or_location else [])
     for corner in bounds:
         target_corner_coordinates = (corner['x'], corner['z'])
-        line_to_target = shapely.geometry.LineString([performer_start_coordinates, target_corner_coordinates])
+        line_to_target = shapely.geometry.LineString(
+            [performer_start_coordinates, target_corner_coordinates])
         if object_poly.intersects(line_to_target):
             obstructing_corners += 1
     return obstructing_corners == 4 if fully else obstructing_corners > 0
-

--- a/scene_generator/geometry_test.py
+++ b/scene_generator/geometry_test.py
@@ -21,12 +21,14 @@ def test_collision():
 
 
 def test_rect_intersection():
-    A = [{'x': 0, 'y': 0, 'z': 0}, {'x': 1, 'y': 0, 'z': 0}, {'x': 1, 'y': 0, 'z': 1}, {'x': 0, 'y': 0, 'z': 1}]
+    A = [{'x': 0, 'y': 0, 'z': 0}, {'x': 1, 'y': 0, 'z': 0},
+         {'x': 1, 'y': 0, 'z': 1}, {'x': 0, 'y': 0, 'z': 1}]
     B = [{'x': .25, 'y': 0, 'z': .25}, {'x': .75, 'y': 0, 'z': .25}, {'x': .75, 'y': 0, 'z': .75},
          {'x': .25, 'y': 0, 'z': .75}]
     C = [{'x': .8, 'y': 0, 'z': 1.2}, {'x': 1.1, 'y': 0, 'z': 1.8}, {'x': 2, 'y': 0, 'z': 1.5},
          {'x': 1.1, 'y': 0, 'z': .3}]
-    D = [{'x': 1, 'y': 0, 'z': 0}, {'x': 2, 'y': 0, 'z': 1.5}, {'x': 3, 'y': 0, 'z': 0}, {'x': 2, 'y': 0, 'z': -1.5}]
+    D = [{'x': 1, 'y': 0, 'z': 0}, {'x': 2, 'y': 0, 'z': 1.5},
+         {'x': 3, 'y': 0, 'z': 0}, {'x': 2, 'y': 0, 'z': -1.5}]
     # A intersects B,C,D. B ints A , C ints A & D, D ints A C
     # Testing transitivity as well
     assert sat_entry(A, B) is True
@@ -52,11 +54,12 @@ def test_point_within_room():
     }
     assert point_within_room(outside2) is False
     inside = {
-        'x': (ROOM_X_MIN + ROOM_X_MAX)/2.0,
+        'x': (ROOM_X_MIN + ROOM_X_MAX) / 2.0,
         'y': 0,
-        'z': (ROOM_Z_MIN + ROOM_Z_MAX)/2.0,
+        'z': (ROOM_Z_MIN + ROOM_Z_MAX) / 2.0,
     }
     assert point_within_room(inside) is True
+
 
 def test_mcs_157():
     bounding_box = [
@@ -83,7 +86,7 @@ def test_mcs_157():
     ]
     assert rect_within_room(bounding_box) is False
 
- 
+
 def test_calc_obj_coords_identity():
 
     a = {'x': 2, 'y': 0, 'z': 2}
@@ -102,7 +105,8 @@ def test_calc_obj_coords_identity():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 0})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 0})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -127,7 +131,8 @@ def test_calc_obj_coords_rotate90():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 90})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 90})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -152,7 +157,8 @@ def test_calc_obj_coords_rotate180():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 180})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 180})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -177,7 +183,8 @@ def test_calc_obj_coords_rotate270():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 270})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, None, {'x': 0, 'z': 0}, {'y': 270})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -202,7 +209,8 @@ def test_calc_obj_coords_nonorigin_identity():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 1, 'z': 1}, {'y': 0})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, None, {'x': 1, 'z': 1}, {'y': 0})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -227,7 +235,8 @@ def test_calc_obj_coords_nonorigin_rotate90():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, None, {'x': 1, 'z': 1}, {'y': 90})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, None, {'x': 1, 'z': 1}, {'y': 90})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -252,7 +261,8 @@ def test_calc_obj_coords_identity_offset():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 0}, {'y': 0})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 0}, {'y': 0})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -277,7 +287,8 @@ def test_calc_obj_coords_rotation90_offset():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 0}, {'y': 90})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 0}, {'y': 90})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -302,7 +313,8 @@ def test_calc_obj_coords_rotation90_offset_position_x():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 0}, {'y': 90})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 0}, {'y': 90})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -327,7 +339,8 @@ def test_calc_obj_coords_rotation90_offset_position_z():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 7}, {'y': 90})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 0, 'z': 7}, {'y': 90})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -352,7 +365,8 @@ def test_calc_obj_coords_rotation90_offset_position_xz():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 7}, {'y': 90})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 7}, {'y': 90})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -377,7 +391,8 @@ def test_calc_obj_coords_rotation45_offset_position_xz():
     assert new_c == pytest.approx(c)
     assert new_d == pytest.approx(d)
 
-    new_a, new_b, new_c, new_d = generate_object_bounds({'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 7}, {'y': 45})
+    new_a, new_b, new_c, new_d = generate_object_bounds(
+        {'x': 4, 'z': 4}, {'x': 1, 'z': 1}, {'x': 7, 'z': 7}, {'y': 45})
     assert new_a == pytest.approx(a)
     assert new_b == pytest.approx(b)
     assert new_c == pytest.approx(c)
@@ -393,7 +408,8 @@ def test__object_collision():
 
 
 def test_get_visible_segment():
-    actual = get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}})
+    actual = get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}})
     expected = shapely.geometry.LineString(
         [[0, MIN_FORWARD_VISIBILITY_DISTANCE], [0, ROOM_Z_MAX]]
     )
@@ -404,7 +420,8 @@ def test_get_visible_segment():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    actual = get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 45}})
+    actual = get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 45}})
     expected = shapely.geometry.LineString(
         [
             [
@@ -421,7 +438,8 @@ def test_get_visible_segment():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    actual = get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 90}})
+    actual = get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 90}})
     expected = shapely.geometry.LineString(
         [[MIN_FORWARD_VISIBILITY_DISTANCE, 0], [ROOM_X_MAX, 0]]
     )
@@ -432,7 +450,8 @@ def test_get_visible_segment():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    actual = get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 135}})
+    actual = get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 135}})
     expected = shapely.geometry.LineString(
         [
             [
@@ -450,7 +469,8 @@ def test_get_visible_segment():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    actual = get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 180}})
+    actual = get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 180}})
     expected = shapely.geometry.LineString(
         [[0, -MIN_FORWARD_VISIBILITY_DISTANCE], [0, -ROOM_Z_MAX]]
     )
@@ -461,7 +481,8 @@ def test_get_visible_segment():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    actual = get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 225}})
+    actual = get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 225}})
     expected = shapely.geometry.LineString(
         [
             [
@@ -478,7 +499,8 @@ def test_get_visible_segment():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    actual = get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 270}})
+    actual = get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 270}})
     expected = shapely.geometry.LineString(
         [[-MIN_FORWARD_VISIBILITY_DISTANCE, 0], [-ROOM_X_MAX, 0]]
     )
@@ -489,7 +511,8 @@ def test_get_visible_segment():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    actual = get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 315}})
+    actual = get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 315}})
     expected = shapely.geometry.LineString(
         [
             [
@@ -508,7 +531,8 @@ def test_get_visible_segment():
 
 
 def test_get_visible_segment_with_position():
-    actual = get_visible_segment({'position': {'x': 1, 'y': 0, 'z': 1}, 'rotation': {'y': 45}})
+    actual = get_visible_segment(
+        {'position': {'x': 1, 'y': 0, 'z': 1}, 'rotation': {'y': 45}})
     expected = shapely.geometry.LineString(
         [
             [
@@ -525,7 +549,8 @@ def test_get_visible_segment_with_position():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    actual = get_visible_segment({'position': {'x': -5, 'y': 0, 'z': -5}, 'rotation': {'y': 45}})
+    actual = get_visible_segment(
+        {'position': {'x': -5, 'y': 0, 'z': -5}, 'rotation': {'y': 45}})
     expected = shapely.geometry.LineString(
         [
             [
@@ -542,155 +567,311 @@ def test_get_visible_segment_with_position():
     assert actual_coords[1][0] == pytest.approx(expected_coords[1][0])
     assert actual_coords[1][1] == pytest.approx(expected_coords[1][1])
 
-    assert get_visible_segment({'position': {'x': 4.5, 'y': 0, 'z': 0}, 'rotation': {'y': 45}}) is None
-    assert get_visible_segment({'position': {'x': 0, 'y': 0, 'z': 4.5}, 'rotation': {'y': 45}}) is None
-    assert get_visible_segment({'position': {'x': 4.5, 'y': 0, 'z': 4.5}, 'rotation': {'y': 45}}) is None
-    assert get_visible_segment({'position': {'x': 5, 'y': 0, 'z': 0}, 'rotation': {'y': 45}}) is None
+    assert get_visible_segment(
+        {'position': {'x': 4.5, 'y': 0, 'z': 0}, 'rotation': {'y': 45}}) is None
+    assert get_visible_segment(
+        {'position': {'x': 0, 'y': 0, 'z': 4.5}, 'rotation': {'y': 45}}) is None
+    assert get_visible_segment(
+        {'position': {'x': 4.5, 'y': 0, 'z': 4.5}, 'rotation': {'y': 45}}) is None
+    assert get_visible_segment(
+        {'position': {'x': 5, 'y': 0, 'z': 0}, 'rotation': {'y': 45}}) is None
 
 
 def test_get_position_in_front_of_performer():
-    performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
+    performer_start = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'y': 0}}
 
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
         target_half_size_x = target_definition['dimensions']['x'] / 2.0
         target_half_size_z = target_definition['dimensions']['z'] / 2.0
 
         performer_start['rotation']['y'] = 0
-        positive_z = get_location_in_front_of_performer(performer_start, target_definition)
+        positive_z = get_location_in_front_of_performer(
+            performer_start, target_definition)
         assert 0 <= positive_z['position']['z'] <= ROOM_Z_MAX
-        assert -target_half_size_x <= positive_z['position']['x'] <= target_half_size_x
-        assert get_bounding_polygon(positive_z).intersection(shapely.geometry.LineString([[0, 1], [0, ROOM_Z_MAX]]))
+        assert - \
+            target_half_size_x <= positive_z['position']['x'] <= target_half_size_x
+        assert get_bounding_polygon(positive_z).intersection(
+            shapely.geometry.LineString([[0, 1], [0, ROOM_Z_MAX]]))
 
         performer_start['rotation']['y'] = 90
-        positive_x = get_location_in_front_of_performer(performer_start, target_definition)
+        positive_x = get_location_in_front_of_performer(
+            performer_start, target_definition)
         assert 0 <= positive_x['position']['x'] <= ROOM_X_MAX
-        assert -target_half_size_z <= positive_x['position']['z'] <= target_half_size_z
-        assert get_bounding_polygon(positive_x).intersection(shapely.geometry.LineString([[1, 0], [ROOM_X_MAX, 0]]))
+        assert - \
+            target_half_size_z <= positive_x['position']['z'] <= target_half_size_z
+        assert get_bounding_polygon(positive_x).intersection(
+            shapely.geometry.LineString([[1, 0], [ROOM_X_MAX, 0]]))
 
         performer_start['rotation']['y'] = 180
-        negative_z = get_location_in_front_of_performer(performer_start, target_definition)
+        negative_z = get_location_in_front_of_performer(
+            performer_start, target_definition)
         assert ROOM_Z_MIN <= negative_z['position']['z'] <= 0
-        assert -target_half_size_x <= negative_z['position']['x'] <= target_half_size_x
-        assert get_bounding_polygon(negative_z).intersection(shapely.geometry.LineString([[0, -1], [0, -ROOM_Z_MAX]]))
+        assert - \
+            target_half_size_x <= negative_z['position']['x'] <= target_half_size_x
+        assert get_bounding_polygon(negative_z).intersection(
+            shapely.geometry.LineString([[0, -1], [0, -ROOM_Z_MAX]]))
 
         performer_start['rotation']['y'] = 270
-        negative_x = get_location_in_front_of_performer(performer_start, target_definition)
+        negative_x = get_location_in_front_of_performer(
+            performer_start, target_definition)
         assert ROOM_X_MIN <= negative_x['position']['x'] <= 0
-        assert -target_half_size_z <= negative_x['position']['z'] <= target_half_size_z
-        assert get_bounding_polygon(negative_x).intersection(shapely.geometry.LineString([[-1, 0], [-ROOM_X_MAX, 0]]))
+        assert - \
+            target_half_size_z <= negative_x['position']['z'] <= target_half_size_z
+        assert get_bounding_polygon(negative_x).intersection(
+            shapely.geometry.LineString([[-1, 0], [-ROOM_X_MAX, 0]]))
 
 
 def test_get_position_in_front_of_performer_next_to_room_wall():
-    performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
+    performer_start = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'y': 0}}
 
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
         performer_start['position']['z'] = ROOM_Z_MAX
-        location = get_location_in_front_of_performer(performer_start, target_definition)
+        location = get_location_in_front_of_performer(
+            performer_start, target_definition)
         assert location is None
 
 
 def test_get_position_in_back_of_performer():
-    performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
+    performer_start = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'y': 0}}
 
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
         performer_start['rotation']['y'] = 0
-        negative_z = get_location_in_back_of_performer(performer_start, target_definition)
+        negative_z = get_location_in_back_of_performer(
+            performer_start, target_definition)
         assert 0 >= negative_z['position']['z'] >= ROOM_Z_MIN
         assert ROOM_X_MAX >= negative_z['position']['x'] >= ROOM_X_MIN
 
         performer_start['rotation']['y'] = 90
-        negative_x = get_location_in_back_of_performer(performer_start, target_definition)
+        negative_x = get_location_in_back_of_performer(
+            performer_start, target_definition)
         assert 0 >= negative_x['position']['x'] >= ROOM_X_MIN
         assert ROOM_Z_MAX >= negative_x['position']['z'] >= ROOM_Z_MIN
 
         performer_start['rotation']['y'] = 180
-        positive_z = get_location_in_back_of_performer(performer_start, target_definition)
+        positive_z = get_location_in_back_of_performer(
+            performer_start, target_definition)
         assert ROOM_Z_MAX >= positive_z['position']['z'] >= 0
         assert ROOM_X_MAX >= positive_z['position']['x'] >= ROOM_X_MIN
 
         performer_start['rotation']['y'] = 270
-        positive_x = get_location_in_back_of_performer(performer_start, target_definition)
+        positive_x = get_location_in_back_of_performer(
+            performer_start, target_definition)
         assert ROOM_X_MAX >= positive_x['position']['x'] >= 0
         assert ROOM_Z_MAX >= positive_x['position']['z'] >= ROOM_Z_MIN
 
 
 def test_get_position_in_back_of_performer_next_to_room_wall():
-    performer_start = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'y': 0}}
+    performer_start = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'y': 0}}
 
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
         performer_start['position']['z'] = ROOM_Z_MIN
-        location = get_location_in_back_of_performer(performer_start, target_definition)
+        location = get_location_in_back_of_performer(
+            performer_start, target_definition)
         assert location is None
 
 
 def test_are_adjacent():
     dimensions = {'x': 2, 'y': 2, 'z': 2}
 
-    center = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    center['boundingBox'] = generate_object_bounds(dimensions, None, center['position'], center['rotation'])
+    center = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    center['boundingBox'] = generate_object_bounds(
+        dimensions, None, center['position'], center['rotation'])
 
-    good_1 = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_1['boundingBox'] = generate_object_bounds(dimensions, None, good_1['position'], good_1['rotation'])
+    good_1 = {
+        'position': {
+            'x': 2, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    good_1['boundingBox'] = generate_object_bounds(
+        dimensions, None, good_1['position'], good_1['rotation'])
     assert are_adjacent(center, good_1)
 
-    good_2 = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_2['boundingBox'] = generate_object_bounds(dimensions, None, good_2['position'], good_2['rotation'])
+    good_2 = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': 0},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_2['boundingBox'] = generate_object_bounds(
+        dimensions, None, good_2['position'], good_2['rotation'])
     assert are_adjacent(center, good_2)
 
-    good_3 = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_3['boundingBox'] = generate_object_bounds(dimensions, None, good_3['position'], good_3['rotation'])
+    good_3 = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 2}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    good_3['boundingBox'] = generate_object_bounds(
+        dimensions, None, good_3['position'], good_3['rotation'])
     assert are_adjacent(center, good_3)
 
-    good_4 = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_4['boundingBox'] = generate_object_bounds(dimensions, None, good_4['position'], good_4['rotation'])
+    good_4 = {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': -2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_4['boundingBox'] = generate_object_bounds(
+        dimensions, None, good_4['position'], good_4['rotation'])
     assert are_adjacent(center, good_4)
 
-    good_5 = {'position': {'x': 2, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_5['boundingBox'] = generate_object_bounds(dimensions, None, good_5['position'], good_5['rotation'])
+    good_5 = {
+        'position': {
+            'x': 2, 'y': 0, 'z': 2}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    good_5['boundingBox'] = generate_object_bounds(
+        dimensions, None, good_5['position'], good_5['rotation'])
     assert are_adjacent(center, good_5)
 
-    good_6 = {'position': {'x': 2, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_6['boundingBox'] = generate_object_bounds(dimensions, None, good_6['position'], good_6['rotation'])
+    good_6 = {
+        'position': {
+            'x': 2,
+            'y': 0,
+            'z': -2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_6['boundingBox'] = generate_object_bounds(
+        dimensions, None, good_6['position'], good_6['rotation'])
     assert are_adjacent(center, good_6)
 
-    good_7 = {'position': {'x': -2, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_7['boundingBox'] = generate_object_bounds(dimensions, None, good_7['position'], good_7['rotation'])
+    good_7 = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': 2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_7['boundingBox'] = generate_object_bounds(
+        dimensions, None, good_7['position'], good_7['rotation'])
     assert are_adjacent(center, good_7)
 
-    good_8 = {'position': {'x': -2, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_8['boundingBox'] = generate_object_bounds(dimensions, None, good_8['position'], good_8['rotation'])
+    good_8 = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': -2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_8['boundingBox'] = generate_object_bounds(
+        dimensions, None, good_8['position'], good_8['rotation'])
     assert are_adjacent(center, good_8)
 
-    bad_1 = {'position': {'x': 3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_1['boundingBox'] = generate_object_bounds(dimensions, None, bad_1['position'], bad_1['rotation'])
+    bad_1 = {
+        'position': {
+            'x': 3, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    bad_1['boundingBox'] = generate_object_bounds(
+        dimensions, None, bad_1['position'], bad_1['rotation'])
     assert not are_adjacent(center, bad_1)
 
-    bad_2 = {'position': {'x': -3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_2['boundingBox'] = generate_object_bounds(dimensions, None, bad_2['position'], bad_2['rotation'])
+    bad_2 = {
+        'position': {
+            'x': -3,
+            'y': 0,
+            'z': 0},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_2['boundingBox'] = generate_object_bounds(
+        dimensions, None, bad_2['position'], bad_2['rotation'])
     assert not are_adjacent(center, bad_2)
 
-    bad_3 = {'position': {'x': 0, 'y': 0, 'z': 3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_3['boundingBox'] = generate_object_bounds(dimensions, None, bad_3['position'], bad_3['rotation'])
+    bad_3 = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 3}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    bad_3['boundingBox'] = generate_object_bounds(
+        dimensions, None, bad_3['position'], bad_3['rotation'])
     assert not are_adjacent(center, bad_3)
 
-    bad_4 = {'position': {'x': 0, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_4['boundingBox'] = generate_object_bounds(dimensions, None, bad_4['position'], bad_4['rotation'])
+    bad_4 = {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': -3},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_4['boundingBox'] = generate_object_bounds(
+        dimensions, None, bad_4['position'], bad_4['rotation'])
     assert not are_adjacent(center, bad_4)
 
-    bad_5 = {'position': {'x': 2.5, 'y': 0, 'z': 2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_5['boundingBox'] = generate_object_bounds(dimensions, None, bad_5['position'], bad_5['rotation'])
+    bad_5 = {
+        'position': {
+            'x': 2.5, 'y': 0, 'z': 2.5}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    bad_5['boundingBox'] = generate_object_bounds(
+        dimensions, None, bad_5['position'], bad_5['rotation'])
     assert not are_adjacent(center, bad_5)
 
-    bad_6 = {'position': {'x': 2.5, 'y': 0, 'z': -2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_6['boundingBox'] = generate_object_bounds(dimensions, None, bad_6['position'], bad_6['rotation'])
+    bad_6 = {
+        'position': {
+            'x': 2.5,
+            'y': 0,
+            'z': -2.5},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_6['boundingBox'] = generate_object_bounds(
+        dimensions, None, bad_6['position'], bad_6['rotation'])
     assert not are_adjacent(center, bad_6)
 
-    bad_7 = {'position': {'x': -2.5, 'y': 0, 'z': 2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_7['boundingBox'] = generate_object_bounds(dimensions, None, bad_7['position'], bad_7['rotation'])
+    bad_7 = {
+        'position': {
+            'x': -2.5,
+            'y': 0,
+            'z': 2.5},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_7['boundingBox'] = generate_object_bounds(
+        dimensions, None, bad_7['position'], bad_7['rotation'])
     assert not are_adjacent(center, bad_7)
 
-    bad_8 = {'position': {'x': -2.5, 'y': 0, 'z': -2.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_8['boundingBox'] = generate_object_bounds(dimensions, None, bad_8['position'], bad_8['rotation'])
+    bad_8 = {
+        'position': {
+            'x': -2.5,
+            'y': 0,
+            'z': -2.5},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_8['boundingBox'] = generate_object_bounds(
+        dimensions, None, bad_8['position'], bad_8['rotation'])
     assert not are_adjacent(center, bad_8)
 
 
@@ -698,87 +879,221 @@ def test_are_adjacent_with_offset():
     dimensions = {'x': 2, 'y': 2, 'z': 2}
     offset = {'x': -1, 'y': 0, 'z': 1}
 
-    center = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    center['boundingBox'] = generate_object_bounds(dimensions, None, center['position'], center['rotation'])
+    center = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    center['boundingBox'] = generate_object_bounds(
+        dimensions, None, center['position'], center['rotation'])
 
-    good_1 = {'position': {'x': 3, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_1['boundingBox'] = generate_object_bounds(dimensions, offset, good_1['position'], good_1['rotation'])
+    good_1 = {
+        'position': {
+            'x': 3, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    good_1['boundingBox'] = generate_object_bounds(
+        dimensions, offset, good_1['position'], good_1['rotation'])
     assert are_adjacent(center, good_1)
 
-    good_2 = {'position': {'x': -1, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_2['boundingBox'] = generate_object_bounds(dimensions, offset, good_2['position'], good_2['rotation'])
+    good_2 = {
+        'position': {
+            'x': -1,
+            'y': 0,
+            'z': 0},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_2['boundingBox'] = generate_object_bounds(
+        dimensions, offset, good_2['position'], good_2['rotation'])
     assert are_adjacent(center, good_2)
 
-    good_3 = {'position': {'x': 0, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_3['boundingBox'] = generate_object_bounds(dimensions, offset, good_3['position'], good_3['rotation'])
+    good_3 = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 1}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    good_3['boundingBox'] = generate_object_bounds(
+        dimensions, offset, good_3['position'], good_3['rotation'])
     assert are_adjacent(center, good_3)
 
-    good_4 = {'position': {'x': 0, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_4['boundingBox'] = generate_object_bounds(dimensions, offset, good_4['position'], good_4['rotation'])
+    good_4 = {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': -3},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_4['boundingBox'] = generate_object_bounds(
+        dimensions, offset, good_4['position'], good_4['rotation'])
     assert are_adjacent(center, good_4)
 
-    good_5 = {'position': {'x': 3, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_5['boundingBox'] = generate_object_bounds(dimensions, offset, good_5['position'], good_5['rotation'])
+    good_5 = {
+        'position': {
+            'x': 3, 'y': 0, 'z': 1}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    good_5['boundingBox'] = generate_object_bounds(
+        dimensions, offset, good_5['position'], good_5['rotation'])
     assert are_adjacent(center, good_5)
 
-    good_6 = {'position': {'x': 3, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_6['boundingBox'] = generate_object_bounds(dimensions, offset, good_6['position'], good_6['rotation'])
+    good_6 = {
+        'position': {
+            'x': 3,
+            'y': 0,
+            'z': -3},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_6['boundingBox'] = generate_object_bounds(
+        dimensions, offset, good_6['position'], good_6['rotation'])
     assert are_adjacent(center, good_6)
 
-    good_7 = {'position': {'x': -1, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_7['boundingBox'] = generate_object_bounds(dimensions, offset, good_7['position'], good_7['rotation'])
+    good_7 = {
+        'position': {
+            'x': -1,
+            'y': 0,
+            'z': 1},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_7['boundingBox'] = generate_object_bounds(
+        dimensions, offset, good_7['position'], good_7['rotation'])
     assert are_adjacent(center, good_7)
 
-    good_8 = {'position': {'x': -1, 'y': 0, 'z': -3}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    good_8['boundingBox'] = generate_object_bounds(dimensions, offset, good_8['position'], good_8['rotation'])
+    good_8 = {
+        'position': {
+            'x': -1,
+            'y': 0,
+            'z': -3},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    good_8['boundingBox'] = generate_object_bounds(
+        dimensions, offset, good_8['position'], good_8['rotation'])
     assert are_adjacent(center, good_8)
 
-    bad_1 = {'position': {'x': 4, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_1['boundingBox'] = generate_object_bounds(dimensions, offset, bad_1['position'], bad_1['rotation'])
+    bad_1 = {
+        'position': {
+            'x': 4, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    bad_1['boundingBox'] = generate_object_bounds(
+        dimensions, offset, bad_1['position'], bad_1['rotation'])
     assert not are_adjacent(center, bad_1)
 
-    bad_2 = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_2['boundingBox'] = generate_object_bounds(dimensions, offset, bad_2['position'], bad_2['rotation'])
+    bad_2 = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': 0},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_2['boundingBox'] = generate_object_bounds(
+        dimensions, offset, bad_2['position'], bad_2['rotation'])
     assert not are_adjacent(center, bad_2)
 
-    bad_3 = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_3['boundingBox'] = generate_object_bounds(dimensions, offset, bad_3['position'], bad_3['rotation'])
+    bad_3 = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 2}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    bad_3['boundingBox'] = generate_object_bounds(
+        dimensions, offset, bad_3['position'], bad_3['rotation'])
     assert not are_adjacent(center, bad_3)
 
-    bad_4 = {'position': {'x': 0, 'y': 0, 'z': -4}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_4['boundingBox'] = generate_object_bounds(dimensions, offset, bad_4['position'], bad_4['rotation'])
+    bad_4 = {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': -4},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_4['boundingBox'] = generate_object_bounds(
+        dimensions, offset, bad_4['position'], bad_4['rotation'])
     assert not are_adjacent(center, bad_4)
 
-    bad_5 = {'position': {'x': 3.5, 'y': 0, 'z': 1.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_5['boundingBox'] = generate_object_bounds(dimensions, offset, bad_5['position'], bad_5['rotation'])
+    bad_5 = {
+        'position': {
+            'x': 3.5, 'y': 0, 'z': 1.5}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    bad_5['boundingBox'] = generate_object_bounds(
+        dimensions, offset, bad_5['position'], bad_5['rotation'])
     assert not are_adjacent(center, bad_5)
 
-    bad_6 = {'position': {'x': 3.5, 'y': 0, 'z': -3.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_6['boundingBox'] = generate_object_bounds(dimensions, offset, bad_6['position'], bad_6['rotation'])
+    bad_6 = {
+        'position': {
+            'x': 3.5,
+            'y': 0,
+            'z': -3.5},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_6['boundingBox'] = generate_object_bounds(
+        dimensions, offset, bad_6['position'], bad_6['rotation'])
     assert not are_adjacent(center, bad_6)
 
-    bad_7 = {'position': {'x': -1.5, 'y': 0, 'z': 1.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_7['boundingBox'] = generate_object_bounds(dimensions, offset, bad_7['position'], bad_7['rotation'])
+    bad_7 = {
+        'position': {
+            'x': -1.5,
+            'y': 0,
+            'z': 1.5},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_7['boundingBox'] = generate_object_bounds(
+        dimensions, offset, bad_7['position'], bad_7['rotation'])
     assert not are_adjacent(center, bad_7)
 
-    bad_8 = {'position': {'x': -1.5, 'y': 0, 'z': -3.5}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    bad_8['boundingBox'] = generate_object_bounds(dimensions, offset, bad_8['position'], bad_8['rotation'])
+    bad_8 = {
+        'position': {
+            'x': -1.5,
+            'y': 0,
+            'z': -3.5},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    bad_8['boundingBox'] = generate_object_bounds(
+        dimensions, offset, bad_8['position'], bad_8['rotation'])
     assert not are_adjacent(center, bad_8)
 
 
 def test_get_adjacent_location():
     # Set the performer start out-of-the-way.
-    performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
+    performer_start = {
+        'position': {
+            'x': ROOM_X_MAX,
+            'y': 0,
+            'z': ROOM_Z_MAX},
+        'rotation': {
+            'y': 0}}
 
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
-        target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], \
-                (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
-                target_location['rotation'])
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
+        target_location = {
+            'position': {
+                'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+                'x': 0, 'y': 0, 'z': 0}}
+        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'],
+                                                                (
+            target_definition['offset'] if 'offset' in target_definition else None), target_location['position'],
+            target_location['rotation'])
         target_poly = get_bounding_polygon(target_location)
 
-        for object_definition in util.retrieve_full_object_definition_list(objects.get('ALL')):
-            location = get_adjacent_location(object_definition, target_definition, target_location, performer_start)
+        for object_definition in util.retrieve_full_object_definition_list(
+                objects.get('ALL')):
+            location = get_adjacent_location(
+                object_definition,
+                target_definition,
+                target_location,
+                performer_start)
             assert location
             object_poly = get_bounding_polygon(location)
             assert object_poly.distance(target_poly) < 0.5
@@ -786,24 +1101,43 @@ def test_get_adjacent_location():
 
 def test_get_adjacent_location_with_obstruct():
     # Set the performer start in the back of the room facing inward.
-    performer_start = {'position': {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, 'rotation': {'y': 0}}
+    performer_start = {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': ROOM_Z_MIN},
+        'rotation': {
+            'y': 0}}
 
-    # Use the sofa in this test because it should obstruct any possible pickupable object.
-    sofa_list = [item for item in objects.get('ALL') if 'type' in item and item['type'] == 'sofa_1']
+    # Use the sofa in this test because it should obstruct any possible
+    # pickupable object.
+    sofa_list = [item for item in objects.get(
+        'ALL') if 'type' in item and item['type'] == 'sofa_1']
     object_definition = util.finalize_object_definition(sofa_list[0])
 
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
-        target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], \
-                (target_definition['offset'] if 'offset' in target_definition else None), target_location['position'], \
-                target_location['rotation'])
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
+        target_location = {
+            'position': {
+                'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+                'x': 0, 'y': 0, 'z': 0}}
+        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'],
+                                                                (
+            target_definition['offset'] if 'offset' in target_definition else None), target_location['position'],
+            target_location['rotation'])
         target_poly = get_bounding_polygon(target_location)
 
-        location = get_adjacent_location(object_definition, target_definition, target_location, performer_start, True)
+        location = get_adjacent_location(
+            object_definition,
+            target_definition,
+            target_location,
+            performer_start,
+            True)
         assert location
         object_poly = get_bounding_polygon(location)
         assert object_poly.distance(target_poly) < 0.5
-        assert does_fully_obstruct_target(performer_start['position'], target_location, object_poly)
+        assert does_fully_obstruct_target(
+            performer_start['position'], target_location, object_poly)
 
 
 def get_min_and_max_in_bounds(bounds):
@@ -812,117 +1146,154 @@ def get_min_and_max_in_bounds(bounds):
 
 def test_get_adjacent_location_on_side():
     # Set the performer start out-of-the-way.
-    performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
+    performer_start = {
+        'position': {
+            'x': ROOM_X_MAX,
+            'y': 0,
+            'z': ROOM_Z_MAX},
+        'rotation': {
+            'y': 0}}
 
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('PICKUPABLE')):
-        target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
-        target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
-                target_location['position'], target_location['rotation'])
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('PICKUPABLE')):
+        target_offset = target_definition['offset'] if 'offset' in target_definition else {
+            'x': 0, 'z': 0}
+        target_location = {
+            'position': {
+                'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+                'x': 0, 'y': 0, 'z': 0}}
+        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], target_offset,
+                                                                target_location['position'], target_location['rotation'])
         target_poly = get_bounding_polygon(target_location)
 
-        target_x_min, target_x_max, target_z_min, target_z_max = get_min_and_max_in_bounds( \
-                target_location['boundingBox'])
+        target_x_min, target_x_max, target_z_min, target_z_max = get_min_and_max_in_bounds(
+            target_location['boundingBox'])
 
-        for object_definition in util.retrieve_full_object_definition_list(objects.get('ALL')):
-            object_offset = object_definition['offset'] if 'offset' in object_definition else {'x': 0, 'z': 0}
+        for object_definition in util.retrieve_full_object_definition_list(
+                objects.get('ALL')):
+            object_offset = object_definition['offset'] if 'offset' in object_definition else {
+                'x': 0, 'z': 0}
 
-            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
-                    performer_start, Side.RIGHT, False)
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location,
+                                                     performer_start, Side.RIGHT, False)
             assert location
-            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['boundingBox'])
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(
+                location['boundingBox'])
             assert target_x_max <= x_min <= ROOM_X_MAX
             assert target_x_max <= x_max <= ROOM_X_MAX
             assert target_location['position']['z'] + target_offset['z'] == \
-                    pytest.approx(location['position']['z'] + object_offset['z'])
+                pytest.approx(location['position']['z'] + object_offset['z'])
             object_poly = get_bounding_polygon(location)
             assert object_poly.distance(target_poly) < 0.5
 
-            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
-                    performer_start, Side.LEFT, False)
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location,
+                                                     performer_start, Side.LEFT, False)
             assert location
-            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['boundingBox'])
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(
+                location['boundingBox'])
             assert ROOM_X_MIN <= x_min <= target_x_min
             assert ROOM_X_MIN <= x_max <= target_x_min
             assert target_location['position']['z'] + target_offset['z'] == \
-                    pytest.approx(location['position']['z'] + object_offset['z'])
+                pytest.approx(location['position']['z'] + object_offset['z'])
             object_poly = get_bounding_polygon(location)
             assert object_poly.distance(target_poly) < 0.5
 
-            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
-                    performer_start, Side.FRONT, False)
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location,
+                                                     performer_start, Side.FRONT, False)
             assert location
-            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['boundingBox'])
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(
+                location['boundingBox'])
             assert target_z_max <= z_min <= ROOM_Z_MAX
             assert target_z_max <= z_max <= ROOM_Z_MAX
             assert target_location['position']['x'] + target_offset['x'] == \
-                    pytest.approx(location['position']['x'] + object_offset['x'])
+                pytest.approx(location['position']['x'] + object_offset['x'])
             object_poly = get_bounding_polygon(location)
             assert object_poly.distance(target_poly) < 0.5
 
-            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
-                    performer_start, Side.BACK, False)
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location,
+                                                     performer_start, Side.BACK, False)
             assert location
-            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(location['boundingBox'])
+            x_min, x_max, z_min, z_max = get_min_and_max_in_bounds(
+                location['boundingBox'])
             assert ROOM_Z_MIN <= z_min <= target_z_min
             assert ROOM_Z_MIN <= z_max <= target_z_min
             assert target_location['position']['x'] + target_offset['x'] == \
-                    pytest.approx(location['position']['x'] + object_offset['x'])
+                pytest.approx(location['position']['x'] + object_offset['x'])
             object_poly = get_bounding_polygon(location)
             assert object_poly.distance(target_poly) < 0.5
 
 
 def test_get_adjacent_location_on_side_next_to_room_wall():
     # Set the performer start out-of-the-way.
-    performer_start = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, 'rotation': {'y': 0}}
+    performer_start = {
+        'position': {
+            'x': ROOM_X_MAX,
+            'y': 0,
+            'z': ROOM_Z_MAX},
+        'rotation': {
+            'y': 0}}
 
-    for target_definition in util.retrieve_full_object_definition_list(objects.get('ALL')):
-        target_offset = target_definition['offset'] if 'offset' in target_definition else {'x': 0, 'z': 0}
-        target_location = {'position': {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], target_offset, \
-                target_location['position'], target_location['rotation'])
+    for target_definition in util.retrieve_full_object_definition_list(
+            objects.get('ALL')):
+        target_offset = target_definition['offset'] if 'offset' in target_definition else {
+            'x': 0, 'z': 0}
+        target_location = {
+            'position': {
+                'x': ROOM_X_MAX, 'y': 0, 'z': 0}, 'rotation': {
+                'x': 0, 'y': 0, 'z': 0}}
+        target_location['boundingBox'] = generate_object_bounds(target_definition['dimensions'], target_offset,
+                                                                target_location['position'], target_location['rotation'])
 
-        for object_definition in util.retrieve_full_object_definition_list(objects.get('ALL')):
-            location = get_adjacent_location_on_side(object_definition, target_definition, target_location, \
-                    performer_start, Side.RIGHT, False)
+        for object_definition in util.retrieve_full_object_definition_list(
+                objects.get('ALL')):
+            location = get_adjacent_location_on_side(object_definition, target_definition, target_location,
+                                                     performer_start, Side.RIGHT, False)
             assert not location
 
 
 def test_get_wider_and_taller_defs():
-    for object_definition in util.retrieve_full_object_definition_list(objects.get('ALL')):
+    for object_definition in util.retrieve_full_object_definition_list(
+            objects.get('ALL')):
         object_dimensions = object_definition['closedDimensions'] if 'closedDimensions' in object_definition else \
-                object_definition['dimensions']
-        bigger_definition_list = get_wider_and_taller_defs(object_definition, False)
+            object_definition['dimensions']
+        bigger_definition_list = get_wider_and_taller_defs(
+            object_definition, False)
         for bigger_definition_result in bigger_definition_list:
             bigger_definition, angle = bigger_definition_result
-            bigger_definition = util.finalize_object_definition(bigger_definition)
+            bigger_definition = util.finalize_object_definition(
+                bigger_definition)
             bigger_dimensions = bigger_definition['closedDimensions'] if 'closedDimensions' in bigger_definition \
-                    else bigger_definition['dimensions']
+                else bigger_definition['dimensions']
             assert bigger_definition['obstruct'] == 'navigation'
             assert bigger_dimensions['y'] >= 0.2
             if angle == 0:
                 assert bigger_dimensions['x'] >= object_dimensions['x']
             else:
-                # We rotate the bigger object so compare its side to the original object's front.
+                # We rotate the bigger object so compare its side to the
+                # original object's front.
                 assert bigger_dimensions['z'] >= object_dimensions['x']
 
 
 def test_get_wider_and_taller_defs_obstruct_vision():
-    for object_definition in util.retrieve_full_object_definition_list(objects.get('ALL')):
+    for object_definition in util.retrieve_full_object_definition_list(
+            objects.get('ALL')):
         object_dimensions = object_definition['closedDimensions'] if 'closedDimensions' in object_definition else \
-                object_definition['dimensions']
-        bigger_definition_list = get_wider_and_taller_defs(object_definition, True)
+            object_definition['dimensions']
+        bigger_definition_list = get_wider_and_taller_defs(
+            object_definition, True)
         for bigger_definition_result in bigger_definition_list:
             bigger_definition, angle = bigger_definition_result
-            bigger_definition = util.finalize_object_definition(bigger_definition)
+            bigger_definition = util.finalize_object_definition(
+                bigger_definition)
             bigger_dimensions = bigger_definition['closedDimensions'] if 'closedDimensions' in bigger_definition \
-                    else bigger_definition['dimensions']
+                else bigger_definition['dimensions']
             assert bigger_definition['obstruct'] == 'vision'
             assert bigger_dimensions['y'] >= object_dimensions['y']
             if angle == 0:
                 assert bigger_dimensions['x'] >= object_dimensions['x']
             else:
-                # We rotate the bigger object so compare its side to the original object's front.
+                # We rotate the bigger object so compare its side to the
+                # original object's front.
                 assert bigger_dimensions['z'] >= object_dimensions['x']
 
 
@@ -932,231 +1303,447 @@ def test_get_bounding_poly():
 
 
 def test_rect_to_poly():
-    rect = [{'x': 1, 'z': 2}, {'x': 3, 'z': 4}, {'x': 7, 'z': 0}, {'x': 5, 'z': -2}]
+    rect = [{'x': 1, 'z': 2}, {'x': 3, 'z': 4},
+            {'x': 7, 'z': 0}, {'x': 5, 'z': -2}]
     expected = shapely.geometry.Polygon([(1, 2), (3, 4), (7, 0), (5, -2)])
     actual = geometry.rect_to_poly(rect)
     assert actual.equals(expected)
 
 
 def test_find_performer_rect():
-    expected1 = [{'x': -0.05, 'z': -0.05}, {'x': -0.05, 'z': 0.05}, {'x': 0.05, 'z': 0.05}, {'x': 0.05, 'z': -0.05}]
+    expected1 = [{'x': -0.05, 'z': -0.05}, {'x': -0.05, 'z': 0.05},
+                 {'x': 0.05, 'z': 0.05}, {'x': 0.05, 'z': -0.05}]
     actual1 = find_performer_rect({'x': 0, 'y': 0, 'z': 0})
     assert actual1 == expected1
 
-    expected2 = [{'x': 0.95, 'z': 0.95}, {'x': 0.95, 'z': 1.05}, {'x': 1.05, 'z': 1.05}, {'x': 1.05, 'z': 0.95}]
+    expected2 = [{'x': 0.95, 'z': 0.95}, {'x': 0.95, 'z': 1.05},
+                 {'x': 1.05, 'z': 1.05}, {'x': 1.05, 'z': 0.95}]
     actual2 = find_performer_rect({'x': 1, 'y': 1, 'z': 1})
     assert actual2 == expected2
 
 
 def test_set_location_rotation():
-    for definition in util.retrieve_full_object_definition_list(objects.get('ALL')):
-        offset = definition['offset'] if 'offset' in definition else {'x': 0, 'z': 0}
+    for definition in util.retrieve_full_object_definition_list(
+            objects.get('ALL')):
+        offset = definition['offset'] if 'offset' in definition else {
+            'x': 0, 'z': 0}
 
-        location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        location = {
+            'position': {
+                'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+                'x': 0, 'y': 0, 'z': 0}}
         location = set_location_rotation(definition, location, 0)
         assert location['rotation']['y'] == 0
-        assert location['boundingBox'][0]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['boundingBox'][0]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['boundingBox'][1]['x'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['boundingBox'][1]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['boundingBox'][2]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['boundingBox'][2]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['boundingBox'][3]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['boundingBox'][3]['z'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][0]['x'] == pytest.approx(
+            definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][0]['z'] == pytest.approx(
+            definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][1]['x'] == pytest.approx(
+            definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][1]['z'] == pytest.approx(
+            -definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][2]['x'] == pytest.approx(
+            -definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][2]['z'] == pytest.approx(
+            -definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][3]['x'] == pytest.approx(
+            -definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][3]['z'] == pytest.approx(
+            definition['dimensions']['z'] / 2 + offset['z'])
 
-        location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        location = {
+            'position': {
+                'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+                'x': 0, 'y': 0, 'z': 0}}
         location = set_location_rotation(definition, location, 90)
         assert location['rotation']['y'] == 90
-        assert location['boundingBox'][0]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['boundingBox'][0]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['boundingBox'][1]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['boundingBox'][1]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['boundingBox'][2]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['boundingBox'][2]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['boundingBox'][3]['x'] == pytest.approx(definition['dimensions']['z'] / 2 + offset['z'])
-        assert location['boundingBox'][3]['z'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][0]['x'] == pytest.approx(
+            definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][0]['z'] == pytest.approx(
+            -definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][1]['x'] == pytest.approx(
+            -definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][1]['z'] == pytest.approx(
+            -definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][2]['x'] == pytest.approx(
+            -definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][2]['z'] == pytest.approx(
+            definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][3]['x'] == pytest.approx(
+            definition['dimensions']['z'] / 2 + offset['z'])
+        assert location['boundingBox'][3]['z'] == pytest.approx(
+            definition['dimensions']['x'] / 2 - offset['x'])
 
-        location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        location = {
+            'position': {
+                'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+                'x': 0, 'y': 0, 'z': 0}}
         location = set_location_rotation(definition, location, 180)
         assert location['rotation']['y'] == 180
-        assert location['boundingBox'][0]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['boundingBox'][0]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['boundingBox'][1]['x'] == pytest.approx(-definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['boundingBox'][1]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['boundingBox'][2]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['boundingBox'][2]['z'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['boundingBox'][3]['x'] == pytest.approx(definition['dimensions']['x'] / 2 - offset['x'])
-        assert location['boundingBox'][3]['z'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][0]['x'] == pytest.approx(
+            -definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][0]['z'] == pytest.approx(
+            -definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][1]['x'] == pytest.approx(
+            -definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][1]['z'] == pytest.approx(
+            definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][2]['x'] == pytest.approx(
+            definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][2]['z'] == pytest.approx(
+            definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][3]['x'] == pytest.approx(
+            definition['dimensions']['x'] / 2 - offset['x'])
+        assert location['boundingBox'][3]['z'] == pytest.approx(
+            -definition['dimensions']['z'] / 2 - offset['z'])
 
-        location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+        location = {
+            'position': {
+                'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+                'x': 0, 'y': 0, 'z': 0}}
         location = set_location_rotation(definition, location, 270)
         assert location['rotation']['y'] == 270
-        assert location['boundingBox'][0]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['boundingBox'][0]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['boundingBox'][1]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['boundingBox'][1]['z'] == pytest.approx(definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['boundingBox'][2]['x'] == pytest.approx(definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['boundingBox'][2]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
-        assert location['boundingBox'][3]['x'] == pytest.approx(-definition['dimensions']['z'] / 2 - offset['z'])
-        assert location['boundingBox'][3]['z'] == pytest.approx(-definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][0]['x'] == pytest.approx(
+            -definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][0]['z'] == pytest.approx(
+            definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][1]['x'] == pytest.approx(
+            definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][1]['z'] == pytest.approx(
+            definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][2]['x'] == pytest.approx(
+            definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][2]['z'] == pytest.approx(
+            -definition['dimensions']['x'] / 2 + offset['x'])
+        assert location['boundingBox'][3]['x'] == pytest.approx(
+            -definition['dimensions']['z'] / 2 - offset['z'])
+        assert location['boundingBox'][3]['z'] == pytest.approx(
+            -definition['dimensions']['x'] / 2 + offset['x'])
 
 
 def test_does_fully_obstruct_target():
-    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
-            target_location['position'], target_location['rotation'])
+    target_location = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None,
+                                                            target_location['position'], target_location['rotation'])
 
-    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': 0},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 2, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': -2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 2}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
 
 def test_does_fully_obstruct_target_returns_false_too_small():
-    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
-            target_location['position'], target_location['rotation'])
+    target_location = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None,
+                                                            target_location['position'], target_location['rotation'])
 
-    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': 0},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 2, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': -2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 2}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 0.5, 'z': 0.5}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
 
 def test_does_fully_obstruct_target_returns_false_performer_start():
-    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
-            target_location['position'], target_location['rotation'])
+    target_location = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None,
+                                                            target_location['position'], target_location['rotation'])
 
-    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': 0},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 2, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': -2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 0, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 2}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
 
 def test_does_fully_obstruct_target_returns_false_visible_corners():
-    target_location = {'position': {'x': 0, 'y': 0, 'z': 0}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None, \
-            target_location['position'], target_location['rotation'])
+    target_location = {
+        'position': {
+            'x': 0, 'y': 0, 'z': 0}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    target_location['boundingBox'] = generate_object_bounds({'x': 1, 'z': 1}, None,
+                                                            target_location['position'], target_location['rotation'])
 
-    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': 1},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': -2, 'y': 0, 'z': -1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': -2,
+            'y': 0,
+            'z': -1},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MIN, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': 1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 2, 'y': 0, 'z': 1}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 2, 'y': 0, 'z': -1}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 2,
+            'y': 0,
+            'z': -1},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': ROOM_X_MAX, 'y': 0, 'z': 0}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 1, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 1,
+            'y': 0,
+            'z': -2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': -1, 'y': 0, 'z': -2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': -1,
+            'y': 0,
+            'z': -2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MIN}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': 1, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': 1, 'y': 0, 'z': 2}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
 
-    obstructor_location = {'position': {'x': -1, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
-    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None, \
-            obstructor_location['position'], obstructor_location['rotation'])
+    obstructor_location = {
+        'position': {
+            'x': -1,
+            'y': 0,
+            'z': 2},
+        'rotation': {
+            'x': 0,
+            'y': 0,
+            'z': 0}}
+    obstructor_location['boundingBox'] = generate_object_bounds({'x': 2, 'z': 2}, None,
+                                                                obstructor_location['position'], obstructor_location['rotation'])
     obstructor_poly = get_bounding_polygon(obstructor_location)
-    assert not does_fully_obstruct_target({'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)
-
+    assert not does_fully_obstruct_target(
+        {'x': 0, 'y': 0, 'z': ROOM_Z_MAX}, target_location, obstructor_poly)

--- a/scene_generator/goal.py
+++ b/scene_generator/goal.py
@@ -20,10 +20,10 @@ WALL_DEPTH = 0.1
 
 DIST_WALL_APART = 1
 SAFE_DIST_FROM_ROOM_WALL = 3.5
-    
 
-def generate_wall(wall_material: str, wall_colors: List[str], performer_position: Dict[str, float], \
-        other_rects: List[List[Dict[str, float]]], dont_obstruct_list: List[Dict[str, Any]] = None) -> \
+
+def generate_wall(wall_material: str, wall_colors: List[str], performer_position: Dict[str, float],
+                  other_rects: List[List[Dict[str, float]]], dont_obstruct_list: List[Dict[str, Any]] = None) -> \
         Optional[Dict[str, Any]]:
     """Generates and returns a randomly positioned obstacle wall. If dont_obstruct_list is not None, the wall won't
     obstruct the line between the performer_position and the objects in dont_obstruct_list."""
@@ -35,24 +35,39 @@ def generate_wall(wall_material: str, wall_colors: List[str], performer_position
         rotation = random.choice((0, 90, 180, 270))
         new_x = geometry.random_position_x()
         new_z = geometry.random_position_z()
-        new_x_size = round(random.uniform(MIN_WALL_WIDTH, MAX_WALL_WIDTH), geometry.POSITION_DIGITS)
-        
+        new_x_size = round(
+            random.uniform(
+                MIN_WALL_WIDTH,
+                MAX_WALL_WIDTH),
+            geometry.POSITION_DIGITS)
+
         # Make sure the wall is not too close to the rooms 4 walls
         if ((rotation == 0 or rotation == 180) and (new_z < -SAFE_DIST_FROM_ROOM_WALL or new_z > SAFE_DIST_FROM_ROOM_WALL)) or \
-            ((rotation == 90 or rotation == 270) and (new_x < -SAFE_DIST_FROM_ROOM_WALL or new_x > SAFE_DIST_FROM_ROOM_WALL)): 
+                ((rotation == 90 or rotation == 270) and (new_x < -SAFE_DIST_FROM_ROOM_WALL or new_x > SAFE_DIST_FROM_ROOM_WALL)):
             continue
 
-        rect = geometry.calc_obj_coords(new_x, new_z, new_x_size, WALL_DEPTH, 0, 0, rotation)
-        # barrier_rect is to allow parallel walls to be at least 1(DIST_WALL_APART) apart on the appropriate axis
-        barrier_rect = geometry.calc_obj_coords(new_x, new_z, new_x_size + DIST_WALL_APART, WALL_DEPTH + DIST_WALL_APART, 0, 0, rotation)
+        rect = geometry.calc_obj_coords(
+            new_x, new_z, new_x_size, WALL_DEPTH, 0, 0, rotation)
+        # barrier_rect is to allow parallel walls to be at least
+        # 1(DIST_WALL_APART) apart on the appropriate axis
+        barrier_rect = geometry.calc_obj_coords(
+            new_x,
+            new_z,
+            new_x_size +
+            DIST_WALL_APART,
+            WALL_DEPTH +
+            DIST_WALL_APART,
+            0,
+            0,
+            rotation)
         wall_poly = geometry.rect_to_poly(rect)
         is_ok = not wall_poly.intersects(performer_poly) and geometry.rect_within_room(rect) and \
-                (len(other_rects) == 0 or not any(separating_axis_theorem.sat_entry(barrier_rect, other_rect) \
-                for other_rect in other_rects))
+            (len(other_rects) == 0 or not any(separating_axis_theorem.sat_entry(barrier_rect, other_rect)
+                                              for other_rect in other_rects))
         if is_ok:
             if dont_obstruct_list:
                 for dont_obstruct_object in dont_obstruct_list:
-                    if 'locationParent' not in dont_obstruct_object and geometry.does_fully_obstruct_target( \
+                    if 'locationParent' not in dont_obstruct_object and geometry.does_fully_obstruct_target(
                             performer_position, dont_obstruct_object, wall_poly):
                         is_ok = False
                         break
@@ -102,20 +117,24 @@ class Goal(ABC):
         self._compute_performer_start()
         self._tag_to_objects = {}
 
-    def update_body(self, body: Dict[str, Any], find_path: bool) -> Dict[str, Any]:
+    def update_body(self, body: Dict[str, Any],
+                    find_path: bool) -> Dict[str, Any]:
         """Helper method that calls other Goal methods to set performerStart, objects, and goal. Returns the goal body
         object."""
-        self._tag_to_objects = self.compute_objects(body['wallMaterial'], body['wallColors'])
+        self._tag_to_objects = self.compute_objects(
+            body['wallMaterial'], body['wallColors'])
         for tag in self._tag_to_objects:
             for object_instance in self._tag_to_objects[tag]:
                 object_instance['role'] = tag
 
         body['performerStart'] = self._performer_start
-        body['objects'] = [element for value in self._tag_to_objects.values() for element in value]
+        body['objects'] = [element for value in self._tag_to_objects.values()
+                           for element in value]
         body['goal'] = self._get_config(self._tag_to_objects)
 
         if find_path:
-            body['answer']['actions'] = self._find_optimal_path(self._tag_to_objects['target'], body['objects'])
+            body['answer']['actions'] = self._find_optimal_path(
+                self._tag_to_objects['target'], body['objects'])
 
         return body
 
@@ -144,12 +163,14 @@ class Goal(ABC):
         return self._performer_start
 
     @abstractmethod
-    def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+    def compute_objects(self, wall_material_name: str,
+                        wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
         """Compute object instances for the scene. Returns a tuple:
         (dict that maps tag strings to object lists, bounding rectangles)"""
         pass
 
-    def update_goal_info_list(self, info_list: List[str], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> List[str]:
+    def update_goal_info_list(
+            self, info_list: List[str], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> List[str]:
         """Update and return the given info_list with the info from all objects in this goal."""
         info_set = set(info_list)
         for key, value in tag_to_objects.items():
@@ -160,12 +181,15 @@ class Goal(ABC):
                 info_set |= set([(key + ' ' + info) for info in info_list])
         return list(info_set)
 
-    def _get_config(self, tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+    def _get_config(
+            self, tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
         """Create and return the goal configuration."""
         goal_config = self._get_subclass_config(tag_to_objects['target'])
         goal_config['category'] = goal_config.get('category', '')
-        goal_config['type_list'] = tags.append_object_tags(goal_config.get('type_list', []), tag_to_objects)
-        goal_config['info_list'] = self.update_goal_info_list(goal_config.get('info_list', []), tag_to_objects)
+        goal_config['type_list'] = tags.append_object_tags(
+            goal_config.get('type_list', []), tag_to_objects)
+        goal_config['info_list'] = self.update_goal_info_list(
+            goal_config.get('info_list', []), tag_to_objects)
         goal_config['metadata'] = goal_config.get('metadata', {})
         return goal_config
 
@@ -184,7 +208,8 @@ class Goal(ABC):
         return self._performer_start
 
     @abstractmethod
-    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _get_subclass_config(
+            self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Get the goal configuration of this specific subclass."""
         pass
 
@@ -201,13 +226,14 @@ class EmptyGoal(Goal):
     def __init__(self):
         super(EmptyGoal, self).__init__()
 
-    def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
-        return { 'target': [] }
+    def compute_objects(self, wall_material_name: str,
+                        wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+        return {'target': []}
 
-    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _get_subclass_config(
+            self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         return {}
 
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
             List[Dict[str, Any]]:
         return []
-

--- a/scene_generator/goal_test.py
+++ b/scene_generator/goal_test.py
@@ -69,7 +69,9 @@ def create_tags_test_object_2():
 
 
 def test_generate_wall():
-    wall = generate_wall('test_material', ['test_color_1', 'test_color_2'], geometry.ORIGIN, [])
+    wall = generate_wall(
+        'test_material', [
+            'test_color_1', 'test_color_2'], geometry.ORIGIN, [])
 
     assert wall
     assert wall['id']
@@ -107,14 +109,17 @@ def test_generate_wall():
 
 def test_generate_wall_multiple():
     wall_1 = generate_wall('test_material', [], geometry.ORIGIN, [])
-    wall_2 = generate_wall('test_material', [], geometry.ORIGIN, [wall_1['shows'][0]['boundingBox']])
+    wall_2 = generate_wall(
+        'test_material', [], geometry.ORIGIN, [
+            wall_1['shows'][0]['boundingBox']])
     wall_1_poly = geometry.rect_to_poly(wall_1['shows'][0]['boundingBox'])
     wall_2_poly = geometry.rect_to_poly(wall_2['shows'][0]['boundingBox'])
     assert not wall_1_poly.intersects(wall_2_poly)
 
 
 def test_generate_wall_with_bounds_list():
-    bounds = [{'x': 4, 'y': 0, 'z': 4}, {'x': 4, 'y': 0, 'z': 1}, {'x': 1, 'y': 0, 'z': 1}, {'x': 1, 'y': 0, 'z': 4}]
+    bounds = [{'x': 4, 'y': 0, 'z': 4}, {'x': 4, 'y': 0, 'z': 1},
+              {'x': 1, 'y': 0, 'z': 1}, {'x': 1, 'y': 0, 'z': 4}]
     wall = generate_wall('test_material', [], geometry.ORIGIN, [bounds])
     poly = geometry.rect_to_poly(bounds)
     wall_poly = geometry.rect_to_poly(wall['shows'][0]['boundingBox'])
@@ -122,11 +127,18 @@ def test_generate_wall_with_bounds_list():
 
 
 def test_generate_wall_with_target_list():
-    bounds = [{'x': 4, 'y': 0, 'z': 4}, {'x': 4, 'y': 0, 'z': 3}, {'x': 3, 'y': 0, 'z': 3}, {'x': 3, 'y': 0, 'z': 4}]
+    bounds = [{'x': 4, 'y': 0, 'z': 4}, {'x': 4, 'y': 0, 'z': 3},
+              {'x': 3, 'y': 0, 'z': 3}, {'x': 3, 'y': 0, 'z': 4}]
     target = {'shows': [{'boundingBox': bounds}]}
-    wall = generate_wall('test_material', [], geometry.ORIGIN, [bounds], [target])
+    wall = generate_wall(
+        'test_material',
+        [],
+        geometry.ORIGIN,
+        [bounds],
+        [target])
     wall_poly = geometry.rect_to_poly(wall['shows'][0]['boundingBox'])
-    assert not geometry.does_fully_obstruct_target(geometry.ORIGIN, target, wall_poly)
+    assert not geometry.does_fully_obstruct_target(
+        geometry.ORIGIN, target, wall_poly)
 
 
 def test_Goal_update_goal_info_list():
@@ -138,25 +150,30 @@ def test_Goal_update_goal_info_list():
     info_list = goal_object.update_goal_info_list([], {'target': []})
     assert info_list == []
 
-    info_list = goal_object.update_goal_info_list([], {'target': [{'info': []}]})
+    info_list = goal_object.update_goal_info_list(
+        [], {'target': [{'info': []}]})
     assert info_list == []
 
-    info_list = goal_object.update_goal_info_list([], {'target': [{'info': ['a', 'b']}]})
+    info_list = goal_object.update_goal_info_list(
+        [], {'target': [{'info': ['a', 'b']}]})
     assert set(info_list) == set(['target a', 'target b'])
 
-    info_list = goal_object.update_goal_info_list(['target a'], {'target': [{'info': ['a', 'b']}]})
+    info_list = goal_object.update_goal_info_list(
+        ['target a'], {'target': [{'info': ['a', 'b']}]})
     assert set(info_list) == set(['target a', 'target b'])
 
-    info_list = goal_object.update_goal_info_list(['target a'], {'target': [{'info': ['b', 'c']}]})
+    info_list = goal_object.update_goal_info_list(
+        ['target a'], {'target': [{'info': ['b', 'c']}]})
     assert set(info_list) == set(['target a', 'target b', 'target c'])
 
-    info_list = goal_object.update_goal_info_list(['target a'], {'target': [{'info': ['a', 'b']}, \
-            {'info': ['b', 'c']}]})
+    info_list = goal_object.update_goal_info_list(['target a'], {'target': [{'info': ['a', 'b']},
+                                                                            {'info': ['b', 'c']}]})
     assert set(info_list) == set(['target a', 'target b', 'target c'])
 
-    info_list = goal_object.update_goal_info_list(['target a', 'distractor b'], {'target': [{'info': ['a', 'b']}], \
-            'distractor': [{'info': ['b', 'c']}]})
-    assert set(info_list) == set(['target a', 'target b', 'distractor b', 'distractor c'])
+    info_list = goal_object.update_goal_info_list(['target a', 'distractor b'], {'target': [{'info': ['a', 'b']}],
+                                                                                 'distractor': [{'info': ['b', 'c']}]})
+    assert set(info_list) == set(
+        ['target a', 'target b', 'distractor b', 'distractor c'])
 
 
 def test_Goal_reset_performer_start():
@@ -171,7 +188,7 @@ def test_Goal_reset_performer_start():
 def test_Goal_tags():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    goal = goal_object._get_config({ 'target': [target] })
+    goal = goal_object._get_config({'target': [target]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -212,7 +229,7 @@ def test_Goal_tags_multiple_target():
     goal_object = RetrievalGoal()
     target_1 = create_tags_test_object_1()
     target_2 = create_tags_test_object_2()
-    goal = goal_object._get_config({ 'target': [target_1, target_2] })
+    goal = goal_object._get_config({'target': [target_1, target_2]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -236,7 +253,8 @@ def test_Goal_tags_with_distractor():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
-    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config(
+        {'target': [target], 'distractor': [distractor]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -269,8 +287,8 @@ def test_Goal_tags_multiple_target_multiple_distractor():
     target_2 = create_tags_test_object_1()
     distractor_1 = create_tags_test_object_2()
     distractor_2 = create_tags_test_object_2()
-    goal = goal_object._get_config({ 'target': [target_1, target_2], \
-            'distractor': [distractor_1, distractor_2] })
+    goal = goal_object._get_config({'target': [target_1, target_2],
+                                    'distractor': [distractor_1, distractor_2]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -300,9 +318,10 @@ def test_Goal_tags_multiple_target_multiple_distractor():
 def test_Goal_tags_with_occluder():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    occluder_wall = { 'info': ['white'] }
-    occluder_pole = { 'info': ['brown'] }
-    goal = goal_object._get_config({ 'target': [target], 'occluder': [occluder_wall, occluder_pole] })
+    occluder_wall = {'info': ['white']}
+    occluder_pole = {'info': ['brown']}
+    goal = goal_object._get_config(
+        {'target': [target], 'occluder': [occluder_wall, occluder_pole]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -324,8 +343,8 @@ def test_Goal_tags_with_occluder():
 def test_Goal_tags_with_wall():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    wall = { 'info': ['white'] }
-    goal = goal_object._get_config({ 'target': [target], 'wall': [wall] })
+    wall = {'info': ['white']}
+    goal = goal_object._get_config({'target': [target], 'wall': [wall]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -346,8 +365,9 @@ def test_Goal_tags_with_wall():
 def test_Goal_tags_with_background_object():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
-    background_object = { 'info': ['red'] }
-    goal = goal_object._get_config({ 'target': [target], 'background object': [background_object] })
+    background_object = {'info': ['red']}
+    goal = goal_object._get_config(
+        {'target': [target], 'background object': [background_object]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -369,7 +389,7 @@ def test_Goal_tags_target_enclosed():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['locationParent'] = 'parent'
-    goal = goal_object._get_config({ 'target': [target] })
+    goal = goal_object._get_config({'target': [target]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -389,7 +409,7 @@ def test_Goal_tags_target_novel_color():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novelColor'] = True
-    goal = goal_object._get_config({ 'target': [target] })
+    goal = goal_object._get_config({'target': [target]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -409,7 +429,7 @@ def test_Goal_tags_target_novel_combination():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novelCombination'] = True
-    goal = goal_object._get_config({ 'target': [target] })
+    goal = goal_object._get_config({'target': [target]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -429,7 +449,7 @@ def test_Goal_tags_target_novel_shape():
     goal_object = RetrievalGoal()
     target = create_tags_test_object_1()
     target['novelShape'] = True
-    goal = goal_object._get_config({ 'target': [target] })
+    goal = goal_object._get_config({'target': [target]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -451,7 +471,7 @@ def test_Goal_tags_target_enclosed_novel_color_novel_shape():
     target['locationParent'] = 'parent'
     target['novelColor'] = True
     target['novelShape'] = True
-    goal = goal_object._get_config({ 'target': [target] })
+    goal = goal_object._get_config({'target': [target]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -472,7 +492,8 @@ def test_Goal_tags_distractor_enclosed():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['locationParent'] = 'parent'
-    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config(
+        {'target': [target], 'distractor': [distractor]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -504,7 +525,8 @@ def test_Goal_tags_distractor_novel_color():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novelColor'] = True
-    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config(
+        {'target': [target], 'distractor': [distractor]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -536,7 +558,8 @@ def test_Goal_tags_distractor_novel_combination():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novelCombination'] = True
-    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config(
+        {'target': [target], 'distractor': [distractor]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -568,7 +591,8 @@ def test_Goal_tags_distractor_novel_shape():
     target = create_tags_test_object_1()
     distractor = create_tags_test_object_2()
     distractor['novelShape'] = True
-    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config(
+        {'target': [target], 'distractor': [distractor]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -602,7 +626,8 @@ def test_Goal_tags_distractor_enclosed_novel_color_novel_shape():
     distractor['locationParent'] = 'parent'
     distractor['novelColor'] = True
     distractor['novelShape'] = True
-    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config(
+        {'target': [target], 'distractor': [distractor]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -639,7 +664,8 @@ def test_Goal_tags_target_distractor_enclosed_novel_color_novel_shape():
     distractor['locationParent'] = 'parent'
     distractor['novelColor'] = True
     distractor['novelShape'] = True
-    goal = goal_object._get_config({ 'target': [target], 'distractor': [distractor] })
+    goal = goal_object._get_config(
+        {'target': [target], 'distractor': [distractor]})
     assert set(goal['info_list']) == {
         'target tiny',
         'target light',
@@ -664,4 +690,3 @@ def test_Goal_tags_target_distractor_enclosed_novel_color_novel_shape():
     assert 'distractor enclosed' in goal['type_list']
     assert 'targets 1' in goal['type_list']
     assert 'distractors 1' in goal['type_list']
-

--- a/scene_generator/goals.py
+++ b/scene_generator/goals.py
@@ -9,7 +9,8 @@ from goal import Goal, EmptyGoal
 from interaction_goals import RetrievalGoal, TransferralGoal, TraversalGoal
 from intphys_goals import GravityGoal, ObjectPermanenceGoal, ShapeConstancyGoal, SpatioTemporalContinuityGoal
 
-# Note: the names of all goal classes in GOAL_TYPES must end in "Goal" or choose_goal will not work
+# Note: the names of all goal classes in GOAL_TYPES must end in "Goal" or
+# choose_goal will not work
 GOAL_TYPES = {
     'interaction': [RetrievalGoal, TransferralGoal, TraversalGoal],
     'intphys': [GravityGoal, ObjectPermanenceGoal, ShapeConstancyGoal, SpatioTemporalContinuityGoal]
@@ -38,8 +39,14 @@ def get_goal_by_name(name: str) -> Goal:
 def get_goal_types(generic_type: Optional[str] = None) -> List[str]:
     if generic_type is None:
         generic_types = GOAL_TYPES.keys()
-        specific_types = [klass.__name__.replace('Goal', '') for classes in GOAL_TYPES.values() for klass in classes]
+        specific_types = [
+            klass.__name__.replace(
+                'Goal',
+                '') for classes in GOAL_TYPES.values() for klass in classes]
         return list(generic_types) + specific_types
     else:
-        specific_types = [klass.__name__.replace('Goal', '') for klass in GOAL_TYPES[generic_type]]
+        specific_types = [
+            klass.__name__.replace(
+                'Goal',
+                '') for klass in GOAL_TYPES[generic_type]]
         return [generic_type] + specific_types

--- a/scene_generator/image_generator/image_generator.py
+++ b/scene_generator/image_generator/image_generator.py
@@ -15,26 +15,36 @@ import simplified_objects
 sys.path.insert(1, '../pretty_json')
 from pretty_json import PrettyJsonEncoder, PrettyJsonNoIndent
 
+
 def generate_materials_lists(materials_options):
     materials_lists = []
     for material_category in materials_options:
         materials_lists_specific_category = []
         for material in material_category:
-            material_list = [item[0] for item in get_global_material_list(material)]
+            material_list = [item[0]
+                             for item in get_global_material_list(material)]
             materials_lists_specific_category.append(material_list)
         if (len(materials_lists_specific_category) > 1):
-            cross_product = list(itertools.product(*materials_lists_specific_category))
-            materials_lists_specific_category = [list(item) for item in cross_product]
+            cross_product = list(
+                itertools.product(
+                    *materials_lists_specific_category))
+            materials_lists_specific_category = [
+                list(item) for item in cross_product]
         else:
-            materials_lists_specific_category = [[item] for item in materials_lists_specific_category[0]]
+            materials_lists_specific_category = [
+                [item] for item in materials_lists_specific_category[0]]
         materials_lists = materials_lists + materials_lists_specific_category
     return materials_lists
 
-def generate_output_file_name(object_type, material_list):
-    material_name_list = [item[(item.rfind('/') + 1):].lower().replace(' ', '_') for item in material_list]
-    return object_type + ('_' if len(material_name_list) > 0 else '') + ('_'.join(material_name_list))
 
-def generate_scene_configuration(object_definition, material_list): 
+def generate_output_file_name(object_type, material_list):
+    material_name_list = [
+        item[(item.rfind('/') + 1):].lower().replace(' ', '_') for item in material_list]
+    return object_type + ('_' if len(material_name_list)
+                          > 0 else '') + ('_'.join(material_name_list))
+
+
+def generate_scene_configuration(object_definition, material_list):
     scene_configuration = {
         'name': 'screenshot',
         'screenshot': True,
@@ -55,24 +65,29 @@ def generate_scene_configuration(object_definition, material_list):
         scene_configuration['objects'][0]['materials'] = material_list
     return scene_configuration
 
+
 def generate_scene_configuration_list(object_list):
     scene_configuration_list = []
     for object_definition in object_list:
         materials_lists = generate_materials_lists(object_definition['materials_options']) if 'materials_options' \
             in object_definition else [None]
         for material_list in materials_lists:
-            scene_configuration_data = generate_scene_configuration(object_definition, material_list)
+            scene_configuration_data = generate_scene_configuration(
+                object_definition, material_list)
             scene_configuration_list.append(scene_configuration_data)
     return scene_configuration_list
 
+
 def get_global_material_list(material):
     return getattr(materials, material.upper() + '_MATERIALS')
+
 
 def retrieve_image_pixel_list(object_screenshot):
     # Retrieve a two-dimensional list of pixel tuples from the Pillow Image
     pixels = list(object_screenshot.getdata())
     width, height = object_screenshot.size
     return [pixels[i * width:(i + 1) * width] for i in range(0, height)]
+
 
 def main(args):
     if len(args) < 2:
@@ -81,7 +96,8 @@ def main(args):
 
     controller = MCS.create_controller(args[1])
 
-    scene_configuration_list = generate_scene_configuration_list(simplified_objects.OBJECT_LIST)
+    scene_configuration_list = generate_scene_configuration_list(
+        simplified_objects.OBJECT_LIST)
 
     output_folder = (args[2] if len(args) > 2 else '../images') + '/'
 
@@ -91,25 +107,35 @@ def main(args):
     for scene_configuration in scene_configuration_list:
         object_config = scene_configuration['objects'][0]
         object_type = object_config['type']
-        material_list = object_config['materials'] if 'materials' in object_config else []
+        material_list = object_config['materials'] if 'materials' in object_config else [
+        ]
 
-        print('type = ' + object_type + ', materials = ' + json.dumps(material_list))
+        print(
+            'type = ' +
+            object_type +
+            ', materials = ' +
+            json.dumps(material_list))
 
         step_output = controller.start_scene(scene_configuration)
         object_screenshot = step_output.image_list[0]
 
         # Shrink and crop the object's screenshot to reduce its size.
         object_screenshot = object_screenshot.resize((300, 200))
-        object_screenshot = object_screenshot.crop(ImageOps.invert(object_screenshot).getbbox())
+        object_screenshot = object_screenshot.crop(
+            ImageOps.invert(object_screenshot).getbbox())
 
-        output_file_name = output_folder + generate_output_file_name(object_type, material_list)
+        output_file_name = output_folder + \
+            generate_output_file_name(object_type, material_list)
         object_screenshot.save(fp=output_file_name + '.png')
 
         pixels = retrieve_image_pixel_list(object_screenshot)
 
         with open(output_file_name + '.txt', 'w') as output_text_file:
-            output_text_file.write(json.dumps(PrettyJsonNoIndent(pixels), cls=PrettyJsonEncoder))
+            output_text_file.write(
+                json.dumps(
+                    PrettyJsonNoIndent(pixels),
+                    cls=PrettyJsonEncoder))
+
 
 if __name__ == '__main__':
     main(sys.argv)
-

--- a/scene_generator/image_generator/materials.py
+++ b/scene_generator/image_generator/materials.py
@@ -24,30 +24,48 @@ NOVEL_COLOR_LIST = [
 ]
 
 BLOCK_BLANK_MATERIALS = [
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/blue_1x1", ["blue"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/gray_1x1", ["grey"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/green_1x1", ["green"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/red_1x1", ["red"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/wood_1x1", ["brown"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/yellow_1x1", ["yellow"])
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/blue_1x1",
+     ["blue"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/gray_1x1",
+     ["grey"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/green_1x1",
+     ["green"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/red_1x1",
+     ["red"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/wood_1x1",
+     ["brown"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/yellow_1x1",
+     ["yellow"])
 ]
 
 BLOCK_LETTER_MATERIALS = [
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_A_Blue_1K/ToyBlockBlueA", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_B_Blue_1K/ToyBlockBlueB", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_C_Blue_1K/ToyBlockBlueC", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_D_Blue_1K/ToyBlockBlueD", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_M_Blue_1K/ToyBlockBlueM", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_S_Blue_1K/ToyBlockBlueS", ["blue", "brown"])
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_A_Blue_1K/ToyBlockBlueA",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_B_Blue_1K/ToyBlockBlueB",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_C_Blue_1K/ToyBlockBlueC",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_D_Blue_1K/ToyBlockBlueD",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_M_Blue_1K/ToyBlockBlueM",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_S_Blue_1K/ToyBlockBlueS",
+     ["blue", "brown"])
 ]
 
 BLOCK_NUMBER_MATERIALS = [
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_1_Yellow_1K/NumberBlockYellow_1", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_2_Yellow_1K/NumberBlockYellow_2", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_3_Yellow_1K/NumberBlockYellow_3", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_4_Yellow_1K/NumberBlockYellow_4", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_5_Yellow_1K/NumberBlockYellow_5", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_6_Yellow_1K/NumberBlockYellow_6", ["yellow", "brown"])
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_1_Yellow_1K/NumberBlockYellow_1",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_2_Yellow_1K/NumberBlockYellow_2",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_3_Yellow_1K/NumberBlockYellow_3",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_4_Yellow_1K/NumberBlockYellow_4",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_5_Yellow_1K/NumberBlockYellow_5",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_6_Yellow_1K/NumberBlockYellow_6",
+     ["yellow", "brown"])
 ]
 
 CERAMIC_MATERIALS = [
@@ -56,7 +74,8 @@ CERAMIC_MATERIALS = [
     ("AI2-THOR/Materials/Ceramics/GREYGRANITE", ["grey"]),
     ("AI2-THOR/Materials/Ceramics/PinkConcrete_Bedroom1", ["red"]),
     ("AI2-THOR/Materials/Ceramics/RedBrick", ["red"]),
-    ("AI2-THOR/Materials/Ceramics/TexturesCom_BrickRound0044_1_seamless_S", ["grey"]),
+    ("AI2-THOR/Materials/Ceramics/TexturesCom_BrickRound0044_1_seamless_S",
+     ["grey"]),
     ("AI2-THOR/Materials/Ceramics/WhiteCountertop", ["grey"])
 ]
 
@@ -76,7 +95,8 @@ METAL_MATERIALS = [
     ("AI2-THOR/Materials/Metals/BrownMetal 1", ["brown"]),
     ("AI2-THOR/Materials/Metals/BrushedIron_AlbedoTransparency", ["black"]),
     ("AI2-THOR/Materials/Metals/GenericStainlessSteel", ["grey"]),
-    ("AI2-THOR/Materials/Metals/HammeredMetal_AlbedoTransparency 1", ["green"]),
+    ("AI2-THOR/Materials/Metals/HammeredMetal_AlbedoTransparency 1",
+     ["green"]),
     ("AI2-THOR/Materials/Metals/Metal", ["grey"]),
     ("AI2-THOR/Materials/Metals/WhiteMetal", ["white"]),
     ("UnityAssetStore/Baby_Room/Models/Materials/cabinet metal", ["grey"])
@@ -86,10 +106,14 @@ PLASTIC_MATERIALS = [
     ("AI2-THOR/Materials/Plastics/BlackPlastic", ["black"]),
     ("AI2-THOR/Materials/Plastics/OrangePlastic", ["orange"]),
     ("AI2-THOR/Materials/Plastics/WhitePlastic", ["white"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 1", ["red"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 2", ["blue"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 3", ["green"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 4", ["yellow"])
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 1",
+     ["red"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 2",
+     ["blue"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 3",
+     ["green"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 4",
+     ["yellow"])
 ]
 
 RUBBER_MATERIALS = [
@@ -115,22 +139,29 @@ WOOD_MATERIALS = [
     ("AI2-THOR/Materials/Wood/DarkWoodSmooth2", ["black"]),
     ("AI2-THOR/Materials/Wood/LightWoodCounters 1", ["brown"]),
     ("AI2-THOR/Materials/Wood/LightWoodCounters4", ["brown"]),
-    ("AI2-THOR/Materials/Wood/TexturesCom_WoodFine0050_1_seamless_S", ["brown"]),
+    ("AI2-THOR/Materials/Wood/TexturesCom_WoodFine0050_1_seamless_S",
+     ["brown"]),
     ("AI2-THOR/Materials/Wood/WhiteWood", ["white"]),
     ("AI2-THOR/Materials/Wood/WoodFloorsCross", ["brown"]),
     ("AI2-THOR/Materials/Wood/WoodGrain_Brown", ["brown"]),
     ("AI2-THOR/Materials/Wood/WoodGrain_Tan", ["brown"]),
     ("AI2-THOR/Materials/Wood/WornWood", ["brown"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 1", ["blue"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 2", ["red"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 3", ["green"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 4", ["yellow"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 1",
+     ["blue"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 2",
+     ["red"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 3",
+     ["green"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 4",
+     ["yellow"]),
     ("UnityAssetStore/Baby_Room/Models/Materials/wood 1", ["brown"])
 ]
 
-CEILING_AND_WALL_MATERIALS = CERAMIC_MATERIALS + METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
+CEILING_AND_WALL_MATERIALS = CERAMIC_MATERIALS + \
+    METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
 
-OCCLUDER_MATERIALS = CERAMIC_MATERIALS + METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
+OCCLUDER_MATERIALS = CERAMIC_MATERIALS + \
+    METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
 
-FLOOR_MATERIALS = CERAMIC_MATERIALS + FABRIC_MATERIALS + METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
-
+FLOOR_MATERIALS = CERAMIC_MATERIALS + FABRIC_MATERIALS + \
+    METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS

--- a/scene_generator/image_generator/test_image_generator.py
+++ b/scene_generator/image_generator/test_image_generator.py
@@ -6,13 +6,17 @@ from PIL import Image
 import image_generator
 from materials import *
 
+
 def mock_get_global_material_list(material):
     return [(material + '_1', 'white'), (material + '_2', 'black')]
 
+
 class Test_Image_Generator(unittest.TestCase):
 
-    @mock.patch('image_generator.get_global_material_list', side_effect=mock_get_global_material_list)
-    def test_generate_materials_lists_single_list_single_material(self, mock_function):
+    @mock.patch('image_generator.get_global_material_list',
+                side_effect=mock_get_global_material_list)
+    def test_generate_materials_lists_single_list_single_material(
+            self, mock_function):
         materials_options = [
             ['plastic']
         ]
@@ -20,8 +24,10 @@ class Test_Image_Generator(unittest.TestCase):
         expected = [['plastic_1'], ['plastic_2']]
         self.assertEqual(actual, expected)
 
-    @mock.patch('image_generator.get_global_material_list', side_effect=mock_get_global_material_list)
-    def test_generate_materials_lists_single_list_multiple_material(self, mock_function):
+    @mock.patch('image_generator.get_global_material_list',
+                side_effect=mock_get_global_material_list)
+    def test_generate_materials_lists_single_list_multiple_material(
+            self, mock_function):
         materials_options = [
             ['plastic', 'metal']
         ]
@@ -34,8 +40,10 @@ class Test_Image_Generator(unittest.TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    @mock.patch('image_generator.get_global_material_list', side_effect=mock_get_global_material_list)
-    def test_generate_materials_lists_multiple_list_single_material(self, mock_function):
+    @mock.patch('image_generator.get_global_material_list',
+                side_effect=mock_get_global_material_list)
+    def test_generate_materials_lists_multiple_list_single_material(
+            self, mock_function):
         materials_options = [
             ['metal'],
             ['plastic']
@@ -49,8 +57,10 @@ class Test_Image_Generator(unittest.TestCase):
         ]
         self.assertEqual(actual, expected)
 
-    @mock.patch('image_generator.get_global_material_list', side_effect=mock_get_global_material_list)
-    def test_generate_materials_lists_multiple_list_multiple_material(self, mock_function):
+    @mock.patch('image_generator.get_global_material_list',
+                side_effect=mock_get_global_material_list)
+    def test_generate_materials_lists_multiple_list_multiple_material(
+            self, mock_function):
         materials_options = [
             ['plastic', 'metal'],
             ['wood', 'wood']
@@ -69,10 +79,19 @@ class Test_Image_Generator(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_generate_output_file_name(self):
-        self.assertEqual(image_generator.generate_output_file_name('test_type', []), 'test_type')
-        self.assertEqual(image_generator.generate_output_file_name('test_type', ['a']), 'test_type_a')
-        self.assertEqual(image_generator.generate_output_file_name('test_type', ['a', 'b']), 'test_type_a_b')
-        self.assertEqual(image_generator.generate_output_file_name('test_type', ['A']), 'test_type_a')
+        self.assertEqual(
+            image_generator.generate_output_file_name(
+                'test_type', []), 'test_type')
+        self.assertEqual(
+            image_generator.generate_output_file_name(
+                'test_type', ['a']), 'test_type_a')
+        self.assertEqual(
+            image_generator.generate_output_file_name(
+                'test_type', [
+                    'a', 'b']), 'test_type_a_b')
+        self.assertEqual(
+            image_generator.generate_output_file_name(
+                'test_type', ['A']), 'test_type_a')
 
     def test_generate_scene_configuration(self):
         object_definition = {
@@ -88,7 +107,8 @@ class Test_Image_Generator(unittest.TestCase):
                 'z': 1
             }
         }
-        actual = image_generator.generate_scene_configuration(object_definition, None)
+        actual = image_generator.generate_scene_configuration(
+            object_definition, None)
         expected = {
             'screenshot': True,
             'objects': [{
@@ -126,7 +146,8 @@ class Test_Image_Generator(unittest.TestCase):
                 'z': 1
             }
         }
-        actual = image_generator.generate_scene_configuration(object_definition, ['test_material'])
+        actual = image_generator.generate_scene_configuration(
+            object_definition, ['test_material'])
         expected = {
             'screenshot': True,
             'objects': [{
@@ -151,7 +172,8 @@ class Test_Image_Generator(unittest.TestCase):
         }
         self.assertEqual(actual, expected)
 
-    @mock.patch('image_generator.get_global_material_list', side_effect=mock_get_global_material_list)
+    @mock.patch('image_generator.get_global_material_list',
+                side_effect=mock_get_global_material_list)
     def test_generate_scene_configuration_list(self, mock_function):
         self.maxDiff = None
         object_list = [{
@@ -292,13 +314,16 @@ class Test_Image_Generator(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_get_global_material_list(self):
-        self.assertEqual(METAL_MATERIALS, image_generator.get_global_material_list('metal'))
-        self.assertEqual(PLASTIC_MATERIALS, image_generator.get_global_material_list('plastic'))
+        self.assertEqual(
+            METAL_MATERIALS,
+            image_generator.get_global_material_list('metal'))
+        self.assertEqual(
+            PLASTIC_MATERIALS,
+            image_generator.get_global_material_list('plastic'))
 
     def test_retrieve_image_pixel_list(self):
-        object_screenshot = Image.fromarray(numpy.array([[(1, 2, 3), (4, 5, 6)], [(7, 8, 9), (10, 11, 12)]], \
-            dtype=numpy.uint8))
+        object_screenshot = Image.fromarray(numpy.array([[(1, 2, 3), (4, 5, 6)], [(7, 8, 9), (10, 11, 12)]],
+                                                        dtype=numpy.uint8))
         actual = image_generator.retrieve_image_pixel_list(object_screenshot)
         expected = [[(1, 2, 3), (4, 5, 6)], [(7, 8, 9), (10, 11, 12)]]
         self.assertEqual(actual, expected)
-

--- a/scene_generator/interaction_goals.py
+++ b/scene_generator/interaction_goals.py
@@ -25,22 +25,27 @@ def generate_image_file_name(target: Dict[str, Any]) -> str:
     if 'materials' not in target or not target['materials']:
         return target['type']
 
-    material_name_list = [item[(item.rfind('/') + 1):].lower().replace(' ', '_') for item in target['materials']]
-    return target['type'] + ('_' if len(material_name_list) > 0 else '') + ('_'.join(material_name_list))
+    material_name_list = [item[(item.rfind(
+        '/') + 1):].lower().replace(' ', '_') for item in target['materials']]
+    return target['type'] + ('_' if len(material_name_list)
+                             > 0 else '') + ('_'.join(material_name_list))
 
 
 def find_image_for_object(object_def: Dict[str, Any]) -> AnyStr:
     image_file_name = ""
 
     try:
-        image_file_name = 'images/' + generate_image_file_name(object_def) + '.txt'
+        image_file_name = 'images/' + \
+            generate_image_file_name(object_def) + '.txt'
 
         with open(image_file_name, 'r') as image_file:
             target_image = image_file.read()
-            
+
         return target_image
-    except: 
-        logging.warning('Image object could not be found, make sure you generated the image: ' + image_file_name)
+    except BaseException:
+        logging.warning(
+            'Image object could not be found, make sure you generated the image: ' +
+            image_file_name)
 
 
 def find_image_name(target: Dict[str, Any]) -> str:
@@ -51,19 +56,19 @@ def parse_path_section(path_section: Sequence[Sequence[float]],
                        current_heading: float,
                        performer: Tuple[float, float],
                        goal_boundary: List[Dict[str, float]]) -> \
-                       Tuple[List[Dict[str, Any]], float, Tuple[float, float]]:
+        Tuple[List[Dict[str, Any]], float, Tuple[float, float]]:
     """Compute the actions for one path section, starting with
     current_heading. Returns a tuple: (list of actions, new heading, performer position)"""
     actions = []
-    dx = path_section[1][0]-performer[0]
-    dz = path_section[1][1]-performer[1]
+    dx = path_section[1][0] - performer[0]
+    dz = path_section[1][1] - performer[1]
     theta = math.degrees(math.atan2(dz, dx))
 
     # IF my calculations are correct, this should be right no matter what
     # I'm assuming a positive angle is a clockwise rotation- so this should work
     # I think
 
-    delta_t = (current_heading-theta) % 360
+    delta_t = (current_heading - theta) % 360
     current_heading = theta
     if delta_t != 0:
         action = {
@@ -75,19 +80,19 @@ def parse_path_section(path_section: Sequence[Sequence[float]],
         }
         actions.append(action)
 
-    goal_center = (path_section[1][0],path_section[1][1])
+    goal_center = (path_section[1][0], path_section[1][1])
     performer_seg = Segment(performer, goal_center)
     distance = None
 
     for indx in range(len(goal_boundary)):
-        intersect_point = intersection(performer_seg, Segment((goal_boundary[indx-1]['x'],goal_boundary[indx-1]['z']),
-                                                              (goal_boundary[indx]['x'],goal_boundary[indx]['z'] )))
+        intersect_point = intersection(performer_seg, Segment((goal_boundary[indx - 1]['x'], goal_boundary[indx - 1]['z']),
+                                                              (goal_boundary[indx]['x'], goal_boundary[indx]['z'])))
         if intersect_point:
             distance = float(intersect_point[0].distance(performer))
             break
 
     if distance is None:
-        distance = math.sqrt( dx ** 2 + dz ** 2 )
+        distance = math.sqrt(dx ** 2 + dz ** 2)
     frac, whole = math.modf(distance / MAX_MOVE_DISTANCE)
     actions.extend([{
         "action": "MoveAhead",
@@ -114,20 +119,27 @@ def parse_path_section(path_section: Sequence[Sequence[float]],
 def get_navigation_actions(start_location: Dict[str, Any],
                            goal_object: Dict[str, Any],
                            all_objects: List[Dict[str, Any]]) -> \
-                           Tuple[List[Dict[str, Any]],
-                                 Tuple[float, float],
-                                 float]:
+    Tuple[List[Dict[str, Any]],
+          Tuple[float, float],
+          float]:
     """Get the action sequence for going from performer start to the
     goal_object. Returns tuple (action_list, performer end position,
     performer end heading).
     """
-    performer = (start_location['position']['x'], start_location['position']['z'])
+    performer = (
+        start_location['position']['x'],
+        start_location['position']['z'])
     if 'locationParent' in goal_object:
-        parent = next((obj for obj in all_objects if obj['id'] == goal_object['locationParent']), None)
+        parent = next(
+            (obj for obj in all_objects if obj['id']
+             == goal_object['locationParent']),
+            None)
         if parent is None:
-            raise PathfindingException(f'object {goal_object["id"]} has parent {goal_object["locationParent"]} that does not exist')
+            raise PathfindingException(
+                f'object {goal_object["id"]} has parent {goal_object["locationParent"]} that does not exist')
         goal_object = parent
-    goal = (goal_object['shows'][0]['position']['x'], goal_object['shows'][0]['position']['z'])
+    goal = (goal_object['shows'][0]['position']['x'],
+            goal_object['shows'][0]['position']['z'])
     hole_rects = []
 
     hole_rects.extend(object['shows'][0]['boundingBox'] for object
@@ -135,15 +147,17 @@ def get_navigation_actions(start_location: Dict[str, Any],
                       and 'locationParent' not in object)
     path = generatepath(performer, goal, hole_rects)
     if path is None:
-        raise PathfindingException(f'could not find path to target {goal_object["id"]}')
+        raise PathfindingException(
+            f'could not find path to target {goal_object["id"]}')
     for object in all_objects:
         if object['id'] == goal_object['id']:
             goal_boundary = object['shows'][0]['boundingBox']
             break
     actions = []
     current_heading = 90 - start_location['rotation']['y']
-    for indx in range(len(path)-1):
-        new_actions, current_heading, performer = parse_path_section(path[indx:indx+2], current_heading, performer, goal_boundary)
+    for indx in range(len(path) - 1):
+        new_actions, current_heading, performer = parse_path_section(
+            path[indx:indx + 2], current_heading, performer, goal_boundary)
         actions.extend(new_actions)
 
     return actions, performer, current_heading
@@ -153,13 +167,14 @@ def trim_actions_to_reach(actions: List[Dict[str, Any]],
                           performer: Tuple[float, float],
                           heading: float,
                           goal_obj: Dict[str, Any]) -> \
-                          Tuple[List[Dict[str, Any]], Tuple[float, float]]:
+        Tuple[List[Dict[str, Any]], Tuple[float, float]]:
     """Trim the action list from the end so that the performer doesn't
     take additonal steps toward the goal object once they're within
     MAX_REACH_DISTANCE.
     """
     goal_position = goal_obj['shows'][0]['position']
-    total_distance = math.sqrt((performer[0] - goal_position['x'])**2 + (performer[1] - goal_position['z'])**2)
+    total_distance = math.sqrt(
+        (performer[0] - goal_position['x'])**2 + (performer[1] - goal_position['z'])**2)
 
     i = len(actions)
     step_dist = 0
@@ -174,14 +189,14 @@ def trim_actions_to_reach(actions: List[Dict[str, Any]],
         dist_moved += step_dist
 
     dist_moved -= step_dist
-    new_actions = actions[:i+1]
+    new_actions = actions[:i + 1]
     new_x = performer[0] - dist_moved * math.cos(math.radians(heading))
     new_z = performer[1] - dist_moved * math.sin(math.radians(heading))
     return new_actions, (new_x, new_z)
 
 
-def move_to_container(target_definition: Dict[str, Any], target: Dict[str, Any], \
-        bounds_list: List[List[Dict[str, float]]], performer_position: Dict[str, float]) -> Dict[str, Any]:
+def move_to_container(target_definition: Dict[str, Any], target: Dict[str, Any],
+                      bounds_list: List[List[Dict[str, float]]], performer_position: Dict[str, float]) -> Dict[str, Any]:
     """Try to find a random container that target will fit in. If found, set the target's locationParent, and add
     container to bounds_list. Return the container, or None if the target was not put into a container."""
     shuffled_containers = containers.retrieve_enclosable_object_definition_list().copy()
@@ -191,12 +206,14 @@ def move_to_container(target_definition: Dict[str, Any], target: Dict[str, Any],
         containment = containers.how_can_contain(container_definition, target)
         if containment is not None:
             # try to place the container before we accept it
-            container_location = geometry.calc_obj_pos(performer_position, bounds_list, container_definition)
+            container_location = geometry.calc_obj_pos(
+                performer_position, bounds_list, container_definition)
             if container_location is not None:
-                container = instantiate_object(container_definition, container_location)
+                container = instantiate_object(
+                    container_definition, container_location)
                 area, angles = containment
-                containers.put_object_in_container(target_definition, target, container, container_definition, area, \
-                        angles[0])
+                containers.put_object_in_container(target_definition, target, container, container_definition, area,
+                                                   angles[0])
                 return container
     return None
 
@@ -204,7 +221,8 @@ def move_to_container(target_definition: Dict[str, Any], target: Dict[str, Any],
 class ObjectRule():
     """Defines rules for how a specific object can be made and positioned as part of a specific goal."""
 
-    def __init__(self, is_position_in_receptacle = False, is_position_on_receptacle = False):
+    def __init__(self, is_position_in_receptacle=False,
+                 is_position_on_receptacle=False):
         self.is_position_in_receptacle = is_position_in_receptacle
         self.is_position_on_receptacle = is_position_on_receptacle
 
@@ -213,95 +231,130 @@ class ObjectRule():
         # Same chance to pick each list.
         object_definition_list = random.choice(objects.get('ALL_LISTS'))
         # Same chance to pick each object definition from the list.
-        object_definition = finalize_object_definition(random.choice(object_definition_list))
-        return random.choice(finalize_object_materials_and_colors(object_definition))
+        object_definition = finalize_object_definition(
+            random.choice(object_definition_list))
+        return random.choice(
+            finalize_object_materials_and_colors(object_definition))
 
-    def choose_location(self, object_definition: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], \
-            bounds_list: List[List[Dict[str, float]]]) -> Tuple[Dict[str, Any], List[List[Dict[str, float]]]]:
+    def choose_location(self, object_definition: Dict[str, Any], performer_start: Dict[str, Dict[str, float]],
+                        bounds_list: List[List[Dict[str, float]]]) -> Tuple[Dict[str, Any], List[List[Dict[str, float]]]]:
         """Choose and return the location for the given object definition. Will modify bounds_list."""
-        object_location = geometry.calc_obj_pos(performer_start['position'], bounds_list, object_definition)
+        object_location = geometry.calc_obj_pos(
+            performer_start['position'], bounds_list, object_definition)
         if not object_location:
-            raise exceptions.SceneException(f'cannot position object (type={object_definition["type"]})')
+            raise exceptions.SceneException(
+                f'cannot position object (type={object_definition["type"]})')
         return object_location, bounds_list
 
-    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
-            performer_start: Dict[str, Dict[str, float]]) -> bool:
+    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]],
+                          performer_start: Dict[str, Dict[str, float]]) -> bool:
         """Returns if the given object location is valid."""
         return True
 
 
 class PickupableObjectRule(ObjectRule):
-    def __init__(self, is_position_in_receptacle = False, is_position_on_receptacle = False):
-        super(PickupableObjectRule, self).__init__(is_position_in_receptacle, is_position_on_receptacle)
+    def __init__(self, is_position_in_receptacle=False,
+                 is_position_on_receptacle=False):
+        super(
+            PickupableObjectRule,
+            self).__init__(
+            is_position_in_receptacle,
+            is_position_on_receptacle)
 
     def choose_definition(self) -> Dict[str, Any]:
         object_definition_list = random.choice(objects.get('PICKUPABLE_LISTS'))
-        object_definition = finalize_object_definition(random.choice(object_definition_list))
-        return random.choice(finalize_object_materials_and_colors(object_definition))
+        object_definition = finalize_object_definition(
+            random.choice(object_definition_list))
+        return random.choice(
+            finalize_object_materials_and_colors(object_definition))
 
 
 class TransferToObjectRule(ObjectRule):
-    def __init__(self, is_position_in_receptacle = False, is_position_on_receptacle = False):
-        super(TransferToObjectRule, self).__init__(is_position_in_receptacle, is_position_on_receptacle)
+    def __init__(self, is_position_in_receptacle=False,
+                 is_position_on_receptacle=False):
+        super(
+            TransferToObjectRule,
+            self).__init__(
+            is_position_in_receptacle,
+            is_position_on_receptacle)
 
     def choose_definition(self) -> Dict[str, Any]:
         choice_list = []
         for possible_list in objects.get('ALL_LISTS'):
-            stack_targets = [definition for definition in possible_list \
-                    if 'stackTarget' in definition.get('attributes', [])]
+            stack_targets = [definition for definition in possible_list
+                             if 'stackTarget' in definition.get('attributes', [])]
             if len(stack_targets) > 0:
                 choice_list.append(stack_targets)
 
         if len(choice_list) == 0:
-            raise exceptions.SceneException('cannot find any stack target definition')
+            raise exceptions.SceneException(
+                'cannot find any stack target definition')
 
         # Same chance to pick each list.
         object_definition_list = random.choice(choice_list)
         # Same chance to pick each object definition from the list.
-        object_definition = finalize_object_definition(random.choice(object_definition_list))
-        return random.choice(finalize_object_materials_and_colors(object_definition))
+        object_definition = finalize_object_definition(
+            random.choice(object_definition_list))
+        return random.choice(
+            finalize_object_materials_and_colors(object_definition))
 
-    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
-            performer_start: Dict[str, Dict[str, float]]) -> bool:
+    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]],
+                          performer_start: Dict[str, Dict[str, float]]) -> bool:
 
         if len(target_list) == 0:
-            raise exceptions.SceneException('cannot find existing target to transfer')
+            raise exceptions.SceneException(
+                'cannot find existing target to transfer')
 
         target_1_position = target_list[0]['shows'][0]['position']
 
-        distance = geometry.position_distance(target_1_position, object_location['position'])
+        distance = geometry.position_distance(
+            target_1_position, object_location['position'])
 
         # Cannot be positioned too close to the existing target object.
         return distance >= geometry.MIN_OBJECTS_SEPARATION_DISTANCE
 
 
 class FarOffObjectRule(ObjectRule):
-    def __init__(self, is_position_in_receptacle = False, is_position_on_receptacle = False):
-        super(FarOffObjectRule, self).__init__(is_position_in_receptacle, is_position_on_receptacle)
+    def __init__(self, is_position_in_receptacle=False,
+                 is_position_on_receptacle=False):
+        super(
+            FarOffObjectRule,
+            self).__init__(
+            is_position_in_receptacle,
+            is_position_on_receptacle)
 
-    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
-            performer_start: Dict[str, Dict[str, float]]) -> bool:
+    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]],
+                          performer_start: Dict[str, Dict[str, float]]) -> bool:
 
-        distance = geometry.position_distance(performer_start['position'], object_location['position'])
+        distance = geometry.position_distance(
+            performer_start['position'],
+            object_location['position'])
 
         # Cannot be positioned too close to the performer.
         return distance >= geometry.MIN_OBJECTS_SEPARATION_DISTANCE
 
 
 class DistractorObjectRule(ObjectRule):
-    def __init__(self, target_confusor_list: List[Dict[str, Any]], is_position_in_receptacle = False, \
-            is_position_on_receptacle = False):
-        super(DistractorObjectRule, self).__init__(is_position_in_receptacle, is_position_on_receptacle)
+    def __init__(self, target_confusor_list: List[Dict[str, Any]], is_position_in_receptacle=False,
+                 is_position_on_receptacle=False):
+        super(
+            DistractorObjectRule,
+            self).__init__(
+            is_position_in_receptacle,
+            is_position_on_receptacle)
         # Don't use the shape of objects like targets or confusors.
         self._target_confusor_list = target_confusor_list
 
     def choose_definition(self) -> Dict[str, Any]:
-        shape_list = [object['shape'][-1] for object in self._target_confusor_list]
+        shape_list = [object['shape'][-1]
+                      for object in self._target_confusor_list]
         for _ in range(util.MAX_TRIES):
-            distractor_definition = super(DistractorObjectRule, self).choose_definition()
+            distractor_definition = super(
+                DistractorObjectRule, self).choose_definition()
             distractor_shape = distractor_definition['shape'][-1] if isinstance(distractor_definition['shape'], list) \
-                    else distractor_definition['shape']
-            # Cannot have the same shape as a goal object, so we don't unintentionally generate a confusor.
+                else distractor_definition['shape']
+            # Cannot have the same shape as a goal object, so we don't
+            # unintentionally generate a confusor.
             if distractor_shape not in shape_list:
                 break
             distractor_definition = None
@@ -315,42 +368,52 @@ class ConfusorObjectRule(ObjectRule):
 
     def choose_definition(self) -> Dict[str, Any]:
         if not self._target_definition:
-            raise exceptions.SceneException('cannot create a confusor with no target definition')
-        confusor_definition = util.get_similar_definition(self._target_definition, objects.get('ALL'))
+            raise exceptions.SceneException(
+                'cannot create a confusor with no target definition')
+        confusor_definition = util.get_similar_definition(
+            self._target_definition, objects.get('ALL'))
         if not confusor_definition:
-            raise exceptions.SceneException(f'cannot find a confusor to create with target={self._target_definition}')
+            raise exceptions.SceneException(
+                f'cannot find a confusor to create with target={self._target_definition}')
         return confusor_definition
 
 
 class ObstructorObjectRule(ObjectRule):
-    def __init__(self, target_definition: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], \
-            obstruct_vision: bool):
+    def __init__(self, target_definition: Dict[str, Any], performer_start: Dict[str, Dict[str, float]],
+                 obstruct_vision: bool):
         super(ObstructorObjectRule, self).__init__()
         self._target_definition = target_definition
         self._obstruct_vision = obstruct_vision
 
     def choose_definition(self) -> Dict[str, Any]:
         if not self._target_definition:
-            raise exceptions.SceneException('cannot create an obstructor with no target definition')
-        obstructor_definition_list = geometry.get_wider_and_taller_defs(self._target_definition, self._obstruct_vision)
+            raise exceptions.SceneException(
+                'cannot create an obstructor with no target definition')
+        obstructor_definition_list = geometry.get_wider_and_taller_defs(
+            self._target_definition, self._obstruct_vision)
         if not obstructor_definition_list:
-            raise exceptions.SceneException(f'cannot find an obstructor to create with target={self._target_definition}')
-        obstructor_definition, obstructor_angle = random.choice(obstructor_definition_list)
-        obstructor_definition = util.finalize_object_definition(obstructor_definition)
+            raise exceptions.SceneException(
+                f'cannot find an obstructor to create with target={self._target_definition}')
+        obstructor_definition, obstructor_angle = random.choice(
+            obstructor_definition_list)
+        obstructor_definition = util.finalize_object_definition(
+            obstructor_definition)
         if not 'rotation' in obstructor_definition:
             obstructor_definition['rotation'] = {
                 'x': 0,
                 'y': 0,
                 'z': 0
             }
-        # Note that this rotation must be also modified with the final performer start Y.
+        # Note that this rotation must be also modified with the final
+        # performer start Y.
         obstructor_definition['rotation']['y'] += obstructor_angle
         return obstructor_definition
 
 
 class InteractionGoal(Goal, ABC):
     LAST_STEP = 600
-    # MAX_DISTRACTORS doesn't count the receptacles randomly generated to containerize other objects.
+    # MAX_DISTRACTORS doesn't count the receptacles randomly generated to
+    # containerize other objects.
     MAX_DISTRACTORS = 10
     OBJECT_RECEPTACLE_CHANCE = 0.333
     WALL_CHOICES = [0, 1, 2, 3]
@@ -372,7 +435,8 @@ class InteractionGoal(Goal, ABC):
         self._no_random_obstructor = False
 
     # override
-    def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+    def compute_objects(self, wall_material_name: str,
+                        wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
         return {
             'target': self.generate_target_list(),
             'confusor': self._confusor_list,
@@ -384,40 +448,56 @@ class InteractionGoal(Goal, ABC):
     def generate_distractor_list(self) -> List[Dict[str, Any]]:
         """Generates and returns the distractors in this goal."""
         if not self._is_distractor_list_done:
-            # Automatically generate a random number of distractors with random parameters.
+            # Automatically generate a random number of distractors with random
+            # parameters.
             distractor_rule_list = []
             number = random.randint(0, InteractionGoal.MAX_DISTRACTORS)
-            logging.debug(f'{self.get_name()} goal generating {number} distractors...')
+            logging.debug(
+                f'{self.get_name()} goal generating {number} distractors...')
             for _ in range(number + 1):
-                distractor_rule_list.append(self.get_distractor_rule(is_position_in_receptacle = \
-                        (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)))
-            self.__generate_object_list(self._distractor_list, distractor_rule_list, self._target_list, \
-                    self._distractor_list)
+                distractor_rule_list.append(
+                    self.get_distractor_rule(
+                        is_position_in_receptacle=(
+                            random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)))
+            self.__generate_object_list(self._distractor_list, distractor_rule_list, self._target_list,
+                                        self._distractor_list)
             self._is_distractor_list_done = True
         return self._distractor_list
 
-    def generate_target_list(self, end_index: int = None) -> List[Dict[str, Any]]:
+    def generate_target_list(
+            self, end_index: int = None) -> List[Dict[str, Any]]:
         """Generates and returns the targets in this goal (or up to the end_index, if given)."""
-        # Only generate each target up to the given end_index, or generate all targets if no end_index was given.
-        end_index_to_generate = (end_index if end_index is not None else len(self._target_rule_list))
+        # Only generate each target up to the given end_index, or generate all
+        # targets if no end_index was given.
+        end_index_to_generate = (
+            end_index if end_index is not None else len(
+                self._target_rule_list))
         if len(self._target_list) < end_index_to_generate:
-            # Keep all existing targets; only generate new targets that don't yet exist.
-            incomplete_target_rule_list = self._target_rule_list[len(self._target_list):end_index_to_generate]
-            self.__generate_object_list(self._target_list, incomplete_target_rule_list, self._target_list, \
-                    self._distractor_list)
+            # Keep all existing targets; only generate new targets that don't
+            # yet exist.
+            incomplete_target_rule_list = self._target_rule_list[len(
+                self._target_list):end_index_to_generate]
+            self.__generate_object_list(self._target_list, incomplete_target_rule_list, self._target_list,
+                                        self._distractor_list)
         return self._target_list
 
-    def generate_wall_list(self, wall_material_name: str, wall_colors: List[str]) -> List[Dict[str, Any]]:
+    def generate_wall_list(self, wall_material_name: str,
+                           wall_colors: List[str]) -> List[Dict[str, Any]]:
         """Generates and returns the walls (other than the room's starting walls) in this goal."""
         if self._wall_list is None:
             self._wall_list = []
-            number = random.choices(InteractionGoal.WALL_CHOICES, weights=InteractionGoal.WALL_WEIGHTS, k=1)[0]
-            logging.debug(f'{self.get_name()} goal generating {number} walls...')
-            dont_obstruct_list = self.__retrieve_target_confusor_list() if self._no_random_obstructor else None
+            number = random.choices(
+                InteractionGoal.WALL_CHOICES,
+                weights=InteractionGoal.WALL_WEIGHTS,
+                k=1)[0]
+            logging.debug(
+                f'{self.get_name()} goal generating {number} walls...')
+            dont_obstruct_list = self.__retrieve_target_confusor_list(
+            ) if self._no_random_obstructor else None
             for _ in range(number + 1):
                 # TODO This should probably be an ObjectRule eventually
-                wall = generate_wall(wall_material_name, wall_colors, self._performer_start['position'], \
-                        self._bounds_list, dont_obstruct_list = dont_obstruct_list)
+                wall = generate_wall(wall_material_name, wall_colors, self._performer_start['position'],
+                                     self._bounds_list, dont_obstruct_list=dont_obstruct_list)
                 if wall:
                     self._wall_list.append(wall)
                     self._bounds_list.append(wall['shows'][0]['boundingBox'])
@@ -433,27 +513,30 @@ class InteractionGoal(Goal, ABC):
         """Returns the confusors in this goal."""
         return self._confusor_list
 
-    def get_confusor_rule(self, target_definition: Dict[str, Any]) -> ObjectRule:
+    def get_confusor_rule(
+            self, target_definition: Dict[str, Any]) -> ObjectRule:
         """Returns the rule for any confusors compatible with this goal."""
-        return self._confusor_rule(target_definition = target_definition)
+        return self._confusor_rule(target_definition=target_definition)
 
     def get_distractor_list(self) -> List[Dict[str, Any]]:
         """Returns the distractors in this goal."""
         return self._distractor_list
 
-    def get_distractor_rule(self, is_position_in_receptacle: bool = False) -> ObjectRule:
+    def get_distractor_rule(
+            self, is_position_in_receptacle: bool = False) -> ObjectRule:
         """Returns the rule for any distractors compatible with this goal."""
-        return self._distractor_rule(target_confusor_list = self.__retrieve_target_confusor_list(), \
-                is_position_in_receptacle = is_position_in_receptacle)
+        return self._distractor_rule(target_confusor_list=self.__retrieve_target_confusor_list(),
+                                     is_position_in_receptacle=is_position_in_receptacle)
 
     def get_obstructor_list(self) -> List[Dict[str, Any]]:
         """Returns the obstructors in this goal."""
         return self._obstructor_list
 
-    def get_obstructor_rule(self, target_definition: Dict[str, Any], obstruct_vision: bool) -> ObjectRule:
+    def get_obstructor_rule(
+            self, target_definition: Dict[str, Any], obstruct_vision: bool) -> ObjectRule:
         """Returns the rule for any obstructors compatible with this goal."""
-        return self._obstructor_rule(target_definition = target_definition, obstruct_vision = obstruct_vision, \
-                performer_start = self.get_performer_start())
+        return self._obstructor_rule(target_definition=target_definition, obstruct_vision=obstruct_vision,
+                                     performer_start=self.get_performer_start())
 
     def get_target_list(self) -> List[Dict[str, Any]]:
         """Returns the targets in this goal."""
@@ -471,47 +554,55 @@ class InteractionGoal(Goal, ABC):
         """If called, the randomly positioned distractors/walls won't obstruct vision to the targets/confusors."""
         self._no_random_obstructor = True
 
-    def __generate_object_list(self, object_list: List[Dict[str, Any]], rule_list: List[ObjectRule], \
-            target_list: List[Dict[str, Any]], distractor_list: List[Dict[str, Any]]) -> None:
+    def __generate_object_list(self, object_list: List[Dict[str, Any]], rule_list: List[ObjectRule],
+                               target_list: List[Dict[str, Any]], distractor_list: List[Dict[str, Any]]) -> None:
         """Generates new objects using the given rule_list and saves them in the given object_list. Will modify the
         given distractor_list and self._bounds_list"""
 
         for rule in rule_list:
             object_definition = rule.choose_definition()
             for _ in range(util.MAX_TRIES):
-                object_location, bounds_list_modified = rule.choose_location(object_definition, \
-                        self._performer_start, self._bounds_list)
-                if rule.validate_location(object_location, target_list, self._performer_start):
+                object_location, bounds_list_modified = rule.choose_location(object_definition,
+                                                                             self._performer_start, self._bounds_list)
+                if rule.validate_location(
+                        object_location, target_list, self._performer_start):
                     break
                 object_location = None
             if not object_location:
-                raise exceptions.SceneException('cannot find a suitable object location')
+                raise exceptions.SceneException(
+                    'cannot find a suitable object location')
             self._bounds_list = bounds_list_modified
-            object_instance = instantiate_object(object_definition, object_location)
+            object_instance = instantiate_object(
+                object_definition, object_location)
             object_list.append(object_instance)
             receptacle_instance = None
             if rule.is_position_in_receptacle:
-                receptacle_instance = self.__move_into_receptacle(object_definition, object_instance, \
-                        self._performer_start, self._bounds_list)
+                receptacle_instance = self.__move_into_receptacle(object_definition, object_instance,
+                                                                  self._performer_start, self._bounds_list)
             if rule.is_position_on_receptacle:
-                receptacle_instance = self.__move_onto_receptacle(object_instance, self._performer_start, \
-                        self._bounds_list)
+                receptacle_instance = self.__move_onto_receptacle(object_instance, self._performer_start,
+                                                                  self._bounds_list)
             if receptacle_instance:
                 distractor_list.append(receptacle_instance)
 
-    def __move_into_receptacle(self, object_definition: Dict[str, Any], object_instance: Dict[str, Any], \
-            performer_start: Dict[str, Dict[str, float]], bounds_list: List[List[Dict[str, float]]]) -> Dict[str, Any]:
+    def __move_into_receptacle(self, object_definition: Dict[str, Any], object_instance: Dict[str, Any],
+                               performer_start: Dict[str, Dict[str, float]], bounds_list: List[List[Dict[str, float]]]) -> Dict[str, Any]:
         """Create and return a receptacle object, moving the given object into the new receptacle. Will modify
         bounds_list."""
         receptacle = None
         # Only a pickupable object can be positioned inside a receptacle.
         if object_instance.get('pickupable', False):
-            # Receptacles that can have objects positioned inside them are sometimes called "containers"
-            receptacle = move_to_container(object_definition, object_instance, bounds_list, performer_start['position'])
+            # Receptacles that can have objects positioned inside them are
+            # sometimes called "containers"
+            receptacle = move_to_container(
+                object_definition,
+                object_instance,
+                bounds_list,
+                performer_start['position'])
         return receptacle
 
-    def __move_onto_receptacle(self, object_instance: Dict[str, Any], performer_start: Dict[str, Dict[str, float]], \
-            bounds_list: List[List[Dict[str, float]]]) -> Dict[str, Any]:
+    def __move_onto_receptacle(self, object_instance: Dict[str, Any], performer_start: Dict[str, Dict[str, float]],
+                               bounds_list: List[List[Dict[str, float]]]) -> Dict[str, Any]:
         """Create and return a receptacle object, moving the given object onto the new receptacle. Will modify
         bounds_list."""
         # TODO MCS-146 Position objects on top of receptacles.
@@ -526,6 +617,7 @@ class InteractionGoal(Goal, ABC):
                     if object_instance['locationParent'] == distractor['id']:
                         object_list.append(distractor)
         return object_list
+
 
 class RetrievalGoal(InteractionGoal):
     """Going to a specified object and picking it up."""
@@ -550,16 +642,20 @@ class RetrievalGoal(InteractionGoal):
     def __init__(self):
         super(RetrievalGoal, self).__init__('retrieval', [
             PickupableObjectRule(
-                is_position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                is_position_in_receptacle=(
+                    random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             )
         ])
 
-    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _get_subclass_config(
+            self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         if len(goal_objects) < 1:
-            raise exceptions.SceneException('need at least 1 object for this goal')
+            raise exceptions.SceneException(
+                'need at least 1 object for this goal')
         target = goal_objects[0]
         if not target.get('pickupable', False):
-            raise exceptions.SceneException(f'first object must be "pickupable": {target}')
+            raise exceptions.SceneException(
+                f'first object must be "pickupable": {target}')
 
         target_image_obj = find_image_for_object(target)
         image_name = find_image_name(target)
@@ -580,39 +676,42 @@ class RetrievalGoal(InteractionGoal):
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
             List[Dict[str, Any]]:
         # Goal should be a singleton... I hope
-        actions, performer, heading = get_navigation_actions(self._performer_start, goal_objects[0], all_objects)
-        actions, performer = trim_actions_to_reach(actions, performer, heading, goal_objects[0])
+        actions, performer, heading = get_navigation_actions(
+            self._performer_start, goal_objects[0], all_objects)
+        actions, performer = trim_actions_to_reach(
+            actions, performer, heading, goal_objects[0])
 
         # Do I have to look down to see the object????
         plane_dist = math.sqrt((goal_objects[0]['shows'][0]['position']['x'] - performer[0]) ** 2 +
                                (goal_objects[0]['shows'][0]['position']['z'] - performer[1]) ** 2)
-        height_dist = PERFORMER_CAMERA_Y - goal_objects[0]['shows'][0]['position']['y']
+        height_dist = PERFORMER_CAMERA_Y - \
+            goal_objects[0]['shows'][0]['position']['y']
         elevation = math.degrees(math.atan2(height_dist, plane_dist))
         if abs(elevation) > 30:
             actions.append({
                 'action': 'RotateLook',
                 'params': {
                     'rotation': 0,
-                    'horizon': round(elevation,0)
-                    }
-                })
+                    'horizon': round(elevation, 0)
+                }
+            })
         actions.append({
             'action': 'PickupObject',
             'params': {
                 'objectId': goal_objects[0]['id']
-                }
-            })
+            }
+        })
         if abs(elevation) > 30:
             actions.append(
-                 {
-                'action': 'RotateLook',
-                'params': {
-                    'rotation': 0,
-                    'horizon': -1*round(elevation, 0)
+                {
+                    'action': 'RotateLook',
+                    'params': {
+                        'rotation': 0,
+                        'horizon': -1 * round(elevation, 0)
                     }
                 })
         return actions
-        
+
 
 class TransferralGoal(InteractionGoal):
     """Moving a specified object to another specified object."""
@@ -641,19 +740,24 @@ class TransferralGoal(InteractionGoal):
     def __init__(self):
         super(TransferralGoal, self).__init__('transferral', [
             PickupableObjectRule(
-                is_position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                is_position_in_receptacle=(
+                    random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             ),
             TransferToObjectRule()
         ])
 
-    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _get_subclass_config(
+            self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         if len(goal_objects) < 2:
-            raise exceptions.SceneException(f'need at least 2 objects for this goal, was given {len(goal_objects)}')
+            raise exceptions.SceneException(
+                f'need at least 2 objects for this goal, was given {len(goal_objects)}')
         target1, target2 = goal_objects[0:2]
         if not target1.get('pickupable', False):
-            raise exceptions.SceneException(f'first object must be "pickupable": {target1}')
+            raise exceptions.SceneException(
+                f'first object must be "pickupable": {target1}')
         if not target2.get('stackTarget', False):
-            raise exceptions.SceneException(f'second object must be "stackTarget": {target2}')
+            raise exceptions.SceneException(
+                f'second object must be "stackTarget": {target2}')
         relationship = random.choice(list(self.RelationshipType))
 
         target1_image_obj = find_image_for_object(target1)
@@ -690,12 +794,14 @@ class TransferralGoal(InteractionGoal):
         actions, performer, heading = get_navigation_actions(self._performer_start,
                                                              goal_objects[0],
                                                              all_objects)
-        actions, performer = trim_actions_to_reach(actions, performer, heading, goal_objects[0])
+        actions, performer = trim_actions_to_reach(
+            actions, performer, heading, goal_objects[0])
 
         # Do I have to look down to see the object????
         plane_dist = math.sqrt((goal_objects[0]['shows'][0]['position']['x'] - performer[0]) ** 2 +
                                (goal_objects[0]['shows'][0]['position']['z'] - performer[1]) ** 2)
-        height_dist = PERFORMER_CAMERA_Y-goal_objects[0]['shows'][0]['position']['y']
+        height_dist = PERFORMER_CAMERA_Y - \
+            goal_objects[0]['shows'][0]['position']['y']
         elevation = math.degrees(math.atan2(height_dist, plane_dist))
         if abs(elevation) > 30:
             actions.append({
@@ -703,65 +809,79 @@ class TransferralGoal(InteractionGoal):
                 'params': {
                     'rotation': 0.0,
                     'horizon': round(elevation, POSITION_DIGITS)
-                    }
-                })
+                }
+            })
         actions.append({
             'action': 'PickupObject',
             'params': {
                 'objectId': goal_objects[0]['id']
-                }
-            })
+            }
+        })
         if abs(elevation) > 30:
             actions.append({
                 'action': 'RotateLook',
                 'params': {
                     'rotation': 0.0,
-                    'horizon': -1*round(elevation, POSITION_DIGITS)
-                    }
-                })
+                    'horizon': -1 * round(elevation, POSITION_DIGITS)
+                }
+            })
 
         ignore_object_ids = [goal_objects[0]['id'], goal_objects[1]['id']]
         if 'locationParent' in goal_objects[0]:
             ignore_object_ids.append(goal_objects[0]['locationParent'])
-            parent = next((obj for obj in all_objects if obj['id'] == goal_objects[0]['locationParent']))
-            target = (parent['shows'][0]['position']['x'], parent['shows'][0]['position']['z'])
+            parent = next(
+                (obj for obj in all_objects if obj['id'] == goal_objects[0]['locationParent']))
+            target = (
+                parent['shows'][0]['position']['x'],
+                parent['shows'][0]['position']['z'])
         else:
-            target = (goal_objects[0]['shows'][0]['position']['x'], goal_objects[0]['shows'][0]['position']['z'])
+            target = (
+                goal_objects[0]['shows'][0]['position']['x'],
+                goal_objects[0]['shows'][0]['position']['z'])
         if 'locationParent' in goal_objects[1]:
             ignore_object_ids.append(goal_objects[1]['locationParent'])
-            parent = next((obj for obj in all_objects if obj['id'] == goal_objects[1]['locationParent']))
-            goal = (parent['shows'][0]['position']['x'], parent['shows'][0]['position']['z'])
+            parent = next(
+                (obj for obj in all_objects if obj['id'] == goal_objects[1]['locationParent']))
+            goal = (parent['shows'][0]['position']['x'],
+                    parent['shows'][0]['position']['z'])
         else:
-            goal = (goal_objects[1]['shows'][0]['position']['x'], goal_objects[1]['shows'][0]['position']['z'])
+            goal = (
+                goal_objects[1]['shows'][0]['position']['x'],
+                goal_objects[1]['shows'][0]['position']['z'])
 
         hole_rects = []
         hole_rects.extend(object['shows'][0]['boundingBox'] for object
                           in all_objects if (object['id'] not in ignore_object_ids and 'locationParent' not in object))
 
-        logging.debug(f'TransferralGoal.f_o_p: target = {target}\tgoal = {goal}\tholes = {hole_rects}')
+        logging.debug(
+            f'TransferralGoal.f_o_p: target = {target}\tgoal = {goal}\tholes = {hole_rects}')
         path = generatepath(target, goal, hole_rects)
         if path is None:
-            raise PathfindingException('could not find path from target object to goal')
+            raise PathfindingException(
+                'could not find path from target object to goal')
         logging.debug(f'TransferralGoal.f_o_p: got path = {path}')
         for object in all_objects:
             if object['id'] == goal_objects[1]['id']:
                 goal_boundary = object['shows'][0]['boundingBox']
                 break
         current_heading = heading
-        for indx in range(len(path)-1):
-            new_actions, current_heading, performer = parse_path_section(path[indx:indx+2], current_heading, performer, goal_boundary)
+        for indx in range(len(path) - 1):
+            new_actions, current_heading, performer = parse_path_section(
+                path[indx:indx + 2], current_heading, performer, goal_boundary)
             actions.extend(new_actions)
 
-        actions, performer = trim_actions_to_reach(actions, performer, current_heading, goal_objects[1])
+        actions, performer = trim_actions_to_reach(
+            actions, performer, current_heading, goal_objects[1])
 
-        # TODO: maybe look at receptacle part of the parent object (future ticket)
+        # TODO: maybe look at receptacle part of the parent object (future
+        # ticket)
         actions.append({
             'action': 'PutObject',
             'params': {
                 'objectId': goal_objects[0]['id'],
                 'receptacleObjectId': goal_objects[1]['id']
-                }})
-  
+            }})
+
         return actions
 
 
@@ -788,13 +908,16 @@ class TraversalGoal(InteractionGoal):
     def __init__(self):
         super(TraversalGoal, self).__init__('traversal', [
             FarOffObjectRule(
-                is_position_in_receptacle = (random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
+                is_position_in_receptacle=(
+                    random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE)
             )
         ])
 
-    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _get_subclass_config(
+            self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         if len(goal_objects) < 1:
-            raise exceptions.SceneException('need at least 1 object for this goal')
+            raise exceptions.SceneException(
+                'need at least 1 object for this goal')
 
         target = goal_objects[0]
         target_image_obj = find_image_for_object(target)
@@ -816,11 +939,12 @@ class TraversalGoal(InteractionGoal):
     def _find_optimal_path(self, goal_objects: List[Dict[str, Any]], all_objects: List[Dict[str, Any]]) -> \
             List[Dict[str, Any]]:
         # Goal should be a singleton... I hope
-        # TODO: (maybe) look at actual object if it's inside a parent (future ticket)
-        return get_navigation_actions(self._performer_start, goal_objects[0], all_objects)[0]
+        # TODO: (maybe) look at actual object if it's inside a parent (future
+        # ticket)
+        return get_navigation_actions(
+            self._performer_start, goal_objects[0], all_objects)[0]
 
 
 class PathfindingException(exceptions.SceneException):
     def __init__(self, message=''):
         super(PathfindingException, self).__init__(message)
-

--- a/scene_generator/interaction_goals_test.py
+++ b/scene_generator/interaction_goals_test.py
@@ -15,8 +15,8 @@ import scene_generator
 from geometry import POSITION_DIGITS
 from goals import *
 from interaction_goals import move_to_container, parse_path_section, get_navigation_actions, trim_actions_to_reach, \
-        PathfindingException, ObjectRule, PickupableObjectRule, TransferToObjectRule, FarOffObjectRule, \
-        DistractorObjectRule, ConfusorObjectRule, ObstructorObjectRule
+    PathfindingException, ObjectRule, PickupableObjectRule, TransferToObjectRule, FarOffObjectRule, \
+    DistractorObjectRule, ConfusorObjectRule, ObstructorObjectRule
 from util import MAX_SIZE_DIFFERENCE, MAX_TRIES, finalize_object_definition, instantiate_object
 
 
@@ -28,7 +28,8 @@ def test_move_to_container():
             obj = instantiate_object(obj_def, geometry.ORIGIN_LOCATION)
             tries = 0
             while tries < 100:
-                container = move_to_container(obj_def, obj, [], geometry.ORIGIN)
+                container = move_to_container(
+                    obj_def, obj, [], geometry.ORIGIN)
                 if container:
                     break
                 tries += 1
@@ -53,7 +54,8 @@ def test_parse_path_section():
             'amount': round(math.sqrt(2 * 0.1**2) / MAX_MOVE_DISTANCE, POSITION_DIGITS)
         }
     }]
-    actions, new_heading, performer = parse_path_section(path_section, 0, (0, 0), [])
+    actions, new_heading, performer = parse_path_section(
+        path_section, 0, (0, 0), [])
     assert actions == expected_actions
 
 
@@ -87,7 +89,8 @@ def test_parse_path_section_fractional():
             'amount': round(0.4 / MAX_MOVE_DISTANCE, POSITION_DIGITS)
         }
     }]
-    actions, new_heading, performer = parse_path_section(path_section, 0, (0, 0), goal_boundary)
+    actions, new_heading, performer = parse_path_section(
+        path_section, 0, (0, 0), goal_boundary)
     assert actions == expected_actions
 
 
@@ -146,7 +149,8 @@ def test_get_navigation_action():
             ]
         }]
     }
-    actions, performer, heading = get_navigation_actions(start, goal_object, [goal_object])
+    actions, performer, heading = get_navigation_actions(
+        start, goal_object, [goal_object])
     assert actions == expected_actions
 
 
@@ -216,7 +220,8 @@ def test_get_navigation_action_with_locationParent():
             }
         }]
     }
-    actions, performer, heading = get_navigation_actions(start, goal_object, [container_object, goal_object])
+    actions, performer, heading = get_navigation_actions(
+        start, goal_object, [container_object, goal_object])
     assert actions == expected_actions
 
 
@@ -304,23 +309,26 @@ def test_get_navigation_action_with_turning():
                     'y': 0,
                     'z': 2
                 },
-                
+
             ]
         }]
     }
     expected_actions = [{'action': 'RotateLook', 'params': {'rotation': 315.0, 'horizon': 0.0}},
-                        {'action': 'MoveAhead', 'params': { 'amount': 1 }},
-                        {'action': 'MoveAhead', 'params': { 'amount': 1 }},
+                        {'action': 'MoveAhead', 'params': {'amount': 1}},
+                        {'action': 'MoveAhead', 'params': {'amount': 1}},
                         {'action': 'MoveAhead', 'params': {'amount': 0.83}},
-                        {'action': 'RotateLook', 'params': {'rotation': 45.0, 'horizon': 0.0}},
-                        {'action': 'MoveAhead', 'params': { 'amount': 1 }},
-                        {'action': 'MoveAhead', 'params': { 'amount': 1 }},
-                        {'action': 'RotateLook', 'params': {'rotation': 45.0, 'horizon': 0.0}},
-                        {'action': 'MoveAhead', 'params': { 'amount': 1 }},
-                        {'action': 'MoveAhead', 'params': { 'amount': 1 }},
-                        {'action': 'MoveAhead', 'params': {'amount': round((.9*math.sqrt(2)-1)/MAX_MOVE_DISTANCE, POSITION_DIGITS)}}]
+                        {'action': 'RotateLook', 'params': {
+                            'rotation': 45.0, 'horizon': 0.0}},
+                        {'action': 'MoveAhead', 'params': {'amount': 1}},
+                        {'action': 'MoveAhead', 'params': {'amount': 1}},
+                        {'action': 'RotateLook', 'params': {
+                            'rotation': 45.0, 'horizon': 0.0}},
+                        {'action': 'MoveAhead', 'params': {'amount': 1}},
+                        {'action': 'MoveAhead', 'params': {'amount': 1}},
+                        {'action': 'MoveAhead', 'params': {'amount': round((.9 * math.sqrt(2) - 1) / MAX_MOVE_DISTANCE, POSITION_DIGITS)}}]
     all_objs = [goal_obj, obstacle_obj]
-    actions, performer, heading = get_navigation_actions(start, goal_obj, all_objs)
+    actions, performer, heading = get_navigation_actions(
+        start, goal_obj, all_objs)
     assert actions == expected_actions
 
 
@@ -349,7 +357,8 @@ def test_trim_actions_to_reach():
             'amount': 1
         }
     }]
-    actions, new_heading, performer = parse_path_section(path_section, 0, (0, 0), goal_boundary)
+    actions, new_heading, performer = parse_path_section(
+        path_section, 0, (0, 0), goal_boundary)
     target = {
         'shows': [{
             'position': {
@@ -359,7 +368,8 @@ def test_trim_actions_to_reach():
             }
         }]
     }
-    actions, performer = trim_actions_to_reach(actions, performer, new_heading, target)
+    actions, performer = trim_actions_to_reach(
+        actions, performer, new_heading, target)
     assert actions == expected_actions
 
 
@@ -373,7 +383,8 @@ def test_ObjectRule_choose_location():
     performer_start = geometry.ORIGIN_LOCATION
     rule = ObjectRule()
     definition = rule.choose_definition()
-    location, bounds_list = rule.choose_location(definition, performer_start, [])
+    location, bounds_list = rule.choose_location(
+        definition, performer_start, [])
     assert location
     assert len(bounds_list) == 1
 
@@ -397,24 +408,27 @@ def test_TransferToObjectRule_validate_location():
 
     target_rule = ObjectRule()
     target_definition = target_rule.choose_definition()
-    target_location, bounds_list = target_rule.choose_location(target_definition, performer_start, [])
+    target_location, bounds_list = target_rule.choose_location(
+        target_definition, performer_start, [])
     target = instantiate_object(target_definition, target_location)
     assert target
 
     rule = TransferToObjectRule()
     definition = rule.choose_definition()
-    location, bounds_list = rule.choose_location(definition, performer_start, bounds_list)
-    assert rule.validate_location(location, [target], performer_start) == (geometry.position_distance( \
-            target_location['position'], location['position']) >= geometry.MIN_OBJECTS_SEPARATION_DISTANCE)
+    location, bounds_list = rule.choose_location(
+        definition, performer_start, bounds_list)
+    assert rule.validate_location(location, [target], performer_start) == (geometry.position_distance(
+        target_location['position'], location['position']) >= geometry.MIN_OBJECTS_SEPARATION_DISTANCE)
 
 
 def test_FarOffObjectRule_validate_location():
     performer_start = geometry.ORIGIN_LOCATION
     rule = FarOffObjectRule()
     definition = rule.choose_definition()
-    location, bounds_list = rule.choose_location(definition, performer_start, [])
-    assert rule.validate_location(location, [], performer_start) == (geometry.position_distance( \
-            performer_start['position'], location['position']) >= geometry.MIN_OBJECTS_SEPARATION_DISTANCE)
+    location, bounds_list = rule.choose_location(
+        definition, performer_start, [])
+    assert rule.validate_location(location, [], performer_start) == (geometry.position_distance(
+        performer_start['position'], location['position']) >= geometry.MIN_OBJECTS_SEPARATION_DISTANCE)
 
 
 def test_DistractorObjectRule_choose_definition():
@@ -422,7 +436,8 @@ def test_DistractorObjectRule_choose_definition():
 
     target_rule = ObjectRule()
     target_definition = target_rule.choose_definition()
-    target_location, bounds_list = target_rule.choose_location(target_definition, performer_start, [])
+    target_location, bounds_list = target_rule.choose_location(
+        target_definition, performer_start, [])
     target = instantiate_object(target_definition, target_location)
     assert target
 
@@ -444,15 +459,16 @@ def test_ConfusorObjectRule_choose_definition():
     is_same_color = set(definition['color']) == set(target_definition['color'])
     is_same_shape = definition['shape'] == target_definition['shape']
     is_same_size = definition['size'] == target_definition['size'] and \
-            (definition['dimensions']['x'] >= target_definition['dimensions']['x'] - MAX_SIZE_DIFFERENCE) and \
-            (definition['dimensions']['x'] <= target_definition['dimensions']['x'] + MAX_SIZE_DIFFERENCE) and \
-            (definition['dimensions']['y'] >= target_definition['dimensions']['y'] - MAX_SIZE_DIFFERENCE) and \
-            (definition['dimensions']['y'] <= target_definition['dimensions']['y'] + MAX_SIZE_DIFFERENCE) and \
-            (definition['dimensions']['z'] >= target_definition['dimensions']['z'] - MAX_SIZE_DIFFERENCE) and \
-            (definition['dimensions']['z'] <= target_definition['dimensions']['z'] + MAX_SIZE_DIFFERENCE)
+        (definition['dimensions']['x'] >= target_definition['dimensions']['x'] - MAX_SIZE_DIFFERENCE) and \
+        (definition['dimensions']['x'] <= target_definition['dimensions']['x'] + MAX_SIZE_DIFFERENCE) and \
+        (definition['dimensions']['y'] >= target_definition['dimensions']['y'] - MAX_SIZE_DIFFERENCE) and \
+        (definition['dimensions']['y'] <= target_definition['dimensions']['y'] + MAX_SIZE_DIFFERENCE) and \
+        (definition['dimensions']['z'] >= target_definition['dimensions']['z'] - MAX_SIZE_DIFFERENCE) and \
+        (definition['dimensions']['z'] <=
+         target_definition['dimensions']['z'] + MAX_SIZE_DIFFERENCE)
     assert (is_same_size and is_same_shape and not is_same_color) or \
-            (is_same_size and is_same_color and not is_same_shape) or \
-            (is_same_shape and is_same_color and not is_same_size)
+        (is_same_size and is_same_color and not is_same_shape) or \
+        (is_same_shape and is_same_color and not is_same_size)
 
 
 def test_ObstructorObjectRule_choose_definition():
@@ -468,9 +484,13 @@ def test_ObstructorObjectRule_choose_definition():
     assert definition['obstruct'] == 'navigation'
 
     if definition['rotation']['y'] == 0:
-        assert (definition['dimensions']['x'] >= target_definition['dimensions']['x'] - MAX_SIZE_DIFFERENCE)
+        assert (
+            definition['dimensions']['x'] >= target_definition['dimensions']['x'] -
+            MAX_SIZE_DIFFERENCE)
     elif definition['rotation']['y'] == 90:
-        assert (definition['dimensions']['z'] >= target_definition['dimensions']['z'] - MAX_SIZE_DIFFERENCE)
+        assert (
+            definition['dimensions']['z'] >= target_definition['dimensions']['z'] -
+            MAX_SIZE_DIFFERENCE)
     else:
         assert False
 
@@ -486,12 +506,18 @@ def test_ObstructorObjectRule_choose_definition_obstruct_vision():
     definition = rule.choose_definition()
     assert definition
     assert definition['obstruct'] == 'vision'
-    assert (definition['dimensions']['y'] >= target_definition['dimensions']['y'] - MAX_SIZE_DIFFERENCE)
+    assert (
+        definition['dimensions']['y'] >= target_definition['dimensions']['y'] -
+        MAX_SIZE_DIFFERENCE)
 
     if definition['rotation']['y'] == 0:
-        assert (definition['dimensions']['x'] >= target_definition['dimensions']['x'] - MAX_SIZE_DIFFERENCE)
+        assert (
+            definition['dimensions']['x'] >= target_definition['dimensions']['x'] -
+            MAX_SIZE_DIFFERENCE)
     elif definition['rotation']['y'] == 90:
-        assert (definition['dimensions']['z'] >= target_definition['dimensions']['z'] - MAX_SIZE_DIFFERENCE)
+        assert (
+            definition['dimensions']['z'] >= target_definition['dimensions']['z'] -
+            MAX_SIZE_DIFFERENCE)
     else:
         assert False
 
@@ -510,7 +536,8 @@ def test_RetrievalGoal_get_config_arg_invalid():
 
 def test_RetrievalGoal_update_body():
     goal = RetrievalGoal()
-    body = goal.update_body({'wallMaterial': 'test_material', 'wallColors': []}, False)
+    body = goal.update_body(
+        {'wallMaterial': 'test_material', 'wallColors': []}, False)
     assert body['performerStart'] == goal.get_performer_start()
     assert body['goal']['category'] == 'retrieval'
     assert body['goal']['metadata']['target']
@@ -522,7 +549,8 @@ def test_RetrievalGoal_update_body():
     target = body['objects'][0]
     assert target['pickupable']
     assert target['id'] == body['goal']['metadata']['target']['id']
-    assert body['goal']['description'] == ('Find and pick up the ' + target['goalString'] + '.')
+    assert body['goal']['description'] == (
+        'Find and pick up the ' + target['goalString'] + '.')
 
 
 def test_RetrievalGoal_get_config():
@@ -534,10 +562,15 @@ def test_RetrievalGoal_get_config():
         'pickupable': True,
         'type': 'sphere'
     }
-    goal = goal_obj._get_config({ 'target': [obj] })
+    goal = goal_obj._get_config({'target': [obj]})
     assert goal['category'] == 'retrieval'
     assert goal['description'] == 'Find and pick up the blue rubber ball.'
-    assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball'}
+    assert set(
+        goal['info_list']) == {
+        'target blue',
+        'target rubber',
+        'target ball',
+        'target blue rubber ball'}
     target = goal['metadata']['target']
     assert target['id'] == obj['id']
     assert target['info'] == ['blue', 'rubber', 'ball']
@@ -551,7 +584,8 @@ def test_TraversalGoal_get_config_arg_count():
 
 def test_TraversalGoal_update_body():
     goal = TraversalGoal()
-    body = goal.update_body({'wallMaterial': 'test_material', 'wallColors': []}, False)
+    body = goal.update_body(
+        {'wallMaterial': 'test_material', 'wallColors': []}, False)
     assert body['performerStart'] == goal.get_performer_start()
     assert body['goal']['category'] == 'traversal'
     assert body['goal']['metadata']['target']
@@ -562,7 +596,8 @@ def test_TraversalGoal_update_body():
 
     target = body['objects'][0]
     assert target['id'] == body['goal']['metadata']['target']['id']
-    assert body['goal']['description'] == ('Find the ' + target['goalString'] + ' and move near it.')
+    assert body['goal']['description'] == (
+        'Find the ' + target['goalString'] + ' and move near it.')
 
 
 def test_TraversalGoal_get_config():
@@ -573,10 +608,15 @@ def test_TraversalGoal_get_config():
         'goalString': 'blue rubber ball',
         'type': 'sphere'
     }
-    goal = goal_obj._get_config({ 'target': [obj] })
+    goal = goal_obj._get_config({'target': [obj]})
     assert goal['category'] == 'traversal'
     assert goal['description'] == 'Find the blue rubber ball and move near it.'
-    assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball'}
+    assert set(
+        goal['info_list']) == {
+        'target blue',
+        'target rubber',
+        'target ball',
+        'target blue rubber ball'}
     target = goal['metadata']['target']
     assert target['id'] == obj['id']
     assert target['info'] == ['blue', 'rubber', 'ball']
@@ -584,7 +624,8 @@ def test_TraversalGoal_get_config():
 
 def test_TransferralGoal_update_body():
     goal = TransferralGoal()
-    body = goal.update_body({'wallMaterial': 'test_material', 'wallColors': []}, False)
+    body = goal.update_body(
+        {'wallMaterial': 'test_material', 'wallColors': []}, False)
     assert body['performerStart'] == goal.get_performer_start()
     assert body['goal']['category'] == 'transferral'
     assert body['goal']['metadata']['target_1']
@@ -600,8 +641,8 @@ def test_TransferralGoal_update_body():
     assert target_2['stackTarget']
     assert target_1['id'] == body['goal']['metadata']['target_1']['id']
     assert target_2['id'] == body['goal']['metadata']['target_2']['id']
-    assert body['goal']['description'] == ('Find and pick up the ' + target_1['goalString'] + ' and move it ' + \
-            body['goal']['metadata']['relationship'][1] + ' the ' + target_2['goalString'] + '.')
+    assert body['goal']['description'] == ('Find and pick up the ' + target_1['goalString'] + ' and move it ' +
+                                           body['goal']['metadata']['relationship'][1] + ' the ' + target_2['goalString'] + '.')
 
 
 def test_TransferralGoal_get_config_arg_count():
@@ -613,13 +654,15 @@ def test_TransferralGoal_get_config_arg_count():
 def test_TransferralGoal_get_config_arg_invalid_1():
     goal_obj = TransferralGoal()
     with pytest.raises(exceptions.SceneException):
-        goal_obj._get_config({'target': [{'pickupable': False}, {'stackTarget': True}]})
+        goal_obj._get_config(
+            {'target': [{'pickupable': False}, {'stackTarget': True}]})
 
 
 def test_TransferralGoal_get_config_arg_invalid_2():
     goal_obj = TransferralGoal()
     with pytest.raises(exceptions.SceneException):
-        goal_obj._get_config({'target': [{'pickupable': True}, {'stackTarget': False}]})
+        goal_obj._get_config(
+            {'target': [{'pickupable': True}, {'stackTarget': False}]})
 
 
 def test_TransferralGoal_get_config():
@@ -641,10 +684,10 @@ def test_TransferralGoal_get_config():
         'type': 'changing_table',
         'stackTarget': True
     }
-    goal = goal_obj._get_config({ 'target': [pickupable_obj, other_obj] })
+    goal = goal_obj._get_config({'target': [pickupable_obj, other_obj]})
 
-    assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball', \
-            'target yellow', 'target wood', 'target changing table', 'target yellow wood changing table'}
+    assert set(goal['info_list']) == {'target blue', 'target rubber', 'target ball', 'target blue rubber ball',
+                                      'target yellow', 'target wood', 'target changing table', 'target yellow wood changing table'}
 
     target1 = goal['metadata']['target_1']
     assert target1['id'] == pickupable_id
@@ -655,11 +698,12 @@ def test_TransferralGoal_get_config():
 
     relationship = goal['metadata']['relationship']
     relationship_type = relationship[1]
-    assert relationship_type in [g.value for g in TransferralGoal.RelationshipType]
+    assert relationship_type in [
+        g.value for g in TransferralGoal.RelationshipType]
 
     assert goal['category'] == 'transferral'
     assert goal['description'] == 'Find and pick up the blue rubber ball and move it ' + \
-            relationship_type + ' the yellow wood changing table.'
+        relationship_type + ' the yellow wood changing table.'
 
 
 def test_TransferralGoal_ensure_pickup_action():
@@ -675,7 +719,8 @@ def test_TransferralGoal_ensure_pickup_action():
             break
 
     # should have a PickupObject action
-    assert any((action['action'] == 'PickupObject' for action in body['answer']['actions']))
+    assert any(
+        (action['action'] == 'PickupObject' for action in body['answer']['actions']))
     # last action one should be PutObject
     assert body['answer']['actions'][-1]['action'] == 'PutObject'
 
@@ -694,10 +739,13 @@ def test_TransferralGoal_navigate_near_objects():
 
     pickupable_id = body['goal']['metadata']['target_1']['id']
     container_id = body['goal']['metadata']['target_2']['id']
-    pickupable_obj = next((obj for obj in body['objects'] if obj['id'] == pickupable_id))
-    container_obj = next((obj for obj in body['objects'] if obj['id'] == container_id))
+    pickupable_obj = next(
+        (obj for obj in body['objects'] if obj['id'] == pickupable_id))
+    container_obj = next(
+        (obj for obj in body['objects'] if obj['id'] == container_id))
     if 'locationParent' in pickupable_obj:
-        parent = next((obj for obj in body['objects'] if obj['id'] == pickupable_obj['locationParent']))
+        parent = next(
+            (obj for obj in body['objects'] if obj['id'] == pickupable_obj['locationParent']))
         pickupable_position = parent['shows'][0]['position']
         pass
     else:
@@ -712,7 +760,8 @@ def test_TransferralGoal_navigate_near_objects():
     for action in body['answer']['actions']:
         if action['action'] == 'PickupObject':
             # should be near pickupable object
-            # TODO I think this needs to account for the dimensions of the pickupable object too?
+            # TODO I think this needs to account for the dimensions of the
+            # pickupable object too?
             pickupable_distance = math.sqrt((x - pickupable_position['x'])**2 +
                                             (z - pickupable_position['z'])**2)
             assert pickupable_distance <= MAX_REACH_DISTANCE
@@ -834,4 +883,3 @@ def test_TransferralGoal_targets_not_close_to_each_other():
     distance = geometry.position_distance(target1['shows'][0]['position'],
                                           target2['shows'][0]['position'])
     assert distance >= geometry.MIN_OBJECTS_SEPARATION_DISTANCE
-

--- a/scene_generator/intphys_goals.py
+++ b/scene_generator/intphys_goals.py
@@ -31,7 +31,8 @@ class IntPhysGoal(Goal, ABC):
     IMPLAUSIBLE = 'implausible'
 
     # The 3.55 or 4.2 is the position at which the object will leave the camera's viewport, and is dependent on the
-    # object's Z position (either 1.6 or 2.7). The * 1.2 is to account for the camera's perspective.
+    # object's Z position (either 1.6 or 2.7). The * 1.2 is to account for the
+    # camera's perspective.
     VIEWPORT_LIMIT_NEAR = 3.55
     VIEWPORT_LIMIT_FAR = 4.2
     VIEWPORT_PERSPECTIVE_FACTOR = 1.2
@@ -108,7 +109,8 @@ class IntPhysGoal(Goal, ABC):
             }
         return self._performer_start
 
-    def update_body(self, body: Dict[str, Any], find_path: bool) -> Dict[str, Any]:
+    def update_body(self, body: Dict[str, Any],
+                    find_path: bool) -> Dict[str, Any]:
         body = super(IntPhysGoal, self).update_body(body, find_path)
         for obj in self._tag_to_objects['target']:
             obj['torques'] = [IntPhysGoal.DEFAULT_TORQUE]
@@ -123,7 +125,8 @@ class IntPhysGoal(Goal, ABC):
             List[Dict[str, Any]]:
         return []
 
-    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _get_subclass_config(
+            self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         goal = copy.deepcopy(self.TEMPLATE)
         goal['last_step'] = self._last_step
         goal['action_list'] = [['Pass']] * goal['last_step']
@@ -134,11 +137,13 @@ class IntPhysGoal(Goal, ABC):
                 goal['type_list'].append(tags.INTPHYS_FALL_DOWN)
         return goal
 
-    def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+    def compute_objects(self, wall_material_name: str,
+                        wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
         self._object_creator = random.choice([IntPhysGoal._get_objects_and_occluders_moving_across,
                                               IntPhysGoal._get_objects_falling_down])
         self._last_step = IntPhysGoal.LAST_STEP_FALL_DOWN
-        moving_objs, occluder_objs = self._object_creator(self, wall_material_name)
+        moving_objs, occluder_objs = self._object_creator(
+            self, wall_material_name)
         background_objs = self._compute_scenery()
 
         return {
@@ -155,7 +160,8 @@ class IntPhysGoal(Goal, ABC):
         MAX_Z = 4.95
 
         def random_x():
-            return util.random_real(MIN_VISIBLE_X, MAX_VISIBLE_X, util.MIN_RANDOM_INTERVAL)
+            return util.random_real(
+                MIN_VISIBLE_X, MAX_VISIBLE_X, util.MIN_RANDOM_INTERVAL)
 
         def random_z():
             # Choose values so the scenery is placed between the
@@ -163,14 +169,15 @@ class IntPhysGoal(Goal, ABC):
             return util.random_real(MIN_Z, MAX_Z, util.MIN_RANDOM_INTERVAL)
 
         scenery_count = random.choices((0, 1, 2, 3, 4, 5),
-                                             (50, 10, 10, 10, 10, 10))[0]
+                                       (50, 10, 10, 10, 10, 10))[0]
         scenery_list = []
         scenery_rects = []
         scenery_defs = objects.get('MOVEABLE') + objects.get('IMMOBILE')
         for _ in range(scenery_count):
             location = None
             while location is None:
-                scenery_def = finalize_object_definition(random.choice(scenery_defs))
+                scenery_def = finalize_object_definition(
+                    random.choice(scenery_defs))
                 location = geometry.calc_obj_pos(geometry.ORIGIN, scenery_rects, scenery_def,
                                                  random_x, random_z)
                 if location is not None:
@@ -195,15 +202,20 @@ class IntPhysGoal(Goal, ABC):
         """Return how many occluders must be paired with a target object."""
         return 1
 
-    def _get_paired_occluder(self, paired_obj, occluder_list, non_room_wall_materials, pole_materials):
+    def _get_paired_occluder(
+            self, paired_obj, occluder_list, non_room_wall_materials, pole_materials):
         occluder_fits = False
         for _ in range(util.MAX_TRIES):
             x_diagonal = math.sqrt(2) * paired_obj['shows'][0]['scale']['x']
             min_scale = min(max(x_diagonal,
                                 IntPhysGoal.MIN_OCCLUDER_SCALE),
                             IntPhysGoal.MAX_OCCLUDER_SCALE)
-            # object could be a cube on its corner, so use the diagonal distance
-            x_scale = util.random_real(min_scale, IntPhysGoal.MAX_OCCLUDER_SCALE, util.MIN_RANDOM_INTERVAL)
+            # object could be a cube on its corner, so use the diagonal
+            # distance
+            x_scale = util.random_real(
+                min_scale,
+                IntPhysGoal.MAX_OCCLUDER_SCALE,
+                util.MIN_RANDOM_INTERVAL)
             position_by_step = paired_obj['intphysOption']['position_by_step']
             paired_z = paired_obj['shows'][0]['position']['z']
             min_paired_x_position = -3 + x_scale / 2
@@ -218,23 +230,27 @@ class IntPhysGoal(Goal, ABC):
             elif paired_z == IntPhysGoal.OBJECT_FAR_Z:
                 occluder_x = paired_x * IntPhysGoal.FAR_X_PERSPECTIVE_FACTOR
             else:
-                logging.warning(f'Unsupported z for occluder target "{paired_obj["id"]}": {paired_z}')
+                logging.warning(
+                    f'Unsupported z for occluder target "{paired_obj["id"]}": {paired_z}')
                 occluder_x = paired_x
             found_collision = False
             for other_occluder in occluder_list:
-                if geometry.occluders_too_close(other_occluder, occluder_x, x_scale):
+                if geometry.occluders_too_close(
+                        other_occluder, occluder_x, x_scale):
                     found_collision = True
                     break
             if not found_collision:
                 # occluder_indices are needed by quartets
-                occluder_indices = paired_obj['intphysOption'].get('occluder_indices', [])
+                occluder_indices = paired_obj['intphysOption'].get(
+                    'occluder_indices', [])
                 occluder_indices.append(position_index)
                 paired_obj['intphysOption']['occluder_indices'] = occluder_indices
                 occluder_fits = True
                 break
         if occluder_fits:
             occluder_objs = objects.create_occluder(random.choice(non_room_wall_materials),
-                                                    random.choice(pole_materials),
+                                                    random.choice(
+                                                        pole_materials),
                                                     occluder_x, x_scale)
         else:
             occluder_objs = None
@@ -263,8 +279,14 @@ class IntPhysGoal(Goal, ABC):
                 occluder_list.extend(occluder_objs)
             else:
                 logging.warning('could not fit required occluder')
-                raise exceptions.SceneException(f'Could not add minimum number of occluders ({num_paired_occluders})')
-        self._add_occluders(occluder_list, num_occluders - num_paired_occluders, non_room_wall_materials, False)
+                raise exceptions.SceneException(
+                    f'Could not add minimum number of occluders ({num_paired_occluders})')
+        self._add_occluders(
+            occluder_list,
+            num_occluders -
+            num_paired_occluders,
+            non_room_wall_materials,
+            False)
         return occluder_list
 
     def _add_occluders(self, occluder_list: List[Dict[str, Any]],
@@ -274,15 +296,22 @@ class IntPhysGoal(Goal, ABC):
         for _ in range(num_to_add):
             occluder_fits = False
             for try_num in range(util.MAX_TRIES):
-                # try random position and scale until we find one that fits (or try too many times)
+                # try random position and scale until we find one that fits (or
+                # try too many times)
                 min_scale = IntPhysGoal.MIN_OCCLUDER_SCALE
-                x_scale = util.random_real(min_scale, IntPhysGoal.MAX_OCCLUDER_SCALE, util.MIN_RANDOM_INTERVAL)
+                x_scale = util.random_real(
+                    min_scale,
+                    IntPhysGoal.MAX_OCCLUDER_SCALE,
+                    util.MIN_RANDOM_INTERVAL)
                 limit = 3.0 - x_scale / 2.0
-                limit = int(limit / util.MIN_RANDOM_INTERVAL) * util.MIN_RANDOM_INTERVAL
-                occluder_x = util.random_real(-limit, limit, util.MIN_RANDOM_INTERVAL)
+                limit = int(limit / util.MIN_RANDOM_INTERVAL) * \
+                    util.MIN_RANDOM_INTERVAL
+                occluder_x = util.random_real(-limit,
+                                              limit, util.MIN_RANDOM_INTERVAL)
                 found_collision = False
                 for other_occluder in occluder_list:
-                    if geometry.occluders_too_close(other_occluder, occluder_x, x_scale):
+                    if geometry.occluders_too_close(
+                            other_occluder, occluder_x, x_scale):
                         found_collision = True
                         break
                 if not found_collision:
@@ -290,18 +319,20 @@ class IntPhysGoal(Goal, ABC):
                     break
             if occluder_fits:
                 occluder_objs = objects.create_occluder(random.choice(non_room_wall_materials),
-                                                        random.choice(materials.METAL_MATERIALS),
+                                                        random.choice(
+                                                            materials.METAL_MATERIALS),
                                                         occluder_x, x_scale, sideways)
                 occluder_list.extend(occluder_objs)
             else:
                 logging.debug(f'could not fit occluder at x={occluder_x}')
 
     def _get_objects_and_occluders_moving_across(self, room_wall_material_name: str) \
-        -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+            -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
         """Get objects to move across the scene and occluders for them. Returns (objects, occluders) pair."""
         self._last_step = IntPhysGoal.LAST_STEP_MOVE_ACROSS
         # Subtract 5 for end occluder movement and rotation
-        new_objects = self._get_objects_moving_across(room_wall_material_name, self._last_step - 5, self._object_defs)
+        new_objects = self._get_objects_moving_across(
+            room_wall_material_name, self._last_step - 5, self._object_defs)
         occluders = self._get_occluders(new_objects, room_wall_material_name)
         return new_objects, occluders
 
@@ -311,7 +342,8 @@ class IntPhysGoal(Goal, ABC):
     def _get_objects_moving_across(self, room_wall_material_name: str, last_action_end_step: int,
                                    valid_defs: List[Dict[str, Any]],
                                    earliest_action_start_step: int = EARLIEST_ACTION_START_STEP,
-                                   valid_positions: Iterable = frozenset(Position),
+                                   valid_positions: Iterable = frozenset(
+                                       Position),
                                    positions: Optional[List[Position]] = None) -> List[Dict[str, Any]]:
         """Get objects to move across the scene. Returns objects."""
         num_objects = self._get_num_objects_moving_across()
@@ -327,7 +359,9 @@ class IntPhysGoal(Goal, ABC):
             IntPhysGoal.Position.LEFT_FIRST_NEAR: (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR),
             IntPhysGoal.Position.LEFT_LAST_NEAR: (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR),
             IntPhysGoal.Position.LEFT_FIRST_FAR: (IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR),
-            IntPhysGoal.Position.LEFT_LAST_FAR: (IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR)
+            IntPhysGoal.Position.LEFT_LAST_FAR: (
+                IntPhysGoal.Position.RIGHT_FIRST_FAR,
+                IntPhysGoal.Position.RIGHT_LAST_FAR)
         }
         # Object in key position must have acceleration <=
         # acceleration for object in value position (e.g., object in
@@ -354,18 +388,22 @@ class IntPhysGoal(Goal, ABC):
                 if location in acceleration_ordering and \
                    acceleration_ordering[location] in location_assignments:
                     # ensure the objects won't collide
-                    acceleration = abs(intphys_option['force']['x'] / obj_def['mass'])
+                    acceleration = abs(
+                        intphys_option['force']['x'] / obj_def['mass'])
                     other_obj = location_assignments[acceleration_ordering[location]]
-                    other_acceleration = abs(other_obj['intphysOption']['force']['x'] / other_obj['mass'])
+                    other_acceleration = abs(
+                        other_obj['intphysOption']['force']['x'] / other_obj['mass'])
 
                     collision = acceleration > other_acceleration
                     if not collision:
                         break
                     elif len(remaining_intphys_options) == 1:
-                        # last chance, so just swap the items to make their relative acceleration "ok"
+                        # last chance, so just swap the items to make their
+                        # relative acceleration "ok"
                         location_assignments[location] = other_obj
                         location = acceleration_ordering[location]
-                        location_assignments[location] = None # to be assigned later
+                        # to be assigned later
+                        location_assignments[location] = None
                         break
                 else:
                     break
@@ -383,28 +421,40 @@ class IntPhysGoal(Goal, ABC):
                 # needed by GravityQuartet for steep ramps
                 intphys_option['saved_options'] = obj_def['saved_intphys_options']
             location_assignments[location] = obj
-            position_by_step = copy.deepcopy(intphys_option['position_by_step'])
+            position_by_step = copy.deepcopy(
+                intphys_option['position_by_step'])
             object_position_x = IntPhysGoal.OBJECT_POSITIONS[location][0]
             # adjust position_by_step and remove outliers
             new_positions = []
             for position in position_by_step:
-                if location in (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR, IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR):
+                if location in (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR,
+                                IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR):
                     position = object_position_x - position
                 else:
                     position = object_position_x + position
                 new_positions.append(position)
-            if location in (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR, IntPhysGoal.Position.LEFT_FIRST_NEAR, IntPhysGoal.Position.LEFT_LAST_NEAR):
-                max_x = IntPhysGoal.VIEWPORT_LIMIT_NEAR + obj_def['scale']['x'] / 2.0 * IntPhysGoal.VIEWPORT_PERSPECTIVE_FACTOR
+            if location in (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR,
+                            IntPhysGoal.Position.LEFT_FIRST_NEAR, IntPhysGoal.Position.LEFT_LAST_NEAR):
+                max_x = IntPhysGoal.VIEWPORT_LIMIT_NEAR + \
+                    obj_def['scale']['x'] / 2.0 * \
+                    IntPhysGoal.VIEWPORT_PERSPECTIVE_FACTOR
             else:
-                max_x = IntPhysGoal.VIEWPORT_LIMIT_FAR + obj_def['scale']['x'] / 2.0 * IntPhysGoal.VIEWPORT_PERSPECTIVE_FACTOR
-            filtered_position_by_step = [position for position in new_positions if (abs(position) <= max_x)]
+                max_x = IntPhysGoal.VIEWPORT_LIMIT_FAR + \
+                    obj_def['scale']['x'] / 2.0 * \
+                    IntPhysGoal.VIEWPORT_PERSPECTIVE_FACTOR
+            filtered_position_by_step = [
+                position for position in new_positions if (
+                    abs(position) <= max_x)]
             intphys_option['position_by_step'] = filtered_position_by_step
 
             # set shows.stepBegin
             min_step_begin = earliest_action_start_step
-            if location in acceleration_ordering and acceleration_ordering[location] in location_assignments:
-                min_step_begin = location_assignments[acceleration_ordering[location]]['shows'][0]['stepBegin']
-            max_step_begin = last_action_end_step - len(filtered_position_by_step)
+            if location in acceleration_ordering and acceleration_ordering[
+                    location] in location_assignments:
+                min_step_begin = location_assignments[acceleration_ordering[location]
+                                                      ]['shows'][0]['stepBegin']
+            max_step_begin = last_action_end_step - \
+                len(filtered_position_by_step)
             if min_step_begin >= max_step_begin:
                 stepBegin = min_step_begin
             else:
@@ -415,7 +465,8 @@ class IntPhysGoal(Goal, ABC):
                 'stepEnd': last_action_end_step,
                 'vector': intphys_option['force']
             }]
-            if location in (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR, IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR):
+            if location in (IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR,
+                            IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR):
                 obj['forces'][0]['vector']['x'] *= -1
             intphys_option['positionY'] = obj_def['positionY']
             obj['intphysOption'] = intphys_option
@@ -429,15 +480,17 @@ class IntPhysGoal(Goal, ABC):
         return 2 if num_objects == 2 else random.choice((1, 2))
 
     def _get_objects_falling_down(self, room_wall_material_name: str) \
-        -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+            -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
         MIN_OCCLUDER_SEPARATION = 0.5
         # Choose between traditional and novel objects.
-        # Only use novel objects in "falling down" scenes for now, since we don't have their intphys_options yet.
-        self._object_defs = objects.get('INTPHYS') + objects.get('INTPHYS_NOVEL')
+        # Only use novel objects in "falling down" scenes for now, since we
+        # don't have their intphys_options yet.
+        self._object_defs = objects.get(
+            'INTPHYS') + objects.get('INTPHYS_NOVEL')
 
         # min scale for each occluder / 2, plus 0.5 separation
         # divided by the smaller scale factor for distance from viewpoint
-        min_obj_distance = (IntPhysGoal.MIN_OCCLUDER_SCALE/2 + IntPhysGoal.MIN_OCCLUDER_SCALE/2 +
+        min_obj_distance = (IntPhysGoal.MIN_OCCLUDER_SCALE / 2 + IntPhysGoal.MIN_OCCLUDER_SCALE / 2 +
                             MIN_OCCLUDER_SEPARATION) / IntPhysGoal.FAR_X_PERSPECTIVE_FACTOR
         num_objects = random.choice((1, 2))
         object_list = []
@@ -451,10 +504,12 @@ class IntPhysGoal(Goal, ABC):
                 # Choose x so the occluder (for this object) is fully
                 # in the camera's viewport and with a gap so we can
                 # see when an object enters/leaves the scene.
-                x_position = util.random_real(-2.5, 2.5, util.MIN_RANDOM_INTERVAL)
+                x_position = util.random_real(-2.5,
+                                              2.5, util.MIN_RANDOM_INTERVAL)
                 too_close = False
                 for obj in object_list:
-                    distance = abs(obj['shows'][0]['position']['x'] - x_position)
+                    distance = abs(
+                        obj['shows'][0]['position']['x'] - x_position)
                     too_close = distance < min_obj_distance
                     if too_close:
                         break
@@ -462,11 +517,12 @@ class IntPhysGoal(Goal, ABC):
                     found_space = True
                     break
             if not found_space:
-                raise exceptions.SceneException(f'Could not place {i+1} objects to fall down')
+                raise exceptions.SceneException(
+                    f'Could not place {i+1} objects to fall down')
             location = {
                 'position': {
                     'x': x_position,
-                    'y': 3.8, # ensure the object starts above the camera viewport
+                    'y': 3.8,  # ensure the object starts above the camera viewport
                     'z': random.choice((IntPhysGoal.OBJECT_NEAR_Z, IntPhysGoal.OBJECT_FAR_Z))
                 }
             }
@@ -480,13 +536,15 @@ class IntPhysGoal(Goal, ABC):
             object_list.append(obj)
         # place required occluders, then (maybe) some random ones
         num_occluders = self._get_num_occluders_falling_down(num_objects)
-        logging.debug(f'num_objects = {num_objects}\tnum_occluders = {num_occluders}')
+        logging.debug(
+            f'num_objects = {num_objects}\tnum_occluders = {num_occluders}')
         occluders = []
         non_room_wall_materials = [m for m in materials.CEILING_AND_WALL_MATERIALS
                                    if m[0] != room_wall_material_name]
         for i in range(num_objects):
             paired_obj = object_list[i]
-            min_scale = min(max(paired_obj['shows'][0]['scale']['x'], IntPhysGoal.MIN_OCCLUDER_SCALE), 1)
+            min_scale = min(
+                max(paired_obj['shows'][0]['scale']['x'], IntPhysGoal.MIN_OCCLUDER_SCALE), 1)
             x_position = paired_obj['shows'][0]['position']['x']
             paired_z = paired_obj['shows'][0]['position']['z']
             factor = IntPhysGoal.NEAR_X_PERSPECTIVE_FACTOR if paired_z == IntPhysGoal.OBJECT_NEAR_Z \
@@ -496,26 +554,38 @@ class IntPhysGoal(Goal, ABC):
             # others.
             max_scale = IntPhysGoal.MAX_OCCLUDER_SCALE
             for occluder in occluders:
-                distance = abs(occluder['shows'][0]['position']['x'] - x_position)
-                scale = 2 * (distance - occluder['shows'][0]['scale']['x'] / 2.0 - MIN_OCCLUDER_SEPARATION)
+                distance = abs(
+                    occluder['shows'][0]['position']['x'] -
+                    x_position)
+                scale = 2 * \
+                    (distance - occluder['shows'][0]['scale']
+                     ['x'] / 2.0 - MIN_OCCLUDER_SEPARATION)
                 if scale < 0:
-                    raise exceptions.SceneException(f'Placed objects too close together after all ({distance})')
+                    raise exceptions.SceneException(
+                        f'Placed objects too close together after all ({distance})')
                 if scale < max_scale:
                     max_scale = scale
             if max_scale <= min_scale:
                 x_scale = min_scale
             else:
-                x_scale = util.random_real(min_scale, max_scale, util.MIN_RANDOM_INTERVAL)
+                x_scale = util.random_real(
+                    min_scale, max_scale, util.MIN_RANDOM_INTERVAL)
             adjusted_x = x_position * factor
             occluder_pair = objects.create_occluder(random.choice(non_room_wall_materials),
-                                                    random.choice(materials.METAL_MATERIALS),
+                                                    random.choice(
+                                                        materials.METAL_MATERIALS),
                                                     adjusted_x, x_scale, True)
             # occluded_id needed by SpatioTemporalContinuityQuartet
             if 'intphysOption' not in occluder_pair[0]:
                 occluder_pair[0]['intphysOption'] = {}
             occluder_pair[0]['intphysOption']['occluded_id'] = paired_obj['id']
             occluders.extend(occluder_pair)
-        self._add_occluders(occluders, num_occluders - num_objects, non_room_wall_materials, True)
+        self._add_occluders(
+            occluders,
+            num_occluders -
+            num_objects,
+            non_room_wall_materials,
+            True)
 
         return object_list, occluders
 
@@ -541,7 +611,8 @@ class GravityGoal(IntPhysGoal):
         }
     }
 
-    def __init__(self, ramp_type: Optional[ramps.Ramp] = None, roll_down: Optional[bool] = None, use_fastest: bool = False):
+    def __init__(self, ramp_type: Optional[ramps.Ramp] = None,
+                 roll_down: Optional[bool] = None, use_fastest: bool = False):
         """Caller can specify ramp type and whether the objects roll down or
         up the ramp, if desired. If not specified, a random choice
         will be made. In the case of steep ramps (i.e., with 90 degree
@@ -555,21 +626,27 @@ class GravityGoal(IntPhysGoal):
 
     def is_ramp_steep(self) -> bool:
         if self._ramp_type is None:
-            raise ValueError('cannot get ramp type before compute_objects is called')
-        return self._ramp_type in (ramps.Ramp.RAMP_90, ramps.Ramp.RAMP_30_90, ramps.Ramp.RAMP_45_90)
+            raise ValueError(
+                'cannot get ramp type before compute_objects is called')
+        return self._ramp_type in (
+            ramps.Ramp.RAMP_90, ramps.Ramp.RAMP_30_90, ramps.Ramp.RAMP_45_90)
 
     def get_ramp_type(self) -> ramps.Ramp:
         if self._ramp_type is None:
-            raise ValueError('cannot get ramp type before compute_objects is called')
+            raise ValueError(
+                'cannot get ramp type before compute_objects is called')
         return self._ramp_type
 
     def is_left_to_right(self) -> bool:
         if self._left_to_right is None:
-            raise ValueError('cannot get left-to-right-ness before compute_objects is called')
+            raise ValueError(
+                'cannot get left-to-right-ness before compute_objects is called')
         return self._left_to_right
 
-    def compute_objects(self, wall_material_name: str, wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
-        ramp_type, left_to_right, ramp_objs, moving_objs = self._get_ramp_and_objects(wall_material_name)
+    def compute_objects(self, wall_material_name: str,
+                        wall_colors: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+        ramp_type, left_to_right, ramp_objs, moving_objs = self._get_ramp_and_objects(
+            wall_material_name)
         self._ramp_type = ramp_type
         self._left_to_right = left_to_right
         background_objs = self._compute_scenery()
@@ -581,16 +658,18 @@ class GravityGoal(IntPhysGoal):
             'ramp': ramp_objs
         }
 
-    def _create_random_ramp(self) -> Tuple[ramps.Ramp, bool, float, List[Dict[str, Any]]]:
+    def _create_random_ramp(
+            self) -> Tuple[ramps.Ramp, bool, float, List[Dict[str, Any]]]:
         material_name = random.choice(materials.OCCLUDER_MATERIALS)[0]
         x_position_percent = random.random()
         left_to_right = random.choice((True, False))
-        ramp_type, x_term, ramp_objs = ramps.create_ramp(material_name, x_position_percent, left_to_right, self._ramp_type)
+        ramp_type, x_term, ramp_objs = ramps.create_ramp(
+            material_name, x_position_percent, left_to_right, self._ramp_type)
         self._ramp_type = ramp_type
         return ramp_type, left_to_right, x_term, ramp_objs
 
     def _get_ramp_and_objects(self, room_wall_material_name: str) -> \
-        Tuple[ramps.Ramp, bool, List[Dict[str, Any]], List[Dict[str, Any]]]:
+            Tuple[ramps.Ramp, bool, List[Dict[str, Any]], List[Dict[str, Any]]]:
 
         ramp_type, left_to_right, x_term, ramp_objs = self._create_random_ramp()
         # only want intphys_options where y == 0
@@ -599,12 +678,16 @@ class GravityGoal(IntPhysGoal):
             # Want to avoid cubes in the gravity tests at this time MCS-269
             if obj_def['type'] != 'cube':
                 new_od = obj_def.copy()
-                valid_intphys = [intphys for intphys in obj_def['intphysOptions'] if intphys['y'] == 0]
+                valid_intphys = [
+                    intphys for intphys in obj_def['intphysOptions'] if intphys['y'] == 0]
                 if len(valid_intphys) != 0:
-                    new_od['saved_intphys_options'] = copy.deepcopy(valid_intphys)
+                    new_od['saved_intphys_options'] = copy.deepcopy(
+                        valid_intphys)
                     if self.is_ramp_steep() and self._use_fastest:
-                        # use the intphys with the highest force.x for each object
-                        sorted_intphys = sorted(valid_intphys, key=lambda intphys: intphys['force']['x'])
+                        # use the intphys with the highest force.x for each
+                        # object
+                        sorted_intphys = sorted(
+                            valid_intphys, key=lambda intphys: intphys['force']['x'])
                         valid_intphys = [sorted_intphys[-1]]
                     new_od['intphysOptions'] = valid_intphys
                     valid_defs.append(new_od)
@@ -612,25 +695,26 @@ class GravityGoal(IntPhysGoal):
             # Don't put objects in places where they'd have to roll up
             # 90 degree (i.e., vertical) ramps.
             if left_to_right:
-                valid_positions = { IntPhysGoal.Position.LEFT_FIRST_NEAR, IntPhysGoal.Position.LEFT_LAST_NEAR,
-                                    IntPhysGoal.Position.LEFT_FIRST_FAR, IntPhysGoal.Position.LEFT_LAST_FAR }
+                valid_positions = {IntPhysGoal.Position.LEFT_FIRST_NEAR, IntPhysGoal.Position.LEFT_LAST_NEAR,
+                                   IntPhysGoal.Position.LEFT_FIRST_FAR, IntPhysGoal.Position.LEFT_LAST_FAR}
             else:
-                valid_positions = { IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR,
-                                    IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR }
+                valid_positions = {IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR,
+                                   IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR}
         elif self._roll_down is not None:
             # enforce rolling up or down the ramp as specified
             if self._roll_down and left_to_right or not self._roll_down and not left_to_right:
-                valid_positions = { IntPhysGoal.Position.LEFT_FIRST_NEAR, IntPhysGoal.Position.LEFT_LAST_NEAR,
-                                    IntPhysGoal.Position.LEFT_FIRST_FAR, IntPhysGoal.Position.LEFT_LAST_FAR }
+                valid_positions = {IntPhysGoal.Position.LEFT_FIRST_NEAR, IntPhysGoal.Position.LEFT_LAST_NEAR,
+                                   IntPhysGoal.Position.LEFT_FIRST_FAR, IntPhysGoal.Position.LEFT_LAST_FAR}
             else:
-                valid_positions = { IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR,
-                                    IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR }
+                valid_positions = {IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR,
+                                   IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR}
         else:
             valid_positions = set(IntPhysGoal.Position)
         positions = []
 
         self._last_step = IntPhysGoal.LAST_STEP_RAMP
-        # Add a buffer to the ramp's last step to account for extra steps needed by objects moving up the ramps.
+        # Add a buffer to the ramp's last step to account for extra steps
+        # needed by objects moving up the ramps.
         objs = self._get_objects_moving_across(room_wall_material_name, self._last_step - IntPhysGoal.LAST_STEP_RAMP_BUFFER,
                                                valid_defs, 0, valid_positions, positions)
         # adjust height to be on top of ramp if necessary
@@ -648,11 +732,13 @@ class GravityGoal(IntPhysGoal):
                         IntPhysGoal.Position.RIGHT_FIRST_NEAR, IntPhysGoal.Position.RIGHT_LAST_NEAR,
                         IntPhysGoal.Position.RIGHT_FIRST_FAR, IntPhysGoal.Position.RIGHT_LAST_FAR):
                 obj['shows'][0]['position']['y'] += ramps.RAMP_OBJECT_HEIGHTS[ramp_type]
-                obj['forces'][0]['vector']['y'] = obj['mass'] * IntPhysGoal.RAMP_DOWNWARD_FORCE
+                obj['forces'][0]['vector']['y'] = obj['mass'] * \
+                    IntPhysGoal.RAMP_DOWNWARD_FORCE
 
         return ramp_type, left_to_right, ramp_objs, objs
 
-    def _get_subclass_config(self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _get_subclass_config(
+            self, goal_objects: List[Dict[str, Any]]) -> Dict[str, Any]:
         goal = super(GravityGoal, self)._get_subclass_config(goal_objects)
         goal['type_list'].append(tags.get_ramp_tag(self._ramp_type.value))
         return goal
@@ -730,7 +816,8 @@ class SpatioTemporalContinuityGoal(IntPhysGoal):
     }
 
     def __init__(self):
-        super(SpatioTemporalContinuityGoal, self).__init__('spatio temporal continuity')
+        super(SpatioTemporalContinuityGoal, self).__init__(
+            'spatio temporal continuity')
 
     def _get_num_occluders(self) -> int:
         return random.choices((2, 3, 4), (40, 30, 30))[0]
@@ -749,10 +836,15 @@ class SpatioTemporalContinuityGoal(IntPhysGoal):
             occluder_objs = self._get_paired_occluder(target, occluder_list, non_room_wall_materials,
                                                       materials.METAL_MATERIALS)
             if occluder_objs is None:
-                raise exceptions.SceneException(f'Could not add minimum number of occluders')
+                raise exceptions.SceneException(
+                    f'Could not add minimum number of occluders')
             occluder_list.extend(occluder_objs)
 
-        self._add_occluders(occluder_list, num_occluders - 2, non_room_wall_materials, False)
+        self._add_occluders(
+            occluder_list,
+            num_occluders - 2,
+            non_room_wall_materials,
+            False)
 
         return occluder_list
 

--- a/scene_generator/intphys_goals_test.py
+++ b/scene_generator/intphys_goals_test.py
@@ -8,30 +8,32 @@ from intphys_goals import IntPhysGoal
 from util import instantiate_object, random_real
 
 BODY_TEMPLATE = {
-  'name': '',
-  'ceilingMaterial': 'AI2-THOR/Materials/Walls/Drywall',
-  'floorMaterial': 'AI2-THOR/Materials/Fabrics/CarpetWhite 3',
-  'wallMaterial': 'AI2-THOR/Materials/Walls/DrywallBeige',
-  'wallColors': ['white'],
-  'performerStart': {
-    'position': {
-      'x': 0,
-      'y': 0,
-      'z': 0
+    'name': '',
+    'ceilingMaterial': 'AI2-THOR/Materials/Walls/Drywall',
+    'floorMaterial': 'AI2-THOR/Materials/Fabrics/CarpetWhite 3',
+    'wallMaterial': 'AI2-THOR/Materials/Walls/DrywallBeige',
+    'wallColors': ['white'],
+    'performerStart': {
+        'position': {
+            'x': 0,
+            'y': 0,
+            'z': 0
+        },
+        'rotation': {
+            'x': 0,
+            'y': 0
+        }
     },
-    'rotation': {
-      'x': 0,
-      'y': 0
-    }
-  },
-  'objects': [],
-  'goal': {},
-  'answer': {}
+    'objects': [],
+    'goal': {},
+    'answer': {}
 }
+
 
 def test_GravityGoal_compute_objects():
     goal = GravityGoal()
-    tag_to_objects = goal.compute_objects('dummy wall material', 'dummy wall color')
+    tag_to_objects = goal.compute_objects(
+        'dummy wall material', 'dummy wall color')
     assert len(tag_to_objects['target']) >= 1
     assert len(tag_to_objects['distractor']) >= 0
     assert len(tag_to_objects['background object']) >= 0
@@ -43,30 +45,33 @@ def test_GravityGoal_update_body():
     goal = GravityGoal()
     body = goal.update_body(copy.deepcopy(BODY_TEMPLATE), False)
     assert body['goal']['last_step'] > 0
-    assert body['goal']['action_list'] == [['Pass']] * body['goal']['last_step']
+    assert body['goal']['action_list'] == [
+        ['Pass']] * body['goal']['last_step']
     assert body['goal']['category'] == 'intphys'
-    assert set(body['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'gravity'])
+    assert set(body['goal']['domain_list']) == set(
+        ['objects', 'object solidity', 'object motion', 'gravity'])
     assert 'passive' in body['goal']['type_list']
     assert 'action none' in body['goal']['type_list']
     assert 'intphys' in body['goal']['type_list']
     assert 'gravity' in body['goal']['type_list']
     assert ('ramp 30-degree' in body['goal']['type_list']) or ('ramp 45-degree' in body['goal']['type_list']) or \
-            ('ramp 90-degree' in body['goal']['type_list']) or \
-            ('ramp 30-degree-90-degree' in body['goal']['type_list']) or \
-            ('ramp 45-degree-90-degree' in body['goal']['type_list'])
+        ('ramp 90-degree' in body['goal']['type_list']) or \
+        ('ramp 30-degree-90-degree' in body['goal']['type_list']) or \
+        ('ramp 45-degree-90-degree' in body['goal']['type_list'])
     assert body['answer']['choice'] == 'plausible'
     assert len(body['objects']) >= 1
 
 
 def test_ObjectPermanenceGoal_compute_objects():
     goal = ObjectPermanenceGoal()
-    tag_to_objects = goal.compute_objects('dummy wall material', 'dummy wall color')
+    tag_to_objects = goal.compute_objects(
+        'dummy wall material', 'dummy wall color')
     assert len(tag_to_objects['target']) >= 1
     assert len(tag_to_objects['distractor']) >= 0
     assert len(tag_to_objects['background object']) >= 0
     assert len(tag_to_objects['occluder']) >= 1
     assert (goal._object_creator == IntPhysGoal._get_objects_and_occluders_moving_across) or \
-            (goal._object_creator == IntPhysGoal._get_objects_falling_down)
+        (goal._object_creator == IntPhysGoal._get_objects_falling_down)
     assert goal._last_step > 0
 
 
@@ -74,27 +79,31 @@ def test_ObjectPermanenceGoal_update_body():
     goal = ObjectPermanenceGoal()
     body = goal.update_body(copy.deepcopy(BODY_TEMPLATE), False)
     assert body['goal']['last_step'] > 0
-    assert body['goal']['action_list'] == [['Pass']] * body['goal']['last_step']
+    assert body['goal']['action_list'] == [
+        ['Pass']] * body['goal']['last_step']
     assert body['goal']['category'] == 'intphys'
-    assert set(body['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'object permanence'])
+    assert set(body['goal']['domain_list']) == set(
+        ['objects', 'object solidity', 'object motion', 'object permanence'])
     assert 'passive' in body['goal']['type_list']
     assert 'action none' in body['goal']['type_list']
     assert 'intphys' in body['goal']['type_list']
     assert 'object permanence' in body['goal']['type_list']
-    assert ('move across' in body['goal']['type_list']) or ('fall down' in body['goal']['type_list'])
+    assert ('move across' in body['goal']['type_list']) or (
+        'fall down' in body['goal']['type_list'])
     assert body['answer']['choice'] == 'plausible'
     assert len(body['objects']) >= 1
 
 
 def test_ShapeConstancyGoal_compute_objects():
     goal = ShapeConstancyGoal()
-    tag_to_objects = goal.compute_objects('dummy wall material', 'dummy wall color')
+    tag_to_objects = goal.compute_objects(
+        'dummy wall material', 'dummy wall color')
     assert len(tag_to_objects['target']) >= 1
     assert len(tag_to_objects['distractor']) >= 0
     assert len(tag_to_objects['background object']) >= 0
     assert len(tag_to_objects['occluder']) >= 1
     assert (goal._object_creator == IntPhysGoal._get_objects_and_occluders_moving_across) or \
-            (goal._object_creator == IntPhysGoal._get_objects_falling_down)
+        (goal._object_creator == IntPhysGoal._get_objects_falling_down)
     assert goal._last_step > 0
 
 
@@ -102,27 +111,31 @@ def test_ShapeConstancyGoal_update_body():
     goal = ShapeConstancyGoal()
     body = goal.update_body(copy.deepcopy(BODY_TEMPLATE), False)
     assert body['goal']['last_step'] > 0
-    assert body['goal']['action_list'] == [['Pass']] * body['goal']['last_step']
+    assert body['goal']['action_list'] == [
+        ['Pass']] * body['goal']['last_step']
     assert body['goal']['category'] == 'intphys'
-    assert set(body['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'object permanence'])
+    assert set(body['goal']['domain_list']) == set(
+        ['objects', 'object solidity', 'object motion', 'object permanence'])
     assert 'passive' in body['goal']['type_list']
     assert 'action none' in body['goal']['type_list']
     assert 'intphys' in body['goal']['type_list']
     assert 'shape constancy' in body['goal']['type_list']
-    assert ('move across' in body['goal']['type_list']) or ('fall down' in body['goal']['type_list'])
+    assert ('move across' in body['goal']['type_list']) or (
+        'fall down' in body['goal']['type_list'])
     assert body['answer']['choice'] == 'plausible'
     assert len(body['objects']) >= 1
 
 
 def test_SpatioTemporalContinuityGoal_compute_objects():
     goal = SpatioTemporalContinuityGoal()
-    tag_to_objects = goal.compute_objects('dummy wall material', 'dummy wall color')
+    tag_to_objects = goal.compute_objects(
+        'dummy wall material', 'dummy wall color')
     assert len(tag_to_objects['target']) >= 1
     assert len(tag_to_objects['distractor']) >= 0
     assert len(tag_to_objects['background object']) >= 0
     assert len(tag_to_objects['occluder']) >= 1
     assert (goal._object_creator == IntPhysGoal._get_objects_and_occluders_moving_across) or \
-            (goal._object_creator == IntPhysGoal._get_objects_falling_down)
+        (goal._object_creator == IntPhysGoal._get_objects_falling_down)
     assert goal._last_step > 0
 
 
@@ -130,14 +143,17 @@ def test_SpatioTemporalContinuityGoal_update_body():
     goal = SpatioTemporalContinuityGoal()
     body = goal.update_body(copy.deepcopy(BODY_TEMPLATE), False)
     assert body['goal']['last_step'] > 0
-    assert body['goal']['action_list'] == [['Pass']] * body['goal']['last_step']
+    assert body['goal']['action_list'] == [
+        ['Pass']] * body['goal']['last_step']
     assert body['goal']['category'] == 'intphys'
-    assert set(body['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'object permanence'])
+    assert set(body['goal']['domain_list']) == set(
+        ['objects', 'object solidity', 'object motion', 'object permanence'])
     assert 'passive' in body['goal']['type_list']
     assert 'action none' in body['goal']['type_list']
     assert 'intphys' in body['goal']['type_list']
     assert 'spatio temporal continuity' in body['goal']['type_list']
-    assert ('move across' in body['goal']['type_list']) or ('fall down' in body['goal']['type_list'])
+    assert ('move across' in body['goal']['type_list']) or (
+        'fall down' in body['goal']['type_list'])
     assert body['answer']['choice'] == 'plausible'
     assert len(body['objects']) >= 1
 
@@ -145,7 +161,8 @@ def test_SpatioTemporalContinuityGoal_update_body():
 # test for MCS-214
 def test_GravityGoal__get_ramp_and_objects():
     goal = GravityGoal()
-    ramp_type, left_to_right, ramp_objs, object_list = goal._get_ramp_and_objects('dummy')
+    ramp_type, left_to_right, ramp_objs, object_list = goal._get_ramp_and_objects(
+        'dummy')
     assert len(ramp_objs) >= 1
     for obj in object_list:
         assert obj['intphysOption']['y'] == 0
@@ -159,7 +176,8 @@ def test_IntPhysGoal__get_objects_and_occluders_moving_across():
 
     goal = TestGoal()
     wall_material = random.choice(materials.CEILING_AND_WALL_MATERIALS)[0]
-    objs, occluders = goal._get_objects_and_occluders_moving_across(wall_material)
+    objs, occluders = goal._get_objects_and_occluders_moving_across(
+        wall_material)
     assert 1 <= len(objs) <= 3
     assert 1 <= len(occluders) <= 4 * 2  # each occluder is actually 2 objects
     # the first occluder should be at one of the positions for the first object
@@ -184,7 +202,8 @@ def test_IntPhysGoal__get_objects_moving_across_collisions():
 
     goal = TestGoal()
     wall_material = random.choice(materials.CEILING_AND_WALL_MATERIALS)[0]
-    objs = goal._get_objects_moving_across(wall_material, 55, goal._object_defs)
+    objs = goal._get_objects_moving_across(
+        wall_material, 55, goal._object_defs)
     for obj in objs:
         x = obj['shows'][0]['position']['x']
         z = obj['shows'][0]['position']['z']
@@ -198,7 +217,7 @@ def test_IntPhysGoal__get_objects_moving_across_collisions():
                 other_a = other['intphysOption']['force']['x'] / obj['mass']
                 assert abs(other_a) <= abs(obj_a)
 
-    
+
 def test_IntPhysGoal__compute_scenery():
     goal = GravityGoal()
     # There's a good chance of no scenery, so keep trying until we get
@@ -223,7 +242,7 @@ def test__get_objects_falling_down():
     wall_material = random.choice(materials.CEILING_AND_WALL_MATERIALS)[0]
     obj_list, occluders = goal._get_objects_falling_down(wall_material)
     assert 1 <= len(obj_list) <= 2
-    assert len(obj_list)*2 <= len(occluders) <= 4
+    assert len(obj_list) * 2 <= len(occluders) <= 4
     for obj in obj_list:
         assert -2.5 <= obj['shows'][0]['position']['x'] <= 2.5
         assert obj['shows'][0]['position']['y'] == 3.8
@@ -241,6 +260,7 @@ def test_mcs_209():
 
     class TestGoal(IntPhysGoal):
         TEMPLATE = {'type_list': [], 'metadata': {}}
+
         def __init__(self):
             super(TestGoal, self).__init__('test')
 

--- a/scene_generator/intphys_non_matching_ids.py
+++ b/scene_generator/intphys_non_matching_ids.py
@@ -11,12 +11,12 @@ def non_matching_ids():
     found_match = False
     files = []
     user_input = Path(input('Enter Dataset directory: '))
-    assert os.path.exists(user_input), "No file at, "+str(user_input)
+    assert os.path.exists(user_input), "No file at, " + str(user_input)
     file_names = os.listdir(user_input)
 
     for file in file_names:
         found_match = False
-        file_to_open = os.path.join(user_input,file)
+        file_to_open = os.path.join(user_input, file)
         with open(file_to_open, 'r') as file_data:
             input_data = file_data.read()
             scene_data = json.loads(input_data, object_pairs_hook=OrderedDict)
@@ -29,7 +29,11 @@ def non_matching_ids():
                         num_of_times_object_id_appears += 1
                         continue
                     else:
-                        print("Matching object ID '" + object_b['id'] + "' in " + file)
+                        print(
+                            "Matching object ID '" +
+                            object_b['id'] +
+                            "' in " +
+                            file)
                         object_b['id'] = str(uuid.uuid4())
                         found_match = True
 
@@ -40,5 +44,6 @@ def non_matching_ids():
                 json.dump(scene_data, json_file, indent=2)
         else:
             print("Cannot find matching objects in " + file)
+
 
 non_matching_ids()

--- a/scene_generator/materials.py
+++ b/scene_generator/materials.py
@@ -24,30 +24,48 @@ NOVEL_COLOR_LIST = [
 ]
 
 BLOCK_BLANK_MATERIALS = [
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/blue_1x1", ["blue"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/gray_1x1", ["grey"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/green_1x1", ["green"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/red_1x1", ["red"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/wood_1x1", ["brown"]),
-    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/yellow_1x1", ["yellow"])
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/blue_1x1",
+     ["blue"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/gray_1x1",
+     ["grey"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/green_1x1",
+     ["green"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/red_1x1",
+     ["red"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/wood_1x1",
+     ["brown"]),
+    ("UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/yellow_1x1",
+     ["yellow"])
 ]
 
 BLOCK_LETTER_MATERIALS = [
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_A_Blue_1K/ToyBlockBlueA", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_B_Blue_1K/ToyBlockBlueB", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_C_Blue_1K/ToyBlockBlueC", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_D_Blue_1K/ToyBlockBlueD", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_M_Blue_1K/ToyBlockBlueM", ["blue", "brown"]),
-    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_S_Blue_1K/ToyBlockBlueS", ["blue", "brown"])
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_A_Blue_1K/ToyBlockBlueA",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_B_Blue_1K/ToyBlockBlueB",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_C_Blue_1K/ToyBlockBlueC",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_D_Blue_1K/ToyBlockBlueD",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_M_Blue_1K/ToyBlockBlueM",
+     ["blue", "brown"]),
+    ("UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_S_Blue_1K/ToyBlockBlueS",
+     ["blue", "brown"])
 ]
 
 BLOCK_NUMBER_MATERIALS = [
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_1_Yellow_1K/NumberBlockYellow_1", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_2_Yellow_1K/NumberBlockYellow_2", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_3_Yellow_1K/NumberBlockYellow_3", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_4_Yellow_1K/NumberBlockYellow_4", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_5_Yellow_1K/NumberBlockYellow_5", ["yellow", "brown"]),
-    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_6_Yellow_1K/NumberBlockYellow_6", ["yellow", "brown"])
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_1_Yellow_1K/NumberBlockYellow_1",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_2_Yellow_1K/NumberBlockYellow_2",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_3_Yellow_1K/NumberBlockYellow_3",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_4_Yellow_1K/NumberBlockYellow_4",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_5_Yellow_1K/NumberBlockYellow_5",
+     ["yellow", "brown"]),
+    ("UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_6_Yellow_1K/NumberBlockYellow_6",
+     ["yellow", "brown"])
 ]
 
 CARDBOARD_MATERIALS = [
@@ -62,7 +80,8 @@ CERAMIC_MATERIALS = [
     ("AI2-THOR/Materials/Ceramics/GREYGRANITE", ["grey"]),
     ("AI2-THOR/Materials/Ceramics/PinkConcrete_Bedroom1", ["red"]),
     ("AI2-THOR/Materials/Ceramics/RedBrick", ["red"]),
-    ("AI2-THOR/Materials/Ceramics/TexturesCom_BrickRound0044_1_seamless_S", ["grey"]),
+    ("AI2-THOR/Materials/Ceramics/TexturesCom_BrickRound0044_1_seamless_S",
+     ["grey"]),
     ("AI2-THOR/Materials/Ceramics/WhiteCountertop", ["grey"])
 ]
 
@@ -82,7 +101,8 @@ METAL_MATERIALS = [
     ("AI2-THOR/Materials/Metals/BrownMetal 1", ["brown"]),
     ("AI2-THOR/Materials/Metals/BrushedIron_AlbedoTransparency", ["black"]),
     ("AI2-THOR/Materials/Metals/GenericStainlessSteel", ["grey"]),
-    ("AI2-THOR/Materials/Metals/HammeredMetal_AlbedoTransparency 1", ["green"]),
+    ("AI2-THOR/Materials/Metals/HammeredMetal_AlbedoTransparency 1",
+     ["green"]),
     ("AI2-THOR/Materials/Metals/Metal", ["grey"]),
     ("AI2-THOR/Materials/Metals/WhiteMetal", ["white"]),
     ("UnityAssetStore/Baby_Room/Models/Materials/cabinet metal", ["grey"])
@@ -92,10 +112,14 @@ PLASTIC_MATERIALS = [
     ("AI2-THOR/Materials/Plastics/BlackPlastic", ["black"]),
     ("AI2-THOR/Materials/Plastics/OrangePlastic", ["orange"]),
     ("AI2-THOR/Materials/Plastics/WhitePlastic", ["white"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 1", ["red"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 2", ["blue"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 3", ["green"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 4", ["yellow"])
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 1",
+     ["red"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 2",
+     ["blue"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 3",
+     ["green"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color 4",
+     ["yellow"])
 ]
 
 RUBBER_MATERIALS = [
@@ -121,16 +145,21 @@ WOOD_MATERIALS = [
     ("AI2-THOR/Materials/Wood/DarkWoodSmooth2", ["black"]),
     ("AI2-THOR/Materials/Wood/LightWoodCounters 1", ["brown"]),
     ("AI2-THOR/Materials/Wood/LightWoodCounters4", ["brown"]),
-    ("AI2-THOR/Materials/Wood/TexturesCom_WoodFine0050_1_seamless_S", ["brown"]),
+    ("AI2-THOR/Materials/Wood/TexturesCom_WoodFine0050_1_seamless_S",
+     ["brown"]),
     ("AI2-THOR/Materials/Wood/WhiteWood", ["white"]),
     ("AI2-THOR/Materials/Wood/WoodFloorsCross", ["brown"]),
     ("AI2-THOR/Materials/Wood/WoodGrain_Brown", ["brown"]),
     ("AI2-THOR/Materials/Wood/WoodGrain_Tan", ["brown"]),
     ("AI2-THOR/Materials/Wood/WornWood", ["brown"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 1", ["blue"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 2", ["red"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 3", ["green"]),
-    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 4", ["yellow"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 1",
+     ["blue"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 2",
+     ["red"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 3",
+     ["green"]),
+    ("UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 4",
+     ["yellow"]),
     ("UnityAssetStore/Baby_Room/Models/Materials/wood 1", ["brown"])
 ]
 
@@ -147,9 +176,11 @@ SOFA_2_MATERIALS = [
     ("AI2-THOR/Materials/Fabrics/Sofa2_Grey", ["grey"])
 ]
 
-CEILING_AND_WALL_MATERIALS = CERAMIC_MATERIALS + METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
+CEILING_AND_WALL_MATERIALS = CERAMIC_MATERIALS + \
+    METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
 
-OCCLUDER_MATERIALS = CERAMIC_MATERIALS + METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
+OCCLUDER_MATERIALS = CERAMIC_MATERIALS + \
+    METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
 
-FLOOR_MATERIALS = CERAMIC_MATERIALS + FABRIC_MATERIALS + METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS
-
+FLOOR_MATERIALS = CERAMIC_MATERIALS + FABRIC_MATERIALS + \
+    METAL_MATERIALS + WALL_MATERIALS + WOOD_MATERIALS

--- a/scene_generator/objects.py
+++ b/scene_generator/objects.py
@@ -234,7 +234,8 @@ _BLOCK_BLANK_CYLINDER = {
 
 
 _BLOCK_LETTER = {
-    # Readers, please ignore the "blue letter c" in the type: the object's chosen material will change this design.
+    # Readers, please ignore the "blue letter c" in the type: the object's
+    # chosen material will change this design.
     "type": "block_blue_letter_c",
     "obstruct": "vision",
     "shape": ["letter block", "cube"],
@@ -263,7 +264,8 @@ _BLOCK_LETTER = {
 
 
 _BLOCK_NUMBER = {
-    # Readers, please ignore the "yellow number 1" in the type: the object's chosen material will change this design.
+    # Readers, please ignore the "yellow number 1" in the type: the object's
+    # chosen material will change this design.
     "type": "block_yellow_number_1",
     "obstruct": "vision",
     "shape": ["number block", "cube"],
@@ -1917,19 +1919,19 @@ _CHANGING_TABLE = {
     "salientMaterials": ["wood"],
     "attributes": ["receptacle", "openable"],
     "enclosedAreas": [{
-# Remove the top drawer for now.
-#        "id": "_drawer_top",
-#        "position": {
-#            "x": 0.165,
-#            "y": 0.47,
-#            "z": -0.03
-#        },
-#        "dimensions": {
-#            "x": 0.68,
-#            "y": 0.22,
-#            "z": 0.41
-#            }
-#    }, {
+        # Remove the top drawer for now.
+        #        "id": "_drawer_top",
+        #        "position": {
+        #            "x": 0.165,
+        #            "y": 0.47,
+        #            "z": -0.03
+        #        },
+        #        "dimensions": {
+        #            "x": 0.68,
+        #            "y": 0.22,
+        #            "z": 0.41
+        #            }
+        #    }, {
         "id": "_drawer_bottom",
         "position": {
             "x": 0.165,
@@ -1943,43 +1945,43 @@ _CHANGING_TABLE = {
         }
     }],
     "openAreas": [{
-# Remove the top shelves for now.
-#        "id": "",
-#        "position": {
-#            "x": 0,
-#            "y": 0.85,
-#            "z": 0
-#        },
-#        "dimensions": {
-#            "x": 1,
-#            "y": 0,
-#            "z": 0.55
-#            }
-#    }, {
-#        "id": "_shelf_top",
-#        "position": {
-#            "x": -0.01,
-#            "y": 0.725,
-#            "z": -0.05
-#        },
-#        "dimensions": {
-#            "x": 1.05,
-#            "y": 0.2,
-#            "z": 0.44
-#            }
-#    }, {
-#        "id": "_shelf_middle",
-#        "position": {
-#            "x": -0.375,
-#            "y": 0.475,
-#            "z": -0.05
-#        },
-#        "dimensions": {
-#            "x": 0.32,
-#            "y": 0.25,
-#            "z": 0.44
-#            }
-#    }, {
+        # Remove the top shelves for now.
+        #        "id": "",
+        #        "position": {
+        #            "x": 0,
+        #            "y": 0.85,
+        #            "z": 0
+        #        },
+        #        "dimensions": {
+        #            "x": 1,
+        #            "y": 0,
+        #            "z": 0.55
+        #            }
+        #    }, {
+        #        "id": "_shelf_top",
+        #        "position": {
+        #            "x": -0.01,
+        #            "y": 0.725,
+        #            "z": -0.05
+        #        },
+        #        "dimensions": {
+        #            "x": 1.05,
+        #            "y": 0.2,
+        #            "z": 0.44
+        #            }
+        #    }, {
+        #        "id": "_shelf_middle",
+        #        "position": {
+        #            "x": -0.375,
+        #            "y": 0.475,
+        #            "z": -0.05
+        #        },
+        #        "dimensions": {
+        #            "x": 0.32,
+        #            "y": 0.25,
+        #            "z": 0.44
+        #            }
+        #    }, {
         "id": "_shelf_bottom",
         "position": {
             "x": -0.375,
@@ -2063,20 +2065,20 @@ _TABLE_LONG = {
     }],
     "chooseSize": [{
         "size": "huge",
-# Remove for now because it's too high up.
-#        "openAreas": [{
-#            "id": "",
-#            "position": {
-#                "x": 0.065 * 1.175,
-#                "y": 0.88,
-#                "z": -0.07
-#            },
-#            "dimensions": {
-#                "x": 0.68 * 1.175,
-#                "y": 0,
-#                "z": 1.62
-#            }
-#        }],
+        # Remove for now because it's too high up.
+        #        "openAreas": [{
+        #            "id": "",
+        #            "position": {
+        #                "x": 0.065 * 1.175,
+        #                "y": 0.88,
+        #                "z": -0.07
+        #            },
+        #            "dimensions": {
+        #                "x": 0.68 * 1.175,
+        #                "y": 0,
+        #                "z": 1.62
+        #            }
+        #        }],
         "dimensions": {
             "x": 0.69 * 1.175,
             "y": 0.88,
@@ -2096,20 +2098,20 @@ _TABLE_LONG = {
         }
     }, {
         "size": "large",
-# Remove for now because it's too high up.
-#        "openAreas": [{
-#            "id": "",
-#            "position": {
-#                "x": 0.065 * 2.35,
-#                "y": 0.88,
-#                "z": -0.07
-#            },
-#            "dimensions": {
-#                "x": 0.68 * 2.35,
-#                "y": 0,
-#                "z": 1.62
-#            }
-#        }],
+        # Remove for now because it's too high up.
+        #        "openAreas": [{
+        #            "id": "",
+        #            "position": {
+        #                "x": 0.065 * 2.35,
+        #                "y": 0.88,
+        #                "z": -0.07
+        #            },
+        #            "dimensions": {
+        #                "x": 0.68 * 2.35,
+        #                "y": 0,
+        #                "z": 1.62
+        #            }
+        #        }],
         "dimensions": {
             "x": 0.69 * 2.35,
             "y": 0.88,
@@ -2181,20 +2183,20 @@ _TABLE_TRAY = {
     "chooseSize": [{
         "size": "large",
         "attributes": ["moveable", "receptacle"],
-# Remove for now because it's too high up.
-#        "openAreas": [{
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.84,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.4,
-#                "y": 0,
-#                "z": 0.4
-#            }
-#        }],
+        # Remove for now because it's too high up.
+        #        "openAreas": [{
+        #            "id": "",
+        #            "position": {
+        #                "x": 0,
+        #                "y": 0.84,
+        #                "z": 0
+        #            },
+        #            "dimensions": {
+        #                "x": 0.4,
+        #                "y": 0,
+        #                "z": 0.4
+        #            }
+        #        }],
         "dimensions": {
             "x": 0.573,
             "y": 1.018,
@@ -2265,20 +2267,20 @@ _TABLE_COFFEE = {
     "chooseSize": [{
         "attributes": ["receptacle"],
         "size": "large",
-# Remove for now because it's too high up.
-#        "openAreas": [{
-#            "id": "",
-#            "position": {
-#                "x": -0.18 * 0.5,
-#                "y": 0.7,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 1.2 * 0.5,
-#                "y": 0,
-#                "z": 0.9 * 0.667
-#            }
-#        }],
+        # Remove for now because it's too high up.
+        #        "openAreas": [{
+        #            "id": "",
+        #            "position": {
+        #                "x": -0.18 * 0.5,
+        #                "y": 0.7,
+        #                "z": 0
+        #            },
+        #            "dimensions": {
+        #                "x": 1.2 * 0.5,
+        #                "y": 0,
+        #                "z": 0.9 * 0.667
+        #            }
+        #        }],
         "dimensions": {
             "x": 1.2 * 0.5,
             "y": 0.7,
@@ -2299,20 +2301,20 @@ _TABLE_COFFEE = {
     }, {
         "attributes": ["receptacle", "stackTarget"],
         "size": "huge",
-# Remove for now because it's too high up.
-#        "openAreas": [{
-#            "id": "",
-#            "position": {
-#                "x": -0.18,
-#                "y": 0.7,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 1.2,
-#                "y": 0,
-#                "z": 0.9 * 0.667
-#            }
-#        }],
+        # Remove for now because it's too high up.
+        #        "openAreas": [{
+        #            "id": "",
+        #            "position": {
+        #                "x": -0.18,
+        #                "y": 0.7,
+        #                "z": 0
+        #            },
+        #            "dimensions": {
+        #                "x": 1.2,
+        #                "y": 0,
+        #                "z": 0.9 * 0.667
+        #            }
+        #        }],
         "dimensions": {
             "x": 1.2,
             "y": 0.7,
@@ -2441,19 +2443,19 @@ _SHELF_CUBBY = {
         "size": "medium",
         "attributes": ["receptacle"],
         "openAreas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.73 * 1.5,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.92 * 1.5,
-#                "y": 0,
-#                "z": 1.01 * 0.5
-#            }
-#        }, {
+            # Remove for now because it's too high up.
+            #            "id": "",
+            #            "position": {
+            #                "x": 0,
+            #                "y": 0.73 * 1.5,
+            #                "z": 0
+            #            },
+            #            "dimensions": {
+            #                "x": 0.92 * 1.5,
+            #                "y": 0,
+            #                "z": 1.01 * 0.5
+            #            }
+            #        }, {
             "id": "_middle_shelf",
             "position": {
                 "x": 0,
@@ -2499,31 +2501,31 @@ _SHELF_CUBBY = {
         "size": "huge",
         "attributes": ["receptacle"],
         "openAreas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.73 * 3,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.92 * 3,
-#                "y": 0,
-#                "z": 1.01 * 0.5
-#            }
-#        }, {
-#            "id": "_middle_shelf",
-#            "position": {
-#                "x": 0,
-#                "y": 0.52 * 3,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.65 * 3,
-#                "y": 0.22 * 3,
-#                "z": 0.87 * 0.5
-#            }
-#        }, {
+            # Remove for now because it's too high up.
+            #            "id": "",
+            #            "position": {
+            #                "x": 0,
+            #                "y": 0.73 * 3,
+            #                "z": 0
+            #            },
+            #            "dimensions": {
+            #                "x": 0.92 * 3,
+            #                "y": 0,
+            #                "z": 1.01 * 0.5
+            #            }
+            #        }, {
+            #            "id": "_middle_shelf",
+            #            "position": {
+            #                "x": 0,
+            #                "y": 0.52 * 3,
+            #                "z": 0
+            #            },
+            #            "dimensions": {
+            #                "x": 0.65 * 3,
+            #                "y": 0.22 * 3,
+            #                "z": 0.87 * 0.5
+            #            }
+            #        }, {
             "id": "_lower_shelf",
             "position": {
                 "x": 0,
@@ -2654,19 +2656,19 @@ _SHELF_TABLE = {
         "size": "medium",
         "attributes": ["receptacle"],
         "openAreas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.78,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.77,
-#                "y": 0,
-#                "z": 0.39
-#            }
-#        }, {
+            # Remove for now because it's too high up.
+            #            "id": "",
+            #            "position": {
+            #                "x": 0,
+            #                "y": 0.78,
+            #                "z": 0
+            #            },
+            #            "dimensions": {
+            #                "x": 0.77,
+            #                "y": 0,
+            #                "z": 0.39
+            #            }
+            #        }, {
             "id": "_top_right_shelf",
             "position": {
                 "x": 0.175,
@@ -2737,43 +2739,43 @@ _SHELF_TABLE = {
         "size": "huge",
         "attributes": ["receptacle"],
         "openAreas": [{
-# Remove for now because it's too high up.
-#            "id": "",
-#            "position": {
-#                "x": 0,
-#                "y": 0.78 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.77 * 2,
-#                "y": 0,
-#                "z": 0.39 * 2
-#            }
-#        }, {
-#            "id": "_top_right_shelf",
-#            "position": {
-#                "x": 0.175 * 2,
-#                "y": 0.56 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.33 * 2,
-#                "y": 0.33 * 2,
-#                "z": 0.38 * 2
-#            }
-#        }, {
-#            "id": "_top_left_shelf",
-#            "position": {
-#                "x": -0.175 * 2,
-#                "y": 0.56 * 2,
-#                "z": 0
-#            },
-#            "dimensions": {
-#                "x": 0.33 * 2,
-#                "y": 0.33 * 2,
-#                "z": 0.38 * 2
-#            }
-#        }, {
+            # Remove for now because it's too high up.
+            #            "id": "",
+            #            "position": {
+            #                "x": 0,
+            #                "y": 0.78 * 2,
+            #                "z": 0
+            #            },
+            #            "dimensions": {
+            #                "x": 0.77 * 2,
+            #                "y": 0,
+            #                "z": 0.39 * 2
+            #            }
+            #        }, {
+            #            "id": "_top_right_shelf",
+            #            "position": {
+            #                "x": 0.175 * 2,
+            #                "y": 0.56 * 2,
+            #                "z": 0
+            #            },
+            #            "dimensions": {
+            #                "x": 0.33 * 2,
+            #                "y": 0.33 * 2,
+            #                "z": 0.38 * 2
+            #            }
+            #        }, {
+            #            "id": "_top_left_shelf",
+            #            "position": {
+            #                "x": -0.175 * 2,
+            #                "y": 0.56 * 2,
+            #                "z": 0
+            #            },
+            #            "dimensions": {
+            #                "x": 0.33 * 2,
+            #                "y": 0.33 * 2,
+            #                "z": 0.38 * 2
+            #            }
+            #        }, {
             "id": "_bottom_right_shelf",
             "position": {
                 "x": 0.175 * 2,
@@ -2998,67 +3000,67 @@ _WARDROBE = {
     "attributes": ["receptacle", "openable"],
     "novelShape": True,
     "enclosedAreas": [{
-# Remove the top drawers and shelves for now.
-#        "id": "_middle_shelf_right",
-#        "position": {
-#            "x": 0.255,
-#            "y": 1.165,
-#            "z": -0.085
-#        },
-#        "dimensions": {
-#            "x": 0.49,
-#            "y": 1.24,
-#            "z": 0.46
-#        }
-#    }, {
-#        "id": "_middle_shelf_left",
-#        "position": {
-#            "x": -0.255,
-#            "y": 1.295,
-#            "z": -0.085
-#        },
-#        "dimensions": {
-#            "x": 0.49,
-#            "y": 0.98,
-#            "z": 0.46
-#        }
-#    }, {
-#        "id": "_bottom_shelf_left",
-#        "position": {
-#            "x": -0.255,
-#            "y": 0.665,
-#            "z": -0.085
-#        },
-#        "dimensions": {
-#            "x": 0.49,
-#            "y": 0.24,
-#            "z": 0.46
-#        }
-#    }, {
-#        "id": "_lower_drawer_top_left",
-#        "position": {
-#            "x": -0.265,
-#            "y": 0.42,
-#            "z": -0.075
-#        },
-#        "dimensions": {
-#            "x": 0.445,
-#            "y": 0.16
-#            "z": 0.425
-#        }
-#    }, {
-#        "id": "_lower_drawer_top_right",
-#        "position": {
-#            "x": 0.265,
-#            "y": 0.42,
-#            "z": -0.075
-#        },
-#        "dimensions": {
-#            "x": 0.445,
-#            "y": 0.16
-#            "z": 0.425
-#        }
-#    }, {
+        # Remove the top drawers and shelves for now.
+        #        "id": "_middle_shelf_right",
+        #        "position": {
+        #            "x": 0.255,
+        #            "y": 1.165,
+        #            "z": -0.085
+        #        },
+        #        "dimensions": {
+        #            "x": 0.49,
+        #            "y": 1.24,
+        #            "z": 0.46
+        #        }
+        #    }, {
+        #        "id": "_middle_shelf_left",
+        #        "position": {
+        #            "x": -0.255,
+        #            "y": 1.295,
+        #            "z": -0.085
+        #        },
+        #        "dimensions": {
+        #            "x": 0.49,
+        #            "y": 0.98,
+        #            "z": 0.46
+        #        }
+        #    }, {
+        #        "id": "_bottom_shelf_left",
+        #        "position": {
+        #            "x": -0.255,
+        #            "y": 0.665,
+        #            "z": -0.085
+        #        },
+        #        "dimensions": {
+        #            "x": 0.49,
+        #            "y": 0.24,
+        #            "z": 0.46
+        #        }
+        #    }, {
+        #        "id": "_lower_drawer_top_left",
+        #        "position": {
+        #            "x": -0.265,
+        #            "y": 0.42,
+        #            "z": -0.075
+        #        },
+        #        "dimensions": {
+        #            "x": 0.445,
+        #            "y": 0.16
+        #            "z": 0.425
+        #        }
+        #    }, {
+        #        "id": "_lower_drawer_top_right",
+        #        "position": {
+        #            "x": 0.265,
+        #            "y": 0.42,
+        #            "z": -0.075
+        #        },
+        #        "dimensions": {
+        #            "x": 0.445,
+        #            "y": 0.16
+        #            "z": 0.425
+        #        }
+        #    }, {
         "id": "_lower_drawer_bottom_left",
         "position": {
             "x": -0.265,
@@ -4744,7 +4746,7 @@ _INTPHYS: List[Dict[str, Any]] = [{
     },
     "scale": {
         "x": 0.75,
-        "y": 0.375, # Must be half
+        "y": 0.375,  # Must be half
         "z": 0.75
     },
     "intphysOptions": [{
@@ -4949,7 +4951,7 @@ _INTPHYS: List[Dict[str, Any]] = [{
     },
     "scale": {
         "x": 0.5,
-        "y": 0.25, # Must be half
+        "y": 0.25,  # Must be half
         "z": 0.5
     },
     "intphysOptions": [{
@@ -5152,7 +5154,7 @@ _INTPHYS: List[Dict[str, Any]] = [{
     },
     "scale": {
         "x": 0.25,
-        "y": 0.125, # Must be half
+        "y": 0.125,  # Must be half
         "z": 0.25
     },
     "intphysOptions": [{
@@ -5327,7 +5329,7 @@ _INTPHYS: List[Dict[str, Any]] = [{
 
 _INTPHYS_NOVEL = [{
     "type": "duck_on_wheels",
-    "novelShape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True,  # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "shape": ["duck"],
     "size": "tiny",
@@ -5357,7 +5359,7 @@ _INTPHYS_NOVEL = [{
     }
 }, {
     "type": "duck_on_wheels",
-    "novelShape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True,  # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "shape": ["duck"],
     "size": "small",
@@ -5387,7 +5389,7 @@ _INTPHYS_NOVEL = [{
     }
 }, {
     "type": "duck_on_wheels",
-    "novelShape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True,  # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "shape": ["duck"],
     "size": "medium",
@@ -5417,7 +5419,7 @@ _INTPHYS_NOVEL = [{
     }
 }, {
     "type": "racecar_red",
-    "novelShape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True,  # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "shape": ["car"],
     "size": "tiny",
@@ -5430,7 +5432,8 @@ _INTPHYS_NOVEL = [{
         "salientMaterials": ["wood"]
     }],
     "dimensions": {
-        # The X and Z dimensions here are switched due to the Y rotation that's configured below.
+        # The X and Z dimensions here are switched due to the Y rotation that's
+        # configured below.
         "x": 0.15 * 2,
         "y": 0.06 * 2,
         "z": 0.07 * 2
@@ -5453,7 +5456,7 @@ _INTPHYS_NOVEL = [{
     }
 }, {
     "type": "racecar_red",
-    "novelShape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True,  # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "shape": ["car"],
     "size": "small",
@@ -5466,7 +5469,8 @@ _INTPHYS_NOVEL = [{
         "salientMaterials": ["wood"]
     }],
     "dimensions": {
-        # The X and Z dimensions here are switched due to the Y rotation that's configured below.
+        # The X and Z dimensions here are switched due to the Y rotation that's
+        # configured below.
         "x": 0.15 * 3.5,
         "y": 0.06 * 3.5,
         "z": 0.07 * 3.5
@@ -5489,7 +5493,7 @@ _INTPHYS_NOVEL = [{
     }
 }, {
     "type": "racecar_red",
-    "novelShape": True, # This is a novel shape for IntPhys scenes
+    "novelShape": True,  # This is a novel shape for IntPhys scenes
     "attributes": ["moveable", "pickupable"],
     "shape": ["car"],
     "size": "medium",
@@ -5502,7 +5506,8 @@ _INTPHYS_NOVEL = [{
         "salientMaterials": ["wood"]
     }],
     "dimensions": {
-        # The X and Z dimensions here are switched due to the Y rotation that's configured below.
+        # The X and Z dimensions here are switched due to the Y rotation that's
+        # configured below.
         "x": 0.15 * 5,
         "y": 0.06 * 5,
         "z": 0.07 * 5
@@ -5564,9 +5569,11 @@ def create_occluder(wall_material: Tuple[str, List[str]], pole_material: Tuple[s
 
     if sideways:
         if x_position > 0:
-            occluder[POLE]['shows'][0]['position']['x'] = 3 + x_position + x_scale / 2
+            occluder[POLE]['shows'][0]['position']['x'] = 3 + \
+                x_position + x_scale / 2
         else:
-            occluder[POLE]['shows'][0]['position']['x'] = -3 + x_position - x_scale / 2
+            occluder[POLE]['shows'][0]['position']['x'] = - \
+                3 + x_position - x_scale / 2
     elif x_position > 0:
         for rot in occluder[WALL]['rotates']:
             rot['vector']['y'] *= -1
@@ -5575,7 +5582,11 @@ def create_occluder(wall_material: Tuple[str, List[str]], pole_material: Tuple[s
 
 
 _PICKUPABLE_BALLS = [_BALL]
-_PICKUPABLE_BLOCKS = [_BLOCK_BLANK_CUBE, _BLOCK_BLANK_CYLINDER, _BLOCK_LETTER, _BLOCK_NUMBER]
+_PICKUPABLE_BLOCKS = [
+    _BLOCK_BLANK_CUBE,
+    _BLOCK_BLANK_CYLINDER,
+    _BLOCK_LETTER,
+    _BLOCK_NUMBER]
 _PICKUPABLE_TOYS = [
     _TOY_CAR,
     _TOY_RACECAR,
@@ -5596,7 +5607,8 @@ _PICKUPABLE_MISC = [
 
 # Moveable (push/pull) but not pickupable
 _MOVEABLE = [
-    # TODO Change definitions to CHAIR_SMALL and CHAIR_MEDIUM when their novel targs are no longer needed
+    # TODO Change definitions to CHAIR_SMALL and CHAIR_MEDIUM when their novel
+    # targs are no longer needed
     _CHAIR_BASIC,
     _CHAIR_STOOL,
     _BLOCK_NOT_PICKUPABLE,
@@ -5625,13 +5637,18 @@ _IMMOBILE = [
 ]
 
 
-_PICKUPABLE_LISTS = [_PICKUPABLE_BALLS, _PICKUPABLE_BLOCKS, _PICKUPABLE_TOYS, _PICKUPABLE_MISC]
-_PICKUPABLE = [item for object_list in _PICKUPABLE_LISTS for item in object_list]
+_PICKUPABLE_LISTS = [
+    _PICKUPABLE_BALLS,
+    _PICKUPABLE_BLOCKS,
+    _PICKUPABLE_TOYS,
+    _PICKUPABLE_MISC]
+_PICKUPABLE = [
+    item for object_list in _PICKUPABLE_LISTS for item in object_list]
 _ALL_LISTS = [_PICKUPABLE, _MOVEABLE, _IMMOBILE]
 _ALL = [item for object_list in _ALL_LISTS for item in object_list]
+
 
 def get(prop: str) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
     """Returns a deep copy of the global property with the given name (normally either an object definition or an object
     definition list)."""
     return copy.deepcopy(globals()['_' + prop])
-

--- a/scene_generator/objects_test.py
+++ b/scene_generator/objects_test.py
@@ -10,7 +10,11 @@ def test_create_occluder_normal():
     x_position = random.uniform(-1, 1)
     x_scale = random.uniform(0.1, 2)
 
-    occluder = create_occluder(wall_material, pole_material, x_position, x_scale)
+    occluder = create_occluder(
+        wall_material,
+        pole_material,
+        x_position,
+        x_scale)
     assert len(occluder) == 2
     wall, pole = occluder
     # make sure we got them back in the right order
@@ -30,7 +34,12 @@ def test_create_occluder_sideways():
     x_position = random.uniform(-1, 1)
     x_scale = random.uniform(0.1, 2)
 
-    occluder = create_occluder(wall_material, pole_material, x_position, x_scale, True)
+    occluder = create_occluder(
+        wall_material,
+        pole_material,
+        x_position,
+        x_scale,
+        True)
     assert len(occluder) == 2
     wall, pole = occluder
     # make sure we got them back in the right order
@@ -57,9 +66,9 @@ def test_all_objects_have_expected_properties():
             assert 'color' in object_definition
         assert 'info' not in object_definition
 
+
 def test_get():
     list_1 = get('ALL')
     list_2 = get('ALL')
     assert not (list_1 is list_2)
     assert list_1 == list_2
-

--- a/scene_generator/optimal_path.py
+++ b/scene_generator/optimal_path.py
@@ -22,10 +22,12 @@ def _dilate_polygons(rects: List[List[Dict[str, float]]], dilation: float,
         poly = Polygon([(point['x'], point['z']) for point in rect])
         poly.buffer(dilation, resolution=4)
         if poly.contains(source):
-            logging.debug(f'source is inside something: source={source}\tpoly={poly}')
+            logging.debug(
+                f'source is inside something: source={source}\tpoly={poly}')
             return None
         if poly.contains(target):
-            logging.debug(f'target is inside something: target={target}\tpoly={poly}')
+            logging.debug(
+                f'target is inside something: target={target}\tpoly={poly}')
             return None
         polygons.append(poly)
     return polygons
@@ -49,7 +51,8 @@ def _unify_and_clean_polygons(polygons: List[Polygon]) \
         num_unified_points += len(coords)
         if coords[0] == coords[-1]:
             del coords[-1]
-    logging.debug(f'unified polygons: {len(poly_coords)}\tunified points: {num_unified_points}')
+    logging.debug(
+        f'unified polygons: {len(poly_coords)}\tunified points: {num_unified_points}')
 
     return poly_coords
 
@@ -65,7 +68,13 @@ def generatepath(source_loc: Tuple[float, float],
     """Boundary has to be CCW, Holes CW"""
     # dilate all the polygons based on the agent width
     dilation = agent_width / 2.0
-    polygons = _dilate_polygons(other_rects, dilation, Point(*source_loc), Point(*target_loc))
+    polygons = _dilate_polygons(
+        other_rects,
+        dilation,
+        Point(
+            *source_loc),
+        Point(
+            *target_loc))
     if polygons is None:
         return None
 

--- a/scene_generator/pairs.py
+++ b/scene_generator/pairs.py
@@ -57,33 +57,35 @@ class ObstructorPairOption(Enum):
 
 
 class SceneOptions():
-    def __init__(self, target_definition: Dict[str, Any] = None, \
-            target_containerize: BoolPairOption = BoolPairOption.NO_NO, \
-            target_location: TargetLocationPairOption = TargetLocationPairOption.RANDOM, \
-            confusor: BoolPairOption = BoolPairOption.NO_NO, confusor_definition: Dict[str, Any] = None,
-            confusor_containerize: BoolPairOption = BoolPairOption.NO_NO, \
-            confusor_location: ConfusorLocationPairOption = ConfusorLocationPairOption.CLOSE_CLOSE, \
-            obstructor: ObstructorPairOption = ObstructorPairOption.NONE_NONE, \
-            obstructor_definition: Dict[str, Any] = None):
+    def __init__(self, target_definition: Dict[str, Any] = None,
+                 target_containerize: BoolPairOption = BoolPairOption.NO_NO,
+                 target_location: TargetLocationPairOption = TargetLocationPairOption.RANDOM,
+                 confusor: BoolPairOption = BoolPairOption.NO_NO, confusor_definition: Dict[str, Any] = None,
+                 confusor_containerize: BoolPairOption = BoolPairOption.NO_NO,
+                 confusor_location: ConfusorLocationPairOption = ConfusorLocationPairOption.CLOSE_CLOSE,
+                 obstructor: ObstructorPairOption = ObstructorPairOption.NONE_NONE,
+                 obstructor_definition: Dict[str, Any] = None):
         self.target_definition = target_definition
         self.target_containerize = target_containerize
         self.target_location = target_location
-        # The confusor is always for the target object, but we may want to change that in the future.
+        # The confusor is always for the target object, but we may want to
+        # change that in the future.
         self.confusor = confusor
         self.confusor_definition = confusor_definition
         self.confusor_containerize = confusor_containerize
         self.confusor_location = confusor_location
-        # The obstructor is always for the target object, but we may want to change that in the future.
+        # The obstructor is always for the target object, but we may want to
+        # change that in the future.
         self.obstructor = obstructor
         self.obstructor_definition = obstructor_definition
 
 
 class DistractorNeverObstructsTargetObjectRule(DistractorObjectRule):
-    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]], \
-            performer_start: Dict[str, Dict[str, float]]) -> bool:
+    def validate_location(self, object_location: Dict[str, Any], target_list: List[Dict[str, Any]],
+                          performer_start: Dict[str, Dict[str, float]]) -> bool:
         for target_or_confusor in self._target_confusor_list:
-            if geometry.does_fully_obstruct_target(performer_start['position'], target_or_confusor, \
-                    geometry.get_bounding_polygon(object_location)):
+            if geometry.does_fully_obstruct_target(performer_start['position'], target_or_confusor,
+                                                   geometry.get_bounding_polygon(object_location)):
                 return False
         return True
 
@@ -92,7 +94,8 @@ class InteractionPair():
     """A pair of interactive scenes that each have the same goals, targets, distractors, walls, materials, and
     performer starts, except for specifically configured scene options."""
 
-    def __init__(self, number: int, template: Dict[str, Any], goal_name: str, find_path: bool, options: SceneOptions):
+    def __init__(self, number: int, template: Dict[str, Any],
+                 goal_name: str, find_path: bool, options: SceneOptions):
         self._number = number
         self._options = options
         tries = 0
@@ -101,16 +104,19 @@ class InteractionPair():
             try:
                 self._scene_1 = copy.deepcopy(template)
                 self._scene_2 = copy.deepcopy(template)
-                self._goal_1 = goals.get_goal_by_name(goal_name) if goal_name else goals.choose_goal('interaction')
-                logging.debug(f'\n\n{self.get_name()} initialize goal {self._goal_1.get_name()} (try {tries})\n')
+                self._goal_1 = goals.get_goal_by_name(
+                    goal_name) if goal_name else goals.choose_goal('interaction')
+                logging.debug(
+                    f'\n\n{self.get_name()} initialize goal {self._goal_1.get_name()} (try {tries})\n')
                 self._initialize_each_goal()
                 self._goal_1.update_body(self._scene_1, find_path)
                 self._goal_2.update_body(self._scene_2, find_path)
                 self._scene_1['goal']['type_list'] = self._scene_1['goal']['type_list'] + \
-                        self._get_goal_type_list_1(self._options)
+                    self._get_goal_type_list_1(self._options)
                 self._scene_2['goal']['type_list'] = self._scene_2['goal']['type_list'] + \
-                        self._get_goal_type_list_2(self._options)
-                logging.debug(f'\n\n{self.get_name()} initialize goal {self._goal_1.get_name()} done\n')
+                    self._get_goal_type_list_2(self._options)
+                logging.debug(
+                    f'\n\n{self.get_name()} initialize goal {self._goal_1.get_name()} done\n')
                 break
             except exceptions.SceneException as e:
                 logging.error(e)
@@ -123,17 +129,19 @@ class InteractionPair():
         """Return both scenes of this pair."""
         return self._scene_1, self._scene_2
 
-    def _get_both_goal_type_list(self, options: SceneOptions, prefix: str, \
-            is_true_func: Callable[[BoolPairOption], bool]) -> List[str]:
+    def _get_both_goal_type_list(self, options: SceneOptions, prefix: str,
+                                 is_true_func: Callable[[BoolPairOption], bool]) -> List[str]:
         """Return the type list for a goal using the given scene options."""
 
         type_list = [self.get_name()]
-        type_list.append(f'{prefix} target {tags.get_containerize_tag(is_true_func(options.target_containerize))}')
-        type_list.append(f'{prefix} confusor {tags.get_exists_tag(is_true_func(options.confusor))}')
+        type_list.append(
+            f'{prefix} target {tags.get_containerize_tag(is_true_func(options.target_containerize))}')
+        type_list.append(
+            f'{prefix} confusor {tags.get_exists_tag(is_true_func(options.confusor))}')
 
         if is_true_func(options.confusor):
-            type_list.append( \
-                    f'{prefix} confusor {tags.get_containerize_tag(is_true_func(options.confusor_containerize))}')
+            type_list.append(
+                f'{prefix} confusor {tags.get_containerize_tag(is_true_func(options.confusor_containerize))}')
 
         return type_list
 
@@ -141,7 +149,8 @@ class InteractionPair():
         """Return the type list for goal 1 using the given scene options."""
 
         prefix = 'pair scene 1'
-        type_list = self._get_both_goal_type_list(options, prefix, self._is_true_goal_1)
+        type_list = self._get_both_goal_type_list(
+            options, prefix, self._is_true_goal_1)
 
         if options.target_location == TargetLocationPairOption.FRONT_BACK or \
                 options.target_location == TargetLocationPairOption.FRONT_FRONT:
@@ -151,10 +160,12 @@ class InteractionPair():
 
         if self._is_true_goal_1(options.confusor):
             if options.confusor_location == ConfusorLocationPairOption.BACK_FRONT:
-                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_BACK}')
+                type_list.append(
+                    f'{prefix} confusor {tags.OBJECT_LOCATION_BACK}')
             elif options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or \
                     options.confusor_location == ConfusorLocationPairOption.CLOSE_FAR:
-                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_CLOSE}')
+                type_list.append(
+                    f'{prefix} confusor {tags.OBJECT_LOCATION_CLOSE}')
 
         type_list.append(f'{prefix} obstructor {tags.get_exists_tag(False)}')
 
@@ -164,7 +175,8 @@ class InteractionPair():
         """Return the type list for goal 2 using the given scene options."""
 
         prefix = 'pair scene 2'
-        type_list = self._get_both_goal_type_list(options, prefix, self._is_true_goal_2)
+        type_list = self._get_both_goal_type_list(
+            options, prefix, self._is_true_goal_2)
 
         if options.target_location == TargetLocationPairOption.FRONT_BACK:
             type_list.append(f'{prefix} target {tags.OBJECT_LOCATION_BACK}')
@@ -175,19 +187,24 @@ class InteractionPair():
 
         if self._is_true_goal_2(options.confusor):
             if options.confusor_location == ConfusorLocationPairOption.BACK_FRONT:
-                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_FRONT}')
+                type_list.append(
+                    f'{prefix} confusor {tags.OBJECT_LOCATION_FRONT}')
             elif options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or \
                     options.confusor_location == ConfusorLocationPairOption.NONE_CLOSE:
-                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_CLOSE}')
+                type_list.append(
+                    f'{prefix} confusor {tags.OBJECT_LOCATION_CLOSE}')
             elif options.confusor_location == ConfusorLocationPairOption.CLOSE_FAR or \
                     options.confusor_location == ConfusorLocationPairOption.NONE_FAR:
-                type_list.append(f'{prefix} confusor {tags.OBJECT_LOCATION_FAR}')
+                type_list.append(
+                    f'{prefix} confusor {tags.OBJECT_LOCATION_FAR}')
 
-        type_list.append( \
-                f'{prefix} obstructor {tags.get_exists_tag(options.obstructor != ObstructorPairOption.NONE_NONE)}')
+        type_list.append(
+            f'{prefix} obstructor {tags.get_exists_tag(options.obstructor != ObstructorPairOption.NONE_NONE)}')
 
         if options.obstructor != ObstructorPairOption.NONE_NONE:
-            obstruct_vision = (tags.get_obstruct_vision_tag(options.obstructor == ObstructorPairOption.NONE_VISION))
+            obstruct_vision = (
+                tags.get_obstruct_vision_tag(
+                    options.obstructor == ObstructorPairOption.NONE_VISION))
             type_list.append(f'{prefix} obstructor {obstruct_vision}')
 
         return type_list
@@ -201,14 +218,16 @@ class InteractionPair():
         - Create the rest of the objects (targets, distractors, walls) in the goal for the first scene.
         - Copy the first scene's goal to make the second scene's goal and replace this pair's objects.
         """
-        # Use the first goal for the pair now, and later copy it and modify the copy that will be the second goal.
+        # Use the first goal for the pair now, and later copy it and modify the
+        # copy that will be the second goal.
         goal_1_target_rule_list = self._goal_1.get_target_rule_list()
 
         target_choice = 0
         # TODO Randomly choose a target from the goal to use in both scenes.
         # target_choice = random.randint(0, len(goal_1_target_rule_list) - 1)
 
-        # Create all the targets in the goal that must come before the chosen one.
+        # Create all the targets in the goal that must come before the chosen
+        # one.
         self._goal_1.generate_target_list(target_choice)
 
         # Save each existing target and its bounding rectangles for later.
@@ -223,15 +242,19 @@ class InteractionPair():
         for _ in range(util.MAX_TRIES):
             # Choose a definition for the chosen target to use in both scenes.
             target_definition = self._options.target_definition if self._options.target_definition else \
-                    goal_1_target_rule_list[target_choice].choose_definition()
+                goal_1_target_rule_list[target_choice].choose_definition()
 
             # Create the target template now at a location, and later it'll move to its location for each scene.
-            # Assumes that both scenes have the same target (will this always be true in the future?)
-            target_template = util.instantiate_object(target_definition, geometry.ORIGIN_LOCATION)
+            # Assumes that both scenes have the same target (will this always
+            # be true in the future?)
+            target_template = util.instantiate_object(
+                target_definition, geometry.ORIGIN_LOCATION)
 
-            # If we must containerize the target, ensure it's not too big for any of the containers.
+            # If we must containerize the target, ensure it's not too big for
+            # any of the containers.
             if must_containerize_target:
-                target_receptacle_definition_list = containers.find_suitable_enclosable_list(target_template)
+                target_receptacle_definition_list = containers.find_suitable_enclosable_list(
+                    target_template)
                 if len(target_receptacle_definition_list) > 0:
                     break
             else:
@@ -240,9 +263,11 @@ class InteractionPair():
             target_template = None
 
         if not target_definition or not target_template:
-            raise exceptions.SceneException(f'{self.get_name()} cannot create good target (maybe all choices are too big?)')
+            raise exceptions.SceneException(
+                f'{self.get_name()} cannot create good target (maybe all choices are too big?)')
 
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} target template: {target_template}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} target template: {target_template}')
 
         confusor_definition = None
         confusor_template = None
@@ -257,18 +282,23 @@ class InteractionPair():
         confusor_rotation = None
 
         # Create the confusor to use in either scene if needed.
-        # Assumes that both scenes have the same confusor (will this always be true in the future?)
+        # Assumes that both scenes have the same confusor (will this always be
+        # true in the future?)
         if self._options.confusor != BoolPairOption.NO_NO:
             for _ in range(util.MAX_TRIES):
                 confusor_definition = self._options.confusor_definition if self._options.confusor_definition else \
-                        self._goal_1.get_confusor_rule(target_template).choose_definition()
-                # Create the confusor template now at a location, and later it'll move to its location for each scene.
-                confusor_template = util.instantiate_object(confusor_definition, geometry.ORIGIN_LOCATION)
+                    self._goal_1.get_confusor_rule(
+                        target_template).choose_definition()
+                # Create the confusor template now at a location, and later
+                # it'll move to its location for each scene.
+                confusor_template = util.instantiate_object(
+                    confusor_definition, geometry.ORIGIN_LOCATION)
 
-                # If we must containerize the confusor, ensure it's not too big for any of the containers.
+                # If we must containerize the confusor, ensure it's not too big
+                # for any of the containers.
                 if must_containerize_confusor:
-                    confusor_receptacle_definition_list = containers.find_suitable_enclosable_list(confusor_template, \
-                            target_receptacle_definition_list if must_containerize_target else None)
+                    confusor_receptacle_definition_list = containers.find_suitable_enclosable_list(confusor_template,
+                                                                                                   target_receptacle_definition_list if must_containerize_target else None)
                     if len(confusor_receptacle_definition_list) > 0:
                         break
                 else:
@@ -277,68 +307,87 @@ class InteractionPair():
                 confusor_template = None
 
             if not confusor_definition or not confusor_template:
-                raise exceptions.SceneException(f'{self.get_name()} cannot create good confusor (maybe all choices are too big?)')
+                raise exceptions.SceneException(
+                    f'{self.get_name()} cannot create good confusor (maybe all choices are too big?)')
 
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} confusor template: {confusor_template}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} confusor template: {confusor_template}')
 
-        is_confusor_close_in_goal_1 = (self._options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or \
-                self._options.confusor_location == ConfusorLocationPairOption.CLOSE_FAR)
+        is_confusor_close_in_goal_1 = (self._options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or
+                                       self._options.confusor_location == ConfusorLocationPairOption.CLOSE_FAR)
 
-        is_confusor_close_in_goal_2 = (self._options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or \
-                self._options.confusor_location == ConfusorLocationPairOption.NONE_CLOSE)
+        is_confusor_close_in_goal_2 = (self._options.confusor_location == ConfusorLocationPairOption.CLOSE_CLOSE or
+                                       self._options.confusor_location == ConfusorLocationPairOption.NONE_CLOSE)
 
         # Create the receptacle to use in either scene that will containerize the target and/or confusor if needed.
-        # Assumes that both scenes have the same receptacle (will this always be true in the future?)
+        # Assumes that both scenes have the same receptacle (will this always
+        # be true in the future?)
         if must_containerize_target or must_containerize_confusor:
-            must_hold_both = (self._is_true_goal_1(self._options.confusor) and \
-                    self._is_true_goal_1(self._options.target_containerize) and \
-                    self._is_true_goal_1(self._options.confusor_containerize) and is_confusor_close_in_goal_1) or \
-                    (self._is_true_goal_2(self._options.confusor) and \
-                    self._is_true_goal_2(self._options.target_containerize) and \
-                    self._is_true_goal_2(self._options.confusor_containerize) and is_confusor_close_in_goal_2)
+            must_hold_both = (self._is_true_goal_1(self._options.confusor) and
+                              self._is_true_goal_1(self._options.target_containerize) and
+                              self._is_true_goal_1(self._options.confusor_containerize) and is_confusor_close_in_goal_1) or \
+                (self._is_true_goal_2(self._options.confusor) and
+                 self._is_true_goal_2(self._options.target_containerize) and
+                 self._is_true_goal_2(self._options.confusor_containerize) and is_confusor_close_in_goal_2)
 
-            # If the confusor will be close to the target in either scene, the receptacle must be able to hold both.
+            # If the confusor will be close to the target in either scene, the
+            # receptacle must be able to hold both.
             if must_hold_both:
-                receptacle_data = self._create_receptacle_around_both(target_definition, confusor_definition)
+                receptacle_data = self._create_receptacle_around_both(
+                    target_definition, confusor_definition)
                 if not receptacle_data:
-                    raise exceptions.SceneException(f'{self.get_name()} cannot create enclosable receptacle around both: target={target_definition} confusor={confusor_definition}')
+                    raise exceptions.SceneException(
+                        f'{self.get_name()} cannot create enclosable receptacle around both: target={target_definition} confusor={confusor_definition}')
                 receptacle_definition, area_index, target_rotation, confusor_rotation, orientation = receptacle_data
-            # Else ensure that a receptacle can hold the target or confusor individually.
+            # Else ensure that a receptacle can hold the target or confusor
+            # individually.
             else:
                 target_definition_if_containerize = target_definition if must_containerize_target else None
                 confusor_definition_if_containerize = confusor_definition if must_containerize_confusor else None
-                receptacle_data = self._create_receptacle_around_either(target_definition_if_containerize, \
-                        confusor_definition_if_containerize)
+                receptacle_data = self._create_receptacle_around_either(target_definition_if_containerize,
+                                                                        confusor_definition_if_containerize)
                 if not receptacle_data:
-                    raise exceptions.SceneException(f'{self.get_name()} cannot create enclosable receptacle around either: target={target_definition_if_containerize} confusor={confusor_definition_if_containerize}')
+                    raise exceptions.SceneException(
+                        f'{self.get_name()} cannot create enclosable receptacle around either: target={target_definition_if_containerize} confusor={confusor_definition_if_containerize}')
                 receptacle_definition, area_index, target_rotation, confusor_rotation = receptacle_data
-            # Create the receptacle template now at a location, and later it'll move to its location for each scene.
-            receptacle_template = util.instantiate_object(receptacle_definition, geometry.ORIGIN_LOCATION)
+            # Create the receptacle template now at a location, and later it'll
+            # move to its location for each scene.
+            receptacle_template = util.instantiate_object(
+                receptacle_definition, geometry.ORIGIN_LOCATION)
 
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} receptacle template: {receptacle_template}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} receptacle template: {receptacle_template}')
 
         # If an object is switched across the scenes (in the same position), use the larger object to generate the
-        # location to avoid any collisions (if positioned inside a receptacle, the receptacle must be larger).
+        # location to avoid any collisions (if positioned inside a receptacle,
+        # the receptacle must be larger).
         larger_of_target_or_receptacle = receptacle_template if must_containerize_target else target_template
         larger_of_confusor_or_receptacle = receptacle_template if must_containerize_confusor else confusor_template
-        larger_of_target_or_confusor = self._find_larger_object(larger_of_target_or_receptacle, \
-                larger_of_confusor_or_receptacle)
+        larger_of_target_or_confusor = self._find_larger_object(larger_of_target_or_receptacle,
+                                                                larger_of_confusor_or_receptacle)
 
         # Create the obstructor to use in either scene if needed.
-        # Assumes that both scenes have the same obstructor (will this always be true in the future?)
+        # Assumes that both scenes have the same obstructor (will this always
+        # be true in the future?)
         if self._options.obstructor != ObstructorPairOption.NONE_NONE:
-            obstruct_vision = (self._options.obstructor == ObstructorPairOption.NONE_VISION)
+            obstruct_vision = (self._options.obstructor ==
+                               ObstructorPairOption.NONE_VISION)
             obstructor_definition = self._options.obstructor_definition if self._options.obstructor_definition else \
-                    self._goal_1.get_obstructor_rule(larger_of_target_or_receptacle, \
-                    obstruct_vision).choose_definition()
-            # Create the obstructor template now at a location, and later it'll move to its location for each scene.
-            obstructor_template = util.instantiate_object(obstructor_definition, geometry.ORIGIN_LOCATION)
+                self._goal_1.get_obstructor_rule(larger_of_target_or_receptacle,
+                                                 obstruct_vision).choose_definition()
+            # Create the obstructor template now at a location, and later it'll
+            # move to its location for each scene.
+            obstructor_template = util.instantiate_object(
+                obstructor_definition, geometry.ORIGIN_LOCATION)
 
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} obstructor template: {obstructor_template}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} obstructor template: {obstructor_template}')
 
-        larger_of_target_or_obstructor = self._find_larger_object(larger_of_target_or_receptacle, \
-                obstructor_template)
-        larger_object = self._find_larger_object(larger_of_target_or_confusor, larger_of_target_or_obstructor)
+        larger_of_target_or_obstructor = self._find_larger_object(larger_of_target_or_receptacle,
+                                                                  obstructor_template)
+        larger_object = self._find_larger_object(
+            larger_of_target_or_confusor,
+            larger_of_target_or_obstructor)
 
         target_location_1 = None
         target_location_2 = None
@@ -346,124 +395,167 @@ class InteractionPair():
         confusor_location_2 = None
 
         is_target_relative_to_performer_start = \
-                (self._options.target_location == TargetLocationPairOption.FRONT_BACK or \
-                self._options.target_location == TargetLocationPairOption.FRONT_FRONT)
-        is_confusor_relative_to_performer_start = (confusor_template and self._options.confusor_location == \
-                ConfusorLocationPairOption.BACK_FRONT)
+            (self._options.target_location == TargetLocationPairOption.FRONT_BACK or
+             self._options.target_location == TargetLocationPairOption.FRONT_FRONT)
+        is_confusor_relative_to_performer_start = (confusor_template and self._options.confusor_location ==
+                                                   ConfusorLocationPairOption.BACK_FRONT)
 
         # If the target must be positioned relative to the performer_start, find locations both in front of and in back
-        # of the performer based on its position/rotation. Do this first because it may change the performer_start.
+        # of the performer based on its position/rotation. Do this first
+        # because it may change the performer_start.
         if is_target_relative_to_performer_start:
-            location_front, location_back = self._generate_front_and_back(self._goal_1, larger_object, \
-                    goal_1_target_rule_list[target_choice], True)
+            location_front, location_back = self._generate_front_and_back(self._goal_1, larger_object,
+                                                                          goal_1_target_rule_list[target_choice], True)
             target_location_1 = location_front
             target_location_2 = location_back if \
-                    self._options.target_location == TargetLocationPairOption.FRONT_BACK else location_front
+                self._options.target_location == TargetLocationPairOption.FRONT_BACK else location_front
             if is_confusor_relative_to_performer_start:
                 confusor_location_1 = location_back
                 confusor_location_2 = location_front
 
         else:
-            # If an object must be positioned relative to the performer_start, do it first.
+            # If an object must be positioned relative to the performer_start,
+            # do it first.
             if is_confusor_relative_to_performer_start:
-                location_front, location_back = self._generate_front_and_back(self._goal_1, \
-                        larger_of_confusor_or_receptacle, goal_1_target_rule_list[target_choice], True)
+                location_front, location_back = self._generate_front_and_back(self._goal_1,
+                                                                              larger_of_confusor_or_receptacle, goal_1_target_rule_list[target_choice], True)
                 confusor_location_1 = location_back
                 confusor_location_2 = location_front
 
-            # If the target isn't positioned relative to the performer_start, it'll be positioned randomly.
-            target_location_1, target_location_2 = self._generate_random_location(self._goal_1, \
-                    larger_of_target_or_receptacle, goal_1_target_rule_list[target_choice], \
-                    goal_1_target_list, shared_bounds_list)
+            # If the target isn't positioned relative to the performer_start,
+            # it'll be positioned randomly.
+            target_location_1, target_location_2 = self._generate_random_location(self._goal_1,
+                                                                                  larger_of_target_or_receptacle, goal_1_target_rule_list[
+                                                                                      target_choice],
+                                                                                  goal_1_target_list, shared_bounds_list)
 
-            # Add more target location scene options here if needed in the future.
+            # Add more target location scene options here if needed in the
+            # future.
 
         # The performer_start shouldn't be modified past here.
         performer_start = self._goal_1.get_performer_start()
 
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} performer start: {performer_start}')
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} target location 1: {target_location_1}')
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} target location 2: {target_location_2}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} performer start: {performer_start}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} target location 1: {target_location_1}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} target location 2: {target_location_2}')
 
-        # If needed, exchange the target with the obstructor, then position the target directly behind the obstructor.
-        obstructor_location_1 = self._generate_obstructor_location(False, target_definition, target_location_1, \
-                obstructor_definition, performer_start)
-        obstructor_location_2 = self._generate_obstructor_location( \
-                (self._options.obstructor != ObstructorPairOption.NONE_NONE), target_definition, target_location_2, \
-                obstructor_definition, performer_start)
+        # If needed, exchange the target with the obstructor, then position the
+        # target directly behind the obstructor.
+        obstructor_location_1 = self._generate_obstructor_location(False, target_definition, target_location_1,
+                                                                   obstructor_definition, performer_start)
+        obstructor_location_2 = self._generate_obstructor_location(
+            (self._options.obstructor !=
+             ObstructorPairOption.NONE_NONE), target_definition, target_location_2,
+            obstructor_definition, performer_start)
 
-        # If the confusor isn't positioned relative to the performer_start, it's positioned relative to the target.
+        # If the confusor isn't positioned relative to the performer_start,
+        # it's positioned relative to the target.
         if confusor_template and not is_confusor_relative_to_performer_start:
             is_target_location_same_in_both = \
-                    (self._options.target_location == TargetLocationPairOption.FRONT_FRONT or \
-                    self._options.target_location == TargetLocationPairOption.RANDOM)
-            confusor_location_1, confusor_location_2 = self._generate_confusor_location(confusor_definition, \
-                    target_definition, target_template, target_location_1, target_location_2, performer_start, \
-                    is_confusor_close_in_goal_1, is_confusor_close_in_goal_2, is_target_location_same_in_both)
+                (self._options.target_location == TargetLocationPairOption.FRONT_FRONT or
+                 self._options.target_location == TargetLocationPairOption.RANDOM)
+            confusor_location_1, confusor_location_2 = self._generate_confusor_location(confusor_definition,
+                                                                                        target_definition, target_template, target_location_1, target_location_2, performer_start,
+                                                                                        is_confusor_close_in_goal_1, is_confusor_close_in_goal_2, is_target_location_same_in_both)
 
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} confusor location 1: {confusor_location_1}')
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} confusor location 2: {confusor_location_2}')
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} obstructor location 1: {obstructor_location_1}')
-        logging.debug(f'{self.get_name()} {self._goal_1.get_name()} obstructor location 2: {obstructor_location_2}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} confusor location 1: {confusor_location_1}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} confusor location 2: {confusor_location_2}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} obstructor location 1: {obstructor_location_1}')
+        logging.debug(
+            f'{self.get_name()} {self._goal_1.get_name()} obstructor location 2: {obstructor_location_2}')
 
-        # Create a new ID so it's not the same ID used by the target's receptacle_instance
+        # Create a new ID so it's not the same ID used by the target's
+        # receptacle_instance
         confusor_receptacle_id = str(uuid.uuid4())
 
-        # Finalize the position of the target and the confusor in both scenes (they may be inside a receptacle).
-        target_1, confusor_1, target_receptacle_1, confusor_receptacle_1 = self._finalize_target_confusor_position( \
-                target_definition, target_template, target_location_1, \
-                self._is_true_goal_1(self._options.target_containerize), \
-                self._is_true_goal_1(self._options.confusor), is_confusor_close_in_goal_1, confusor_definition, \
-                confusor_template, confusor_location_1, self._is_true_goal_1(self._options.confusor_containerize), \
-                receptacle_definition, receptacle_template, area_index, target_rotation, confusor_rotation, \
-                orientation, shared_bounds_list, confusor_receptacle_id)
-        target_2, confusor_2, target_receptacle_2, confusor_receptacle_2 = self._finalize_target_confusor_position( \
-                target_definition, target_template, target_location_2, \
-                self._is_true_goal_2(self._options.target_containerize), \
-                self._is_true_goal_2(self._options.confusor), is_confusor_close_in_goal_2, confusor_definition, \
-                confusor_template, confusor_location_2, self._is_true_goal_2(self._options.confusor_containerize), \
-                receptacle_definition, receptacle_template, area_index, target_rotation, confusor_rotation, \
-                orientation, shared_bounds_list, confusor_receptacle_id)
+        # Finalize the position of the target and the confusor in both scenes
+        # (they may be inside a receptacle).
+        target_1, confusor_1, target_receptacle_1, confusor_receptacle_1 = self._finalize_target_confusor_position(
+            target_definition, target_template, target_location_1,
+            self._is_true_goal_1(self._options.target_containerize),
+            self._is_true_goal_1(
+                self._options.confusor), is_confusor_close_in_goal_1, confusor_definition,
+            confusor_template, confusor_location_1, self._is_true_goal_1(
+                self._options.confusor_containerize),
+            receptacle_definition, receptacle_template, area_index, target_rotation, confusor_rotation,
+            orientation, shared_bounds_list, confusor_receptacle_id)
+        target_2, confusor_2, target_receptacle_2, confusor_receptacle_2 = self._finalize_target_confusor_position(
+            target_definition, target_template, target_location_2,
+            self._is_true_goal_2(self._options.target_containerize),
+            self._is_true_goal_2(
+                self._options.confusor), is_confusor_close_in_goal_2, confusor_definition,
+            confusor_template, confusor_location_2, self._is_true_goal_2(
+                self._options.confusor_containerize),
+            receptacle_definition, receptacle_template, area_index, target_rotation, confusor_rotation,
+            orientation, shared_bounds_list, confusor_receptacle_id)
 
-        obstructor_1 = self._finalize_obstructor(False, obstructor_definition, obstructor_template, \
-                obstructor_location_1, shared_bounds_list)
-        obstructor_2 = self._finalize_obstructor((self._options.obstructor != ObstructorPairOption.NONE_NONE), \
-                obstructor_definition, obstructor_template, obstructor_location_2, shared_bounds_list)
+        obstructor_1 = self._finalize_obstructor(False, obstructor_definition, obstructor_template,
+                                                 obstructor_location_1, shared_bounds_list)
+        obstructor_2 = self._finalize_obstructor((self._options.obstructor != ObstructorPairOption.NONE_NONE),
+                                                 obstructor_definition, obstructor_template, obstructor_location_2, shared_bounds_list)
 
-        logging.info(f'{self.get_name()} {self._goal_1.get_name()} target_1 {target_1["type"]} {target_1["id"]}')
-        logging.info(f'{self.get_name()} {self._goal_1.get_name()} target_2 {target_2["type"]} {target_2["id"]}')
-        logging.info(f'{self.get_name()} {self._goal_1.get_name()} target_receptacle_1 {((target_receptacle_1["type"] + " " + target_receptacle_1["id"]) if target_receptacle_1 else "None")}')
-        logging.info(f'{self.get_name()} {self._goal_1.get_name()} target_receptacle_2 {((target_receptacle_2["type"] + " " + target_receptacle_2["id"]) if target_receptacle_2 else "None")}')
-        logging.info(f'{self.get_name()} {self._goal_1.get_name()} confusor_1 {((confusor_1["type"] + " " + confusor_1["id"]) if confusor_1 else "None")}')
-        logging.info(f'{self.get_name()} {self._goal_1.get_name()} confusor_2 {((confusor_2["type"] + " " + confusor_2["id"]) if confusor_2 else "None")}')
-        logging.info(f'{self.get_name()} {self._goal_1.get_name()} obstructor_1 {((obstructor_1["type"] + " " + obstructor_1["id"]) if obstructor_1 else "None")}')
-        logging.info(f'{self.get_name()} {self._goal_1.get_name()} obstructor_2 {((obstructor_2["type"] + " " + obstructor_2["id"]) if obstructor_2 else "None")}')
+        logging.info(
+            f'{self.get_name()} {self._goal_1.get_name()} target_1 {target_1["type"]} {target_1["id"]}')
+        logging.info(
+            f'{self.get_name()} {self._goal_1.get_name()} target_2 {target_2["type"]} {target_2["id"]}')
+        logging.info(
+            f'{self.get_name()} {self._goal_1.get_name()} target_receptacle_1 {((target_receptacle_1["type"] + " " + target_receptacle_1["id"]) if target_receptacle_1 else "None")}')
+        logging.info(
+            f'{self.get_name()} {self._goal_1.get_name()} target_receptacle_2 {((target_receptacle_2["type"] + " " + target_receptacle_2["id"]) if target_receptacle_2 else "None")}')
+        logging.info(
+            f'{self.get_name()} {self._goal_1.get_name()} confusor_1 {((confusor_1["type"] + " " + confusor_1["id"]) if confusor_1 else "None")}')
+        logging.info(
+            f'{self.get_name()} {self._goal_1.get_name()} confusor_2 {((confusor_2["type"] + " " + confusor_2["id"]) if confusor_2 else "None")}')
+        logging.info(
+            f'{self.get_name()} {self._goal_1.get_name()} obstructor_1 {((obstructor_1["type"] + " " + obstructor_1["id"]) if obstructor_1 else "None")}')
+        logging.info(
+            f'{self.get_name()} {self._goal_1.get_name()} obstructor_2 {((obstructor_2["type"] + " " + obstructor_2["id"]) if obstructor_2 else "None")}')
 
         confusor_list_1 = [confusor_1] if confusor_1 else []
         confusor_list_2 = [confusor_2] if confusor_2 else []
-        distractor_list_1 = [instance for instance in [target_receptacle_1, confusor_receptacle_1] if instance]
-        distractor_list_2 = [instance for instance in [target_receptacle_2, confusor_receptacle_2] if instance]
+        distractor_list_1 = [
+            instance for instance in [
+                target_receptacle_1,
+                confusor_receptacle_1] if instance]
+        distractor_list_2 = [
+            instance for instance in [
+                target_receptacle_2,
+                confusor_receptacle_2] if instance]
         obstructor_list_1 = [obstructor_1] if obstructor_1 else []
         obstructor_list_2 = [obstructor_2] if obstructor_2 else []
 
         if is_target_relative_to_performer_start or is_confusor_relative_to_performer_start:
-            # Ensure that the random location of distractors or walls doesn't accidentally make them obstructors.
-            self._goal_1.set_distractor_rule(DistractorNeverObstructsTargetObjectRule)
+            # Ensure that the random location of distractors or walls doesn't
+            # accidentally make them obstructors.
+            self._goal_1.set_distractor_rule(
+                DistractorNeverObstructsTargetObjectRule)
             self._goal_1.set_no_random_obstructor()
 
-        self._finalize_goal_1(target_1, confusor_list_1, distractor_list_1, obstructor_list_1)
-        self._finalize_goal_2(target_choice, confusor_list_1, distractor_list_1, obstructor_list_1, target_2, \
-                confusor_list_2, distractor_list_2, obstructor_list_2)
+        self._finalize_goal_1(
+            target_1,
+            confusor_list_1,
+            distractor_list_1,
+            obstructor_list_1)
+        self._finalize_goal_2(target_choice, confusor_list_1, distractor_list_1, obstructor_list_1, target_2,
+                              confusor_list_2, distractor_list_2, obstructor_list_2)
 
     def _create_receptacle_around_both(self, target_instance: Dict[str, Any], confusor_instance: Dict[str, Any]) -> \
             Optional[Tuple[Dict[str, Any], int, float, float, containers.Orientation]]:
         """Create and return a receptacle that encloses the target and confusor together. If impossible return None."""
 
-        # Find an enclosable receptacle that can hold both the target and the confusor together.
+        # Find an enclosable receptacle that can hold both the target and the
+        # confusor together.
         receptacle_definition_list = containers.retrieve_enclosable_object_definition_list().copy()
         random.shuffle(receptacle_definition_list)
         for receptacle_definition in receptacle_definition_list:
-            valid_containment = containers.can_contain_both(receptacle_definition, target_instance, confusor_instance)
+            valid_containment = containers.can_contain_both(
+                receptacle_definition, target_instance, confusor_instance)
             if valid_containment:
                 break
             valid_containment = None
@@ -476,11 +568,12 @@ class InteractionPair():
             Optional[Tuple[Dict[str, Any], int, float, float]]:
         """Create and return a receptacle that encloses the target or confusor alone. If impossible return None."""
 
-        # Find an enclosable receptacle that can hold either the target or the confusor individually.
+        # Find an enclosable receptacle that can hold either the target or the
+        # confusor individually.
         receptacle_definition_list = containers.retrieve_enclosable_object_definition_list().copy()
         random.shuffle(receptacle_definition_list)
-        valid_containment_list = containers.get_enclosable_containments((target_instance, confusor_instance), \
-                receptacle_definition_list)
+        valid_containment_list = containers.get_enclosable_containments((target_instance, confusor_instance),
+                                                                        receptacle_definition_list)
 
         if len(valid_containment_list) == 0:
             return None
@@ -488,11 +581,13 @@ class InteractionPair():
         valid_containment = random.choice(valid_containment_list)
         receptacle_definition, area_index, angles = valid_containment
 
-        # The angles list should have a length of 2 if the confusor_instance is not None
-        return receptacle_definition, area_index, angles[0], (angles[1] if len(angles) == 2 else None)
+        # The angles list should have a length of 2 if the confusor_instance is
+        # not None
+        return receptacle_definition, area_index, angles[0], (angles[1] if len(
+            angles) == 2 else None)
 
-    def _finalize_goal_1(self, target_1: Dict[str, Any], confusor_list: List[Dict[str, Any]], \
-            distractor_list: List[Dict[str, Any]], obstructor_list: List[Dict[str, Any]]) -> None:
+    def _finalize_goal_1(self, target_1: Dict[str, Any], confusor_list: List[Dict[str, Any]],
+                         distractor_list: List[Dict[str, Any]], obstructor_list: List[Dict[str, Any]]) -> None:
         """Finalize the target and other objects in the first goal."""
 
         # Add the first version of each chosen object to the first goal.
@@ -508,23 +603,28 @@ class InteractionPair():
         for obstructor in obstructor_list:
             goal_1_obstructor_list.append(obstructor)
 
-        # Generate the other random objects in the first goal, then copy them to the second goal.
-        self._goal_1.compute_objects(self._scene_1['wallMaterial'], self._scene_1['wallColors'])
+        # Generate the other random objects in the first goal, then copy them
+        # to the second goal.
+        self._goal_1.compute_objects(
+            self._scene_1['wallMaterial'],
+            self._scene_1['wallColors'])
 
-    def _finalize_goal_2(self, target_choice: int, confusor_list_1: List[Dict[str, Any]], \
-            distractor_list_1: List[Dict[str, Any]], obstructor_list_1: List[Dict[str, Any]], \
-            target_2: Dict[str, Any], confusor_list_2: List[Dict[str, Any]], \
-            distractor_list_2: List[Dict[str, Any]], obstructor_list_2: List[Dict[str, Any]]) -> None:
+    def _finalize_goal_2(self, target_choice: int, confusor_list_1: List[Dict[str, Any]],
+                         distractor_list_1: List[Dict[str, Any]], obstructor_list_1: List[Dict[str, Any]],
+                         target_2: Dict[str, Any], confusor_list_2: List[Dict[str, Any]],
+                         distractor_list_2: List[Dict[str, Any]], obstructor_list_2: List[Dict[str, Any]]) -> None:
         """Finalize the target and other objects in the first goal."""
 
         # Copy the random objects from the first goal to the second goal.
         self._goal_2 = copy.deepcopy(self._goal_1)
 
-        # Exchange the first version of the target object with the second version to keep it at the same list index.
+        # Exchange the first version of the target object with the second
+        # version to keep it at the same list index.
         goal_2_target_list = self._goal_2.get_target_list()
         goal_2_target_list[target_choice] = target_2
 
-        # Remove the first version of each chosen object in the lists that were copied from the first goal.
+        # Remove the first version of each chosen object in the lists that were
+        # copied from the first goal.
         goal_2_confusor_list = self._goal_2.get_confusor_list()
         for confusor in confusor_list_1:
             goal_2_confusor_list.pop(0)
@@ -546,94 +646,115 @@ class InteractionPair():
         for obstructor in obstructor_list_2:
             goal_2_obstructor_list.insert(0, obstructor)
 
-    def _finalize_obstructor(self, show_obstructor: bool, obstructor_definition: Dict[str, Any], \
-            obstructor_template: Dict[str, Any], obstructor_location: Dict[str, float], \
-            bounds_list: List[List[Dict[str, float]]]) -> Dict[str, Any]:
+    def _finalize_obstructor(self, show_obstructor: bool, obstructor_definition: Dict[str, Any],
+                             obstructor_template: Dict[str, Any], obstructor_location: Dict[str, float],
+                             bounds_list: List[List[Dict[str, float]]]) -> Dict[str, Any]:
         """Finalize the position of the obstructor object and return it (if any). Will modify the given bounds_list."""
 
         if show_obstructor:
             obstructor_instance = copy.deepcopy(obstructor_template)
-            util.move_to_location(obstructor_definition, obstructor_instance, obstructor_location, \
-                    geometry.generate_object_bounds(obstructor_definition['dimensions'], \
-                    obstructor_definition['offset'] if 'offset' in obstructor_definition else None,
-                    obstructor_location['position'], obstructor_location['rotation']), obstructor_definition)
+            util.move_to_location(obstructor_definition, obstructor_instance, obstructor_location,
+                                  geometry.generate_object_bounds(obstructor_definition['dimensions'],
+                                                                  obstructor_definition[
+                                                                      'offset'] if 'offset' in obstructor_definition else None,
+                                                                  obstructor_location['position'], obstructor_location['rotation']), obstructor_definition)
             bounds_list.append(obstructor_instance['shows'][0]['boundingBox'])
             return obstructor_instance
 
         return None
 
-    def _finalize_target_confusor_position(self, target_definition: Dict[str, Any], target_template: Dict[str, Any], \
-            target_location: Dict[str, Any], containerize_target: bool, show_confusor: bool, is_confusor_close: bool, \
-            confusor_definition: Dict[str, Any], confusor_template: Dict[str, Any], \
-            confusor_location: Dict[str, Any], containerize_confusor: bool, receptacle_definition: Dict[str, Any], \
-            receptacle_template: Dict[str, Any], area_index: int, target_rotation: float, confusor_rotation: float, \
-            orientation: containers.Orientation, bounds_list: List[List[Dict[str, float]]], \
-            confusor_receptacle_id: int) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+    def _finalize_target_confusor_position(self, target_definition: Dict[str, Any], target_template: Dict[str, Any],
+                                           target_location: Dict[str, Any], containerize_target: bool, show_confusor: bool, is_confusor_close: bool,
+                                           confusor_definition: Dict[str, Any], confusor_template: Dict[str, Any],
+                                           confusor_location: Dict[str, Any], containerize_confusor: bool, receptacle_definition: Dict[str, Any],
+                                           receptacle_template: Dict[str, Any], area_index: int, target_rotation: float, confusor_rotation: float,
+                                           orientation: containers.Orientation, bounds_list: List[List[Dict[str, float]]],
+                                           confusor_receptacle_id: int) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
         """Finalize the position of the target and confusor, and return the target, confusor (if any), target
         receptacle (if any), and confusor receptacle (if any). Will modify the given bounds_list."""
 
         target_instance = copy.deepcopy(target_template)
-        confusor_instance = copy.deepcopy(confusor_template) if (confusor_template and show_confusor) else None
+        confusor_instance = copy.deepcopy(confusor_template) if (
+            confusor_template and show_confusor) else None
         target_receptacle_instance = None
         confusor_receptacle_instance = None
 
-        # If needed, position both the target and confusor together inside a receptacle.
+        # If needed, position both the target and confusor together inside a
+        # receptacle.
         if containerize_target and containerize_confusor and show_confusor and is_confusor_close:
             target_receptacle_instance = copy.deepcopy(receptacle_template)
-            # Update the Y position of the location to use the positionY from the receptacle definition.
-            target_location['position']['y'] = receptacle_definition.get('positionY', 0)
-            util.move_to_location(receptacle_definition, target_receptacle_instance, target_location, \
-                    geometry.generate_object_bounds(receptacle_definition['dimensions'], \
-                    receptacle_definition['offset'] if 'offset' in receptacle_definition else None, \
-                    target_location['position'], target_location['rotation']), target_definition)
-            containers.put_objects_in_container(target_definition, target_instance, confusor_definition, \
-                    confusor_instance, target_receptacle_instance, receptacle_definition, area_index, orientation, \
-                    target_rotation, confusor_rotation)
-            bounds_list.append(target_receptacle_instance['shows'][0]['boundingBox'])
+            # Update the Y position of the location to use the positionY from
+            # the receptacle definition.
+            target_location['position']['y'] = receptacle_definition.get(
+                'positionY', 0)
+            util.move_to_location(receptacle_definition, target_receptacle_instance, target_location,
+                                  geometry.generate_object_bounds(receptacle_definition['dimensions'],
+                                                                  receptacle_definition[
+                                                                      'offset'] if 'offset' in receptacle_definition else None,
+                                                                  target_location['position'], target_location['rotation']), target_definition)
+            containers.put_objects_in_container(target_definition, target_instance, confusor_definition,
+                                                confusor_instance, target_receptacle_instance, receptacle_definition, area_index, orientation,
+                                                target_rotation, confusor_rotation)
+            bounds_list.append(
+                target_receptacle_instance['shows'][0]['boundingBox'])
 
         else:
             if containerize_target:
-                # Use the target location for its receptacle, then position the target inside its receptacle.
+                # Use the target location for its receptacle, then position the
+                # target inside its receptacle.
                 target_receptacle_instance = copy.deepcopy(receptacle_template)
-                # Update the Y position of the location to use the positionY from the receptacle definition.
-                target_location['position']['y'] = receptacle_definition.get('positionY', 0)
-                util.move_to_location(receptacle_definition, target_receptacle_instance, target_location, \
-                    geometry.generate_object_bounds(receptacle_definition['dimensions'], \
-                    receptacle_definition['offset'] if 'offset' in receptacle_definition else None, \
-                    target_location['position'], target_location['rotation']), target_definition)
-                containers.put_object_in_container(target_definition, target_instance, target_receptacle_instance, \
-                        receptacle_definition, area_index, target_rotation)
-                bounds_list.append(target_receptacle_instance['shows'][0]['boundingBox'])
+                # Update the Y position of the location to use the positionY
+                # from the receptacle definition.
+                target_location['position']['y'] = receptacle_definition.get(
+                    'positionY', 0)
+                util.move_to_location(receptacle_definition, target_receptacle_instance, target_location,
+                                      geometry.generate_object_bounds(receptacle_definition['dimensions'],
+                                                                      receptacle_definition[
+                                                                          'offset'] if 'offset' in receptacle_definition else None,
+                                                                      target_location['position'], target_location['rotation']), target_definition)
+                containers.put_object_in_container(target_definition, target_instance, target_receptacle_instance,
+                                                   receptacle_definition, area_index, target_rotation)
+                bounds_list.append(
+                    target_receptacle_instance['shows'][0]['boundingBox'])
             else:
-                util.move_to_location(target_definition, target_instance, target_location, \
-                    geometry.generate_object_bounds(target_definition['dimensions'], \
-                    target_definition['offset'] if 'offset' in target_definition else None, \
-                    target_location['position'], target_location['rotation']), target_definition)
+                util.move_to_location(target_definition, target_instance, target_location,
+                                      geometry.generate_object_bounds(target_definition['dimensions'],
+                                                                      target_definition['offset'] if 'offset' in target_definition else None,
+                                                                      target_location['position'], target_location['rotation']), target_definition)
                 bounds_list.append(target_instance['shows'][0]['boundingBox'])
             if show_confusor:
                 if containerize_confusor:
-                    # Use the confusor location for its receptacle, then position the confusor inside its receptacle.
-                    confusor_receptacle_instance = copy.deepcopy(receptacle_template)
-                    # Update the Y position of the location to use the positionY from the receptacle definition.
-                    confusor_location['position']['y'] = receptacle_definition.get('positionY', 0)
+                    # Use the confusor location for its receptacle, then
+                    # position the confusor inside its receptacle.
+                    confusor_receptacle_instance = copy.deepcopy(
+                        receptacle_template)
+                    # Update the Y position of the location to use the
+                    # positionY from the receptacle definition.
+                    confusor_location['position']['y'] = receptacle_definition.get(
+                        'positionY', 0)
                     confusor_receptacle_instance['id'] = confusor_receptacle_id
-                    util.move_to_location(receptacle_definition, confusor_receptacle_instance, confusor_location, \
-                        geometry.generate_object_bounds(receptacle_definition['dimensions'], \
-                        receptacle_definition['offset'] if 'offset' in receptacle_definition else None, \
-                        confusor_location['position'], confusor_location['rotation']), confusor_definition)
-                    containers.put_object_in_container(confusor_definition, confusor_instance, \
-                            confusor_receptacle_instance, receptacle_definition, area_index, confusor_rotation)
-                    bounds_list.append(confusor_receptacle_instance['shows'][0]['boundingBox'])
+                    util.move_to_location(receptacle_definition, confusor_receptacle_instance, confusor_location,
+                                          geometry.generate_object_bounds(receptacle_definition['dimensions'],
+                                                                          receptacle_definition[
+                                                                              'offset'] if 'offset' in receptacle_definition else None,
+                                                                          confusor_location['position'], confusor_location['rotation']), confusor_definition)
+                    containers.put_object_in_container(confusor_definition, confusor_instance,
+                                                       confusor_receptacle_instance, receptacle_definition, area_index, confusor_rotation)
+                    bounds_list.append(
+                        confusor_receptacle_instance['shows'][0]['boundingBox'])
                 else:
-                    util.move_to_location(confusor_definition, confusor_instance, confusor_location, \
-                        geometry.generate_object_bounds(confusor_definition['dimensions'], \
-                        confusor_definition['offset'] if 'offset' in confusor_definition else None, \
-                        confusor_location['position'], confusor_location['rotation']), confusor_definition)
-                    bounds_list.append(confusor_instance['shows'][0]['boundingBox'])
+                    util.move_to_location(confusor_definition, confusor_instance, confusor_location,
+                                          geometry.generate_object_bounds(confusor_definition['dimensions'],
+                                                                          confusor_definition[
+                                                                              'offset'] if 'offset' in confusor_definition else None,
+                                                                          confusor_location['position'], confusor_location['rotation']), confusor_definition)
+                    bounds_list.append(
+                        confusor_instance['shows'][0]['boundingBox'])
 
         return target_instance, confusor_instance, target_receptacle_instance, confusor_receptacle_instance
 
-    def _find_larger_object(self, object_one: Dict[str, Any], object_two: Dict[str, Any]) -> Dict[str, Any]:
+    def _find_larger_object(
+            self, object_one: Dict[str, Any], object_two: Dict[str, Any]) -> Dict[str, Any]:
         """Return the larger of the two given objects."""
         if not object_one and not object_two:
             return None
@@ -641,46 +762,49 @@ class InteractionPair():
             return object_two
         if not object_two:
             return object_one
-        # TODO Handle case if one object has larger X and other object has larger Z
-        return object_one if (object_one['dimensions']['x'] > object_two['dimensions']['x'] or \
-                object_one['dimensions']['z'] > object_two['dimensions']['z']) else object_two
+        # TODO Handle case if one object has larger X and other object has
+        # larger Z
+        return object_one if (object_one['dimensions']['x'] > object_two['dimensions']['x'] or
+                              object_one['dimensions']['z'] > object_two['dimensions']['z']) else object_two
 
-    def _generate_confusor_location(self, confusor_definition: Dict[str, Any], target_definition: Dict[str, Any], \
-            target_template: Dict[str, Any], target_location_1: Dict[str, float], 
-            target_location_2: Dict[str, float], performer_start: Dict[str, Dict[str, float]], \
-            is_confusor_close_in_goal_1: bool, is_confusor_close_in_goal_2: bool, \
-            is_target_location_same_in_both: bool) -> Tuple[Dict[str, float], Dict[str, float]]:
+    def _generate_confusor_location(self, confusor_definition: Dict[str, Any], target_definition: Dict[str, Any],
+                                    target_template: Dict[str, Any], target_location_1: Dict[str, float],
+                                    target_location_2: Dict[str, float], performer_start: Dict[str, Dict[str, float]],
+                                    is_confusor_close_in_goal_1: bool, is_confusor_close_in_goal_2: bool,
+                                    is_target_location_same_in_both: bool) -> Tuple[Dict[str, float], Dict[str, float]]:
         """Generate and return the location for the confusor in both scenes positioned relative to the target."""
 
-        # If the target location is the same in both scenes, just generate the confusor location once.
+        # If the target location is the same in both scenes, just generate the
+        # confusor location once.
         if is_confusor_close_in_goal_1 and is_confusor_close_in_goal_2 and is_target_location_same_in_both:
-            confusor_location = self._generate_location_close_to_object(confusor_definition, target_definition, \
-                    target_location_1, performer_start)
+            confusor_location = self._generate_location_close_to_object(confusor_definition, target_definition,
+                                                                        target_location_1, performer_start)
             return confusor_location, confusor_location
 
         confusor_location_1 = None
         confusor_location_2 = None
 
         if is_confusor_close_in_goal_1:
-            confusor_location_1 = self._generate_location_close_to_object(confusor_definition, target_definition, \
-                    target_location_1, performer_start)
+            confusor_location_1 = self._generate_location_close_to_object(confusor_definition, target_definition,
+                                                                          target_location_1, performer_start)
         else:
-            confusor_location_1 = self._generate_location_far_from_object(confusor_definition, target_location_1, \
-                    performer_start)
+            confusor_location_1 = self._generate_location_far_from_object(confusor_definition, target_location_1,
+                                                                          performer_start)
 
         if is_confusor_close_in_goal_2:
-            confusor_location_2 = self._generate_location_close_to_object(confusor_definition, target_definition, \
-                    target_location_2, performer_start)
+            confusor_location_2 = self._generate_location_close_to_object(confusor_definition, target_definition,
+                                                                          target_location_2, performer_start)
         else:
-            confusor_location_2 = self._generate_location_far_from_object(confusor_definition, target_location_2, \
-                    performer_start)
+            confusor_location_2 = self._generate_location_far_from_object(confusor_definition, target_location_2,
+                                                                          performer_start)
 
-        # Add more confusor location scene options here if needed in the future.
+        # Add more confusor location scene options here if needed in the
+        # future.
 
         return confusor_location_1, confusor_location_2
 
-    def _generate_front_and_back(self, goal: InteractionGoal, object_definition: Dict[str, Any], \
-            object_rule: ObjectRule, generate_back: bool) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def _generate_front_and_back(self, goal: InteractionGoal, object_definition: Dict[str, Any],
+                                 object_rule: ObjectRule, generate_back: bool) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Generate a location both in front of and in back of the performer_start. Will modify the performer_start
         in the given goal if needed to generate the two locations. Return the front and back locations."""
 
@@ -690,10 +814,12 @@ class InteractionPair():
 
         for _ in range(util.MAX_TRIES):
             # TODO Use existing target bounds?
-            location_front = self._identify_front(object_definition, object_rule, performer_start)
+            location_front = self._identify_front(
+                object_definition, object_rule, performer_start)
             if location_front:
                 if generate_back:
-                    location_back = self._identify_back(object_definition, object_rule, performer_start)
+                    location_back = self._identify_back(
+                        object_definition, object_rule, performer_start)
                     if location_back:
                         break
                 else:
@@ -703,87 +829,99 @@ class InteractionPair():
             performer_start = goal.reset_performer_start()
 
         if not generate_back and not location_front:
-            raise exceptions.SceneException(f'{self.get_name()} cannot position performer start in front of object={object_definition}')
+            raise exceptions.SceneException(
+                f'{self.get_name()} cannot position performer start in front of object={object_definition}')
 
         if generate_back and (not location_front or not location_back):
-            raise exceptions.SceneException(f'{self.get_name()} cannot position performer start in front of and in back of object={object_definition}')
+            raise exceptions.SceneException(
+                f'{self.get_name()} cannot position performer start in front of and in back of object={object_definition}')
 
         return location_front, location_back
 
-    def _generate_location_close_to_object(self, object_definition: Dict[str, Any], target_definition: Dict[str, Any], \
-            target_location: Dict[str, float], performer_start: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+    def _generate_location_close_to_object(self, object_definition: Dict[str, Any], target_definition: Dict[str, Any],
+                                           target_location: Dict[str, float], performer_start: Dict[str, Dict[str, float]]) -> Dict[str, float]:
         """Generate and return a new location close to the given target_location."""
         # TODO Use existing target bounds?
-        location_close = geometry.get_adjacent_location(object_definition, target_definition, target_location, \
-                performer_start)
+        location_close = geometry.get_adjacent_location(object_definition, target_definition, target_location,
+                                                        performer_start)
         if not location_close:
-            raise exceptions.SceneException(f'{self.get_name()} cannot position close to target: object={object_definition} target={target_definition}')
+            raise exceptions.SceneException(
+                f'{self.get_name()} cannot position close to target: object={object_definition} target={target_definition}')
         return location_close
 
-    def _generate_location_far_from_object(self, object_definition: Dict[str, Any], target_location: Dict[str, float], \
-            performer_start: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+    def _generate_location_far_from_object(self, object_definition: Dict[str, Any], target_location: Dict[str, float],
+                                           performer_start: Dict[str, Dict[str, float]]) -> Dict[str, float]:
         """Generate and return a new location far away the given target location."""
         for _ in range(util.MAX_TRIES):
             # TODO Use existing target bounds?
-            location_far = geometry.calc_obj_pos(performer_start['position'], [], object_definition)
-            if not geometry.are_adjacent(target_location, location_far, distance = \
-                    geometry.MIN_OBJECTS_SEPARATION_DISTANCE):
+            location_far = geometry.calc_obj_pos(
+                performer_start['position'], [], object_definition)
+            if not geometry.are_adjacent(
+                    target_location, location_far, distance=geometry.MIN_OBJECTS_SEPARATION_DISTANCE):
                 break
             location_far = None
         if not location_far:
-            raise exceptions.SceneException(f'{self.get_name()} cannot position far from target: object={object_definition} target={target_location}')
+            raise exceptions.SceneException(
+                f'{self.get_name()} cannot position far from target: object={object_definition} target={target_location}')
         return location_far
 
-    def _generate_obstructor_location(self, show_obstructor: bool, target_definition: Dict[str, Any], \
-            target_location: Dict[str, float], obstructor_definition: Dict[str, Any], \
-            performer_start: Dict[str, Dict[str, float]]) -> Dict[str, float]:
+    def _generate_obstructor_location(self, show_obstructor: bool, target_definition: Dict[str, Any],
+                                      target_location: Dict[str, float], obstructor_definition: Dict[str, Any],
+                                      performer_start: Dict[str, Dict[str, float]]) -> Dict[str, float]:
         """If needed, find and return a location for the given obstructor directly in front of the given target."""
 
         if show_obstructor and obstructor_definition:
             # Generate an adjacent location so that the obstructor is between the target and the performer start.
             # TODO Use existing target bounds?
-            obstructor_location = geometry.get_adjacent_location(obstructor_definition, target_definition, \
-                    target_location, performer_start, True)
+            obstructor_location = geometry.get_adjacent_location(obstructor_definition, target_definition,
+                                                                 target_location, performer_start, True)
             if not obstructor_location:
-                raise exceptions.SceneException(f'{self.get_name()} cannot position target directly behind obstructor: performer_start={performer_start} target={target_definition} obstructor={obstructor_definition}')
+                raise exceptions.SceneException(
+                    f'{self.get_name()} cannot position target directly behind obstructor: performer_start={performer_start} target={target_definition} obstructor={obstructor_definition}')
             return obstructor_location
 
         return None
 
-    def _generate_random_location(self, goal: InteractionGoal, object_definition: Dict[str, Any], \
-            object_rule: ObjectRule, target_list: List[Dict[str, Any]], \
-            bounds_list: List[List[Dict[str, float]]]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def _generate_random_location(self, goal: InteractionGoal, object_definition: Dict[str, Any],
+                                  object_rule: ObjectRule, target_list: List[Dict[str, Any]],
+                                  bounds_list: List[List[Dict[str, float]]]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Generate a random location and return it twice."""
 
         for _ in range(util.MAX_TRIES):
             # TODO Use existing target bounds?
-            object_location, bounds = object_rule.choose_location(object_definition, goal.get_performer_start(), \
-                    bounds_list)
-            if object_rule.validate_location(object_location, target_list, goal.get_performer_start()):
+            object_location, bounds = object_rule.choose_location(object_definition, goal.get_performer_start(),
+                                                                  bounds_list)
+            if object_rule.validate_location(
+                    object_location, target_list, goal.get_performer_start()):
                 break
             object_location = None
         if not object_location:
-            raise exceptions.SceneException(f'{self.get_name()} cannot randomly position object={object_definition}')
+            raise exceptions.SceneException(
+                f'{self.get_name()} cannot randomly position object={object_definition}')
         return object_location, object_location
 
-    def _identify_front(self, object_definition: Dict[str, Any], object_rule: ObjectRule, \
-            performer_start: Dict[str, float]) -> Dict[str, Any]:
+    def _identify_front(self, object_definition: Dict[str, Any], object_rule: ObjectRule,
+                        performer_start: Dict[str, float]) -> Dict[str, Any]:
         """Find and return a location in front of the given performer_start."""
 
         for _ in range(util.MAX_TRIES):
-            location_front = geometry.get_location_in_front_of_performer(performer_start, object_definition)
-            if location_front and object_rule.validate_location(location_front, [], performer_start):
+            location_front = geometry.get_location_in_front_of_performer(
+                performer_start, object_definition)
+            if location_front and object_rule.validate_location(
+                    location_front, [], performer_start):
                 break
             location_front = None
         return location_front
 
-    def _identify_back(self, object_definition: Dict[str, Any], object_rule: ObjectRule, \
-            performer_start: Dict[str, float]) -> Dict[str, Any]:
+    def _identify_back(self, object_definition: Dict[str, Any], object_rule: ObjectRule,
+                       performer_start: Dict[str, float]) -> Dict[str, Any]:
         """Find and return a location in back of the given performer_start."""
 
         for _ in range(util.MAX_TRIES):
-            location_back = geometry.get_location_in_back_of_performer(performer_start, object_definition)
-            if location_back and object_rule.validate_location(location_back, [], performer_start):
+            location_back = geometry.get_location_in_back_of_performer(
+                performer_start, object_definition)
+            if location_back and object_rule.validate_location(
+                    location_back, [], performer_start):
                 break
             location_back = None
         return location_back
@@ -796,6 +934,7 @@ class InteractionPair():
         """Return if the given scene options bool_pair is true in the second goal."""
         return bool_pair == BoolPairOption.NO_YES or bool_pair == BoolPairOption.YES_YES
 
+
 class Pair1(InteractionPair):
     """(1A) The Target Object is immediately visible (starting in view of
     the camera) OR (1B) behind the camera (must rotate to see the
@@ -803,11 +942,12 @@ class Pair1(InteractionPair):
     container (like a box). See MCS-232.
     """
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
         containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
-                BoolPairOption.NO_NO
-        super(Pair1, self).__init__(1, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = containerize, target_location = TargetLocationPairOption.FRONT_BACK))
+            BoolPairOption.NO_NO
+        super(Pair1, self).__init__(1, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=containerize, target_location=TargetLocationPairOption.FRONT_BACK))
 
 
 class Pair6(InteractionPair):
@@ -820,13 +960,14 @@ class Pair6(InteractionPair):
     used in that pair. See MCS-233.
     """
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
         containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
-                BoolPairOption.NO_NO
-        super(Pair6, self).__init__(6, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = containerize, target_location = TargetLocationPairOption.FRONT_BACK, \
-                confusor = BoolPairOption.YES_YES, confusor_containerize = containerize, \
-                confusor_location = ConfusorLocationPairOption.BACK_FRONT))
+            BoolPairOption.NO_NO
+        super(Pair6, self).__init__(6, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=containerize, target_location=TargetLocationPairOption.FRONT_BACK,
+            confusor=BoolPairOption.YES_YES, confusor_containerize=containerize,
+            confusor_location=ConfusorLocationPairOption.BACK_FRONT))
 
 
 class Pair2(InteractionPair):
@@ -836,24 +977,26 @@ class Pair2(InteractionPair):
     box). See MCS-239.
     """
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
         containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
-                BoolPairOption.NO_NO
+            BoolPairOption.NO_NO
         # TODO MCS-320 Let target be containerized
         containerize = BoolPairOption.NO_NO
-        super(Pair2, self).__init__(2, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = containerize, target_location = TargetLocationPairOption.FRONT_FRONT, \
-                obstructor = ObstructorPairOption.NONE_VISION))
+        super(Pair2, self).__init__(2, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=containerize, target_location=TargetLocationPairOption.FRONT_FRONT,
+            obstructor=ObstructorPairOption.NONE_VISION))
 
 
 class Pair7(InteractionPair):
     """(7) Like pair (6), but the Target Object is always inside a container, and the Similar Object is never inside a
     container."""
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
-        super(Pair7, self).__init__(7, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = BoolPairOption.YES_YES, target_location = TargetLocationPairOption.FRONT_BACK, \
-                confusor = BoolPairOption.YES_YES, confusor_location = ConfusorLocationPairOption.BACK_FRONT))
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
+        super(Pair7, self).__init__(7, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=BoolPairOption.YES_YES, target_location=TargetLocationPairOption.FRONT_BACK,
+            confusor=BoolPairOption.YES_YES, confusor_location=ConfusorLocationPairOption.BACK_FRONT))
 
 
 class Pair3(InteractionPair):
@@ -865,12 +1008,13 @@ class Pair3(InteractionPair):
     that pair.
     """
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
         containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
-                BoolPairOption.NO_NO
-        super(Pair3, self).__init__(3, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = containerize, confusor = BoolPairOption.NO_YES, \
-                confusor_containerize = containerize, confusor_location = ConfusorLocationPairOption.NONE_CLOSE))
+            BoolPairOption.NO_NO
+        super(Pair3, self).__init__(3, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=containerize, confusor=BoolPairOption.NO_YES,
+            confusor_containerize=containerize, confusor_location=ConfusorLocationPairOption.NONE_CLOSE))
 
 
 class Pair4(InteractionPair):
@@ -880,12 +1024,13 @@ class Pair4(InteractionPair):
     containers, but only if the container is big enough to hold both
     individually; otherwise, no container will be used in that pair."""
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
         containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
-                BoolPairOption.NO_NO
-        super(Pair4, self).__init__(4, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = containerize, confusor = BoolPairOption.NO_YES, \
-                confusor_containerize = containerize, confusor_location = ConfusorLocationPairOption.NONE_FAR))
+            BoolPairOption.NO_NO
+        super(Pair4, self).__init__(4, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=containerize, confusor=BoolPairOption.NO_YES,
+            confusor_containerize=containerize, confusor_location=ConfusorLocationPairOption.NONE_FAR))
 
 
 class Pair5(InteractionPair):
@@ -896,22 +1041,24 @@ class Pair5(InteractionPair):
     container will be used in that pair.
     """
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
         containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
-                BoolPairOption.NO_NO
-        super(Pair5, self).__init__(5, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = containerize, confusor = BoolPairOption.YES_YES, \
-                confusor_containerize = containerize, confusor_location = ConfusorLocationPairOption.CLOSE_FAR))
+            BoolPairOption.NO_NO
+        super(Pair5, self).__init__(5, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=containerize, confusor=BoolPairOption.YES_YES,
+            confusor_containerize=containerize, confusor_location=ConfusorLocationPairOption.CLOSE_FAR))
 
 
 class Pair8(InteractionPair):
     """(8A) The Target Object is positioned adjacent to a Similar Object OR (8B) the Target Object is positioned
     adjacent to a Similar Object, but the Target Object is inside a container. See MCS-238."""
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
-        super(Pair8, self).__init__(8, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = BoolPairOption.NO_YES, confusor = BoolPairOption.YES_YES, \
-                confusor_location = ConfusorLocationPairOption.CLOSE_CLOSE))
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
+        super(Pair8, self).__init__(8, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=BoolPairOption.NO_YES, confusor=BoolPairOption.YES_YES,
+            confusor_location=ConfusorLocationPairOption.CLOSE_CLOSE))
 
 
 class Pair9(InteractionPair):
@@ -921,32 +1068,34 @@ class Pair9(InteractionPair):
     the coffee table, so to get to it, the AI would need to maneuver around the coffee table.  For each pair, the
     object may or may not be inside an open container (like a box)."""
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
         containerize = BoolPairOption.YES_YES if random.random() < InteractionGoal.OBJECT_RECEPTACLE_CHANCE else \
-                BoolPairOption.NO_NO
+            BoolPairOption.NO_NO
         # TODO MCS-320 Let target be containerized
         containerize = BoolPairOption.NO_NO
-        super(Pair9, self).__init__(9, template, goal_name, find_path, options = SceneOptions( \
-                target_containerize = containerize, target_location = TargetLocationPairOption.FRONT_FRONT, \
-                obstructor = ObstructorPairOption.NONE_NAVIGATION))
+        super(Pair9, self).__init__(9, template, goal_name, find_path, options=SceneOptions(
+            target_containerize=containerize, target_location=TargetLocationPairOption.FRONT_FRONT,
+            obstructor=ObstructorPairOption.NONE_NAVIGATION))
 
 
 class Pair11(InteractionPair):
     """(11A) The Target Object and a Similar Object are positioned adjacent to each other and immediately visible OR
     (11B) the Target Object and a Similar Object are positioned adjacent to each other and NOT immediately visible."""
 
-    def __init__(self, template: Dict[str, Any], goal_name: str = None, find_path: bool = False):
-        super(Pair11, self).__init__(11, template, goal_name, find_path, options = SceneOptions( \
-                target_location = TargetLocationPairOption.FRONT_BACK, confusor = BoolPairOption.YES_YES,
-                confusor_location = ConfusorLocationPairOption.CLOSE_CLOSE))
+    def __init__(self, template: Dict[str, Any],
+                 goal_name: str = None, find_path: bool = False):
+        super(Pair11, self).__init__(11, template, goal_name, find_path, options=SceneOptions(
+            target_location=TargetLocationPairOption.FRONT_BACK, confusor=BoolPairOption.YES_YES,
+            confusor_location=ConfusorLocationPairOption.CLOSE_CLOSE))
 
 
 INTERACTION_PAIR_CLASSES = [
     Pair1,
     Pair2,
     Pair3,
-    #Pair4, # Won't use
-    #Pair5, # Won't use
+    # Pair4, # Won't use
+    # Pair5, # Won't use
     Pair6,
     Pair7,
     Pair8,
@@ -962,5 +1111,5 @@ def get_pair_class(name: str) -> Type[InteractionPair]:
 
 
 def get_pair_types() -> List[str]:
-    return [klass.__name__.replace('Pair', '') for klass in INTERACTION_PAIR_CLASSES]
-
+    return [klass.__name__.replace('Pair', '')
+            for klass in INTERACTION_PAIR_CLASSES]

--- a/scene_generator/pairs_test.py
+++ b/scene_generator/pairs_test.py
@@ -11,7 +11,11 @@ import pairs
 import util
 
 
-MAX_DIMENSION = max(geometry.ROOM_X_MAX - geometry.ROOM_X_MIN, geometry.ROOM_Z_MAX - geometry.ROOM_Z_MIN)
+MAX_DIMENSION = max(
+    geometry.ROOM_X_MAX -
+    geometry.ROOM_X_MIN,
+    geometry.ROOM_Z_MAX -
+    geometry.ROOM_Z_MIN)
 BODY_TEMPLATE = {
     'wallMaterial': 'test_wall_material',
     'wallColors': ['test_wall_color'],
@@ -41,26 +45,33 @@ def verify_confusor(target, confusor):
     is_same_color = set(target['color']) == set(confusor['color'])
     is_same_shape = target['shape'] == confusor['shape']
     is_same_size = target['size'] == confusor['size'] and \
-            (target['dimensions']['x'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['x'] <= \
-            (target['dimensions']['x'] + util.MAX_SIZE_DIFFERENCE) and \
-            (target['dimensions']['y'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['y'] <= \
-            (target['dimensions']['y'] + util.MAX_SIZE_DIFFERENCE) and \
-            (target['dimensions']['z'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['z'] <= \
-            (target['dimensions']['z'] + util.MAX_SIZE_DIFFERENCE)
-    if ((not is_same_color and not is_same_shape) or (not is_same_color and not is_same_size) or \
+        (target['dimensions']['x'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['x'] <= \
+        (target['dimensions']['x'] + util.MAX_SIZE_DIFFERENCE) and \
+        (target['dimensions']['y'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['y'] <= \
+        (target['dimensions']['y'] + util.MAX_SIZE_DIFFERENCE) and \
+        (target['dimensions']['z'] - util.MAX_SIZE_DIFFERENCE) <= confusor['dimensions']['z'] <= \
+        (target['dimensions']['z'] + util.MAX_SIZE_DIFFERENCE)
+    if ((not is_same_color and not is_same_shape) or (not is_same_color and not is_same_size) or
             (not is_same_shape and not is_same_size) or (is_same_color and is_same_shape and is_same_size)):
-        print(f'[ERROR] CONFUSOR SHOULD BE THE SAME AS THE TARGET IN ALL EXCEPT ONE: color={is_same_color} shape={is_same_shape} size={is_same_size}\ntarget={target}\nconfusor={confusor}')
+        print(
+            f'[ERROR] CONFUSOR SHOULD BE THE SAME AS THE TARGET IN ALL EXCEPT ONE: color={is_same_color} shape={is_same_shape} size={is_same_size}\ntarget={target}\nconfusor={confusor}')
         return False
     return True
 
 
-def verify_immediately_visible(performer_start, object_list, target, name = 'target'):
-    target_or_parent = get_parent(target, object_list) if 'locationParent' in target else target
+def verify_immediately_visible(
+        performer_start, object_list, target, name='target'):
+    target_or_parent = get_parent(
+        target, object_list) if 'locationParent' in target else target
     target_poly = geometry.get_bounding_polygon(target_or_parent)
 
     view_line = shapely.geometry.LineString([[0, 0], [0, MAX_DIMENSION]])
-    view_line = affinity.rotate(view_line, -performer_start['rotation']['y'], origin=(0, 0))
-    view_line = affinity.translate(view_line, performer_start['position']['x'], performer_start['position']['z'])
+    view_line = affinity.rotate(view_line, -
+                                performer_start['rotation']['y'], origin=(0, 0))
+    view_line = affinity.translate(
+        view_line,
+        performer_start['position']['x'],
+        performer_start['position']['z'])
 
     if not target_poly.intersection(view_line):
         print(f'[ERROR] {name.upper()} SHOULD BE VISIBLE IN FRONT OF PERFORMER:\n{name}={target_or_parent}\nperformer_start={performer_start}')
@@ -70,53 +81,69 @@ def verify_immediately_visible(performer_start, object_list, target, name = 'tar
     for object_instance in object_list:
         if object_instance['id'] not in ignore_id_list:
             object_poly = geometry.get_bounding_polygon(object_instance)
-            if geometry.does_fully_obstruct_target(performer_start['position'], target_or_parent, object_poly):
-                print(f'[ERROR] NON-{name.upper()} SHOULD NOT OBSTRUCT {name.upper()}:\n{name}={target_or_parent}\nnon-{name}={object_instance}\nperformer_start={performer_start}')
+            if geometry.does_fully_obstruct_target(
+                    performer_start['position'], target_or_parent, object_poly):
+                print(
+                    f'[ERROR] NON-{name.upper()} SHOULD NOT OBSTRUCT {name.upper()}:\n{name}={target_or_parent}\nnon-{name}={object_instance}\nperformer_start={performer_start}')
                 return False
 
     return True
 
 
-def verify_not_immediately_visible(performer_start, object_list, target, name = 'target'):
-    result = verify_immediately_visible(performer_start, object_list, target, name)
+def verify_not_immediately_visible(
+        performer_start, object_list, target, name='target'):
+    result = verify_immediately_visible(
+        performer_start, object_list, target, name)
     if result:
-        target_or_parent = get_parent(target, object_list) if 'locationParent' in target else target
+        target_or_parent = get_parent(
+            target, object_list) if 'locationParent' in target else target
         print(f'[ERROR] {name.upper()} SHOULD NOT BE VISIBLE IN FRONT OF PERFORMER:\n{name}={target_or_parent}\nperformer_start={performer_start}')
     return not result
 
 
-def verify_obstructor(goal, scene, obstruct_vision = False):
+def verify_obstructor(goal, scene, obstruct_vision=False):
     performer_start = goal.get_performer_start()
     target = goal.get_target_list()[0]
     obstructor = goal.get_obstructor_list()[0]
     dimensions = obstructor['closedDimensions'] if 'closedDimensions' in obstructor else obstructor['dimensions']
 
     is_bigger = (target['dimensions']['x'] <= dimensions['x'] or target['dimensions']['z'] <= dimensions['z']) and \
-            (not obstruct_vision or target['dimensions']['y'] <= dimensions['y'])
+        (not obstruct_vision or target['dimensions']['y'] <= dimensions['y'])
     if not is_bigger:
-        print(f'[ERROR] OBSTRUCTOR SHOULD BE BIGGER THAN TARGET:\ntarget={target}\nobstructor={obstructor}')
+        print(
+            f'[ERROR] OBSTRUCTOR SHOULD BE BIGGER THAN TARGET:\ntarget={target}\nobstructor={obstructor}')
         return False
 
     obstructor_poly = geometry.get_bounding_polygon(obstructor)
-    if not geometry.does_fully_obstruct_target(performer_start['position'], target, obstructor_poly):
-        print(f'[ERROR] OBSTRUCTOR SHOULD OBSTRUCT TARGET:\ntarget={target}\nobstructor={obstructor}')
+    if not geometry.does_fully_obstruct_target(
+            performer_start['position'], target, obstructor_poly):
+        print(
+            f'[ERROR] OBSTRUCTOR SHOULD OBSTRUCT TARGET:\ntarget={target}\nobstructor={obstructor}')
         return False
 
     object_list = scene['objects']
-    ignore_id_list = [obstructor['id'], target['id'], target['locationParent'] if 'locationParent' in target else None]
+    ignore_id_list = [
+        obstructor['id'],
+        target['id'],
+        target['locationParent'] if 'locationParent' in target else None]
     for object_instance in object_list:
         if object_instance['id'] not in ignore_id_list:
             object_poly = geometry.get_bounding_polygon(object_instance)
-            if geometry.does_fully_obstruct_target(performer_start['position'], target, object_poly):
-                print(f'[ERROR] NON-OBSTRUCTOR SHOULD NOT OBSTRUCT TARGET:\nobject={object_instance}\ntarget={target}\nperformer_start={performer_start}')
+            if geometry.does_fully_obstruct_target(
+                    performer_start['position'], target, object_poly):
+                print(
+                    f'[ERROR] NON-OBSTRUCTOR SHOULD NOT OBSTRUCT TARGET:\nobject={object_instance}\ntarget={target}\nperformer_start={performer_start}')
                 return False
 
     return True
 
 
-def verify_same_object_list(name, object_list_1, object_list_2, ignore_id_list):
-    modified_object_list_1 = [obj for obj in object_list_1 if obj['id'] not in ignore_id_list]
-    modified_object_list_2 = [obj for obj in object_list_2 if obj['id'] not in ignore_id_list]
+def verify_same_object_list(
+        name, object_list_1, object_list_2, ignore_id_list):
+    modified_object_list_1 = [
+        obj for obj in object_list_1 if obj['id'] not in ignore_id_list]
+    modified_object_list_2 = [
+        obj for obj in object_list_2 if obj['id'] not in ignore_id_list]
     if len(modified_object_list_1) != len(modified_object_list_2):
         print(f'[ERROR] {name.upper()} LIST SHOULD BE THE SAME LENGTH')
         return False
@@ -124,7 +151,8 @@ def verify_same_object_list(name, object_list_1, object_list_2, ignore_id_list):
         object_instance_1 = modified_object_list_1[index]
         object_instance_2 = modified_object_list_2[index]
         if object_instance_1 != object_instance_2:
-            print(f'[ERROR] {name.upper()} SHOULD BE THE SAME:\n{name}_1={object_instance_1}\n{name}_2={object_instance_2}')
+            print(
+                f'[ERROR] {name.upper()} SHOULD BE THE SAME:\n{name}_1={object_instance_1}\n{name}_2={object_instance_2}')
             return False
     return True
 
@@ -134,21 +162,24 @@ def verify_same_object(name, object_1, object_2, difference_list):
     key_set_2 = set(object_2.keys())
     for key in key_set_1.union(key_set_2):
         if key in difference_list:
-            if (key in object_1 and key not in object_2) or (key not in object_1 and key in object_2):
+            if (key in object_1 and key not in object_2) or (
+                    key not in object_1 and key in object_2):
                 pass
             elif (key not in object_1 and key not in object_2) or object_1[key] == object_2[key]:
-                print(f'[ERROR] "{key}" PROPERTY SHOULD NOT BE THE SAME:\n{name}_1={object_1}\n{name}_2={object_2}')
+                print(
+                    f'[ERROR] "{key}" PROPERTY SHOULD NOT BE THE SAME:\n{name}_1={object_1}\n{name}_2={object_2}')
                 return False
         else:
             if key not in object_1 or key not in object_2 or object_1[key] != object_2[key]:
-                print(f'[ERROR] "{key}" PROPERTY SHOULD BE THE SAME:\n{name}_1={object_1}\n{name}_2={object_2}')
+                print(
+                    f'[ERROR] "{key}" PROPERTY SHOULD BE THE SAME:\n{name}_1={object_1}\n{name}_2={object_2}')
                 return False
     return True
 
 
-def verify_pair(pair, scene_1, scene_2, target_same_position = True, confusor_same_position = True, \
-        target_parent_same_position = True, confusor_parent_same_position = True, target_parent_same = True, \
-        confusor_parent_same = True):
+def verify_pair(pair, scene_1, scene_2, target_same_position=True, confusor_same_position=True,
+                target_parent_same_position=True, confusor_parent_same_position=True, target_parent_same=True,
+                confusor_parent_same=True):
     assert scene_1
     assert scene_2
 
@@ -158,70 +189,83 @@ def verify_pair(pair, scene_1, scene_2, target_same_position = True, confusor_sa
     performer_start_2 = pair._goal_2.get_performer_start()
     assert performer_start_2
     if performer_start_1 != performer_start_2:
-        print(f'[ERROR] performer_start SHOULD BE THE SAME: {performer_start_1} != {performer_start_2}')
+        print(
+            f'[ERROR] performer_start SHOULD BE THE SAME: {performer_start_1} != {performer_start_2}')
         return False
 
-    performer_start_poly = geometry.rect_to_poly(geometry.find_performer_rect(performer_start_1['position']))
+    performer_start_poly = geometry.rect_to_poly(
+        geometry.find_performer_rect(
+            performer_start_1['position']))
     for object_instance in scene_1['objects']:
         object_poly = geometry.get_bounding_polygon(object_instance)
         if object_poly.intersects(performer_start_poly):
-            print(f'[ERROR] performer_start SHOULD NOT BE INSIDE AN OBJECT:\nperformer_start_poly={performer_start_poly}\nobject_poly={object_poly}')
+            print(
+                f'[ERROR] performer_start SHOULD NOT BE INSIDE AN OBJECT:\nperformer_start_poly={performer_start_poly}\nobject_poly={object_poly}')
             return False
 
-    # Ensure the target object in each scene is the same, except for expected differences.
+    # Ensure the target object in each scene is the same, except for expected
+    # differences.
     target_1 = pair._goal_1.get_target_list()[0]
     assert target_1
     print(f'[DEBUG] target_1={target_1}')
     target_2 = pair._goal_2.get_target_list()[0]
     assert target_2
     print(f'[DEBUG] target_2={target_2}')
-    if not verify_same_object('target', target_1, target_2, ([] if target_same_position else ['shows']) + \
-            ([] if target_parent_same else ['locationParent'])):
+    if not verify_same_object('target', target_1, target_2, ([] if target_same_position else ['shows']) +
+                              ([] if target_parent_same else ['locationParent'])):
         return False
 
-    # If the target in each scene has a parent, ensure each target's parent is the same.
-    target_parent_1 = get_parent(target_1, scene_1['objects']) if 'locationParent' in target_1 else None
+    # If the target in each scene has a parent, ensure each target's parent is
+    # the same.
+    target_parent_1 = get_parent(
+        target_1, scene_1['objects']) if 'locationParent' in target_1 else None
     print(f'[DEBUG] target_parent_1={target_parent_1}')
-    target_parent_2 = get_parent(target_2, scene_2['objects']) if 'locationParent' in target_2 else None
+    target_parent_2 = get_parent(
+        target_2, scene_2['objects']) if 'locationParent' in target_2 else None
     print(f'[DEBUG] target_parent_2={target_parent_2}')
     if target_parent_1 and target_parent_2 and target_parent_same:
-        if not verify_same_object('target_parent', target_parent_1, target_parent_2, \
-                [] if target_parent_same_position else ['shows']):
+        if not verify_same_object('target_parent', target_parent_1, target_parent_2,
+                                  [] if target_parent_same_position else ['shows']):
             return False
 
     # If a scene has a confusor, verify that it's a confusor of the target.
-    confusor_1 = pair._goal_1.get_confusor_list()[0] if len(pair._goal_1.get_confusor_list()) > 0 else None
+    confusor_1 = pair._goal_1.get_confusor_list()[0] if len(
+        pair._goal_1.get_confusor_list()) > 0 else None
     print(f'[DEBUG] confusor_1={confusor_1}')
     if confusor_1 and not verify_confusor(target_1, confusor_1):
         return False
-    confusor_2 = pair._goal_2.get_confusor_list()[0] if len(pair._goal_2.get_confusor_list()) > 0 else None
+    confusor_2 = pair._goal_2.get_confusor_list()[0] if len(
+        pair._goal_2.get_confusor_list()) > 0 else None
     print(f'[DEBUG] confusor_2={confusor_2}')
     if confusor_2 and not verify_confusor(target_2, confusor_2):
         return False
     if confusor_1 and confusor_2:
-        if not verify_same_object('confusor', confusor_1, confusor_2, ([] if confusor_same_position else ['shows']) + \
-                ([] if confusor_parent_same else ['locationParent'])):
+        if not verify_same_object('confusor', confusor_1, confusor_2, ([] if confusor_same_position else ['shows']) +
+                                  ([] if confusor_parent_same else ['locationParent'])):
             return False
 
-    # If each scene has a confusor with a parent, ensure each confusor's parent is the same.
+    # If each scene has a confusor with a parent, ensure each confusor's
+    # parent is the same.
     confusor_parent_1 = get_parent(confusor_1, scene_1['objects']) if (confusor_1 and 'locationParent' in confusor_1) \
-            else None
+        else None
     print(f'[DEBUG] confusor_parent_1={confusor_parent_1}')
     confusor_parent_2 = get_parent(confusor_2, scene_2['objects']) if (confusor_2 and 'locationParent' in confusor_2) \
-            else None
+        else None
     print(f'[DEBUG] confusor_parent_2={confusor_parent_2}')
     if confusor_parent_1 and confusor_parent_2 and confusor_parent_same:
-        if not verify_same_object('confusor_parent', confusor_parent_1, confusor_parent_2, \
-                [] if confusor_parent_same_position else ['shows']):
+        if not verify_same_object('confusor_parent', confusor_parent_1, confusor_parent_2,
+                                  [] if confusor_parent_same_position else ['shows']):
             return False
 
-    target_parent_id = target_parent_1['id'] if target_parent_1 else (target_parent_2['id'] if target_parent_2 else \
-            None)
-    confusor_id = confusor_1['id'] if confusor_1 else (confusor_2['id'] if confusor_2 else None)
-    confusor_parent_id = confusor_parent_1['id'] if confusor_parent_1 else (confusor_parent_2['id'] if \
-            confusor_parent_2 else None)
+    target_parent_id = target_parent_1['id'] if target_parent_1 else (target_parent_2['id'] if target_parent_2 else
+                                                                      None)
+    confusor_id = confusor_1['id'] if confusor_1 else (
+        confusor_2['id'] if confusor_2 else None)
+    confusor_parent_id = confusor_parent_1['id'] if confusor_parent_1 else (confusor_parent_2['id'] if
+                                                                            confusor_parent_2 else None)
 
-    # Ignore the IDs of the target, confusor, and target/confusor parent, because they may change across the scenes.
+    # Ignore the IDs of the target, confusor, and target/confusor parent,
+    # because they may change across the scenes.
     ignore_id_list = [object_id for object_id in [
         target_1['id'],
         target_2['id'],
@@ -236,7 +280,8 @@ def verify_pair(pair, scene_1, scene_2, target_same_position = True, confusor_sa
     # Ensure the random distractors are the same across the scenes.
     distractor_list_1 = pair._goal_1.get_distractor_list()
     distractor_list_2 = pair._goal_2.get_distractor_list()
-    if not verify_same_object_list('distractor', distractor_list_1, distractor_list_2, ignore_id_list):
+    if not verify_same_object_list(
+            'distractor', distractor_list_1, distractor_list_2, ignore_id_list):
         return False
 
     return True
@@ -247,19 +292,29 @@ def test_Pair1():
     assert pair
     scene_1, scene_2 = pair.get_scenes()
     containerize = pair._options.target_containerize == pairs.BoolPairOption.YES_YES
-    # The target's position is the same if it's in a box because only its box will have a different position.
-    assert verify_pair(pair, scene_1, scene_2, target_same_position = containerize, target_parent_same_position = False)
+    # The target's position is the same if it's in a box because only its box
+    # will have a different position.
+    assert verify_pair(
+        pair,
+        scene_1,
+        scene_2,
+        target_same_position=containerize,
+        target_parent_same_position=False)
 
     target_1 = pair._goal_1.get_target_list()[0]
     target_2 = pair._goal_2.get_target_list()[0]
     if containerize:
-        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
-                get_parent(target_1, scene_1['objects']))
-        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
-                get_parent(target_2, scene_2['objects']))
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'],
+                                          get_parent(target_1, scene_1['objects']))
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'],
+                                              get_parent(target_2, scene_2['objects']))
     else:
-        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
-        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+        assert verify_immediately_visible(
+            pair._goal_1.get_performer_start(),
+            scene_1['objects'],
+            target_1)
+        assert verify_not_immediately_visible(
+            pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
 
     assert len(pair._goal_1.get_confusor_list()) == 0
     assert len(pair._goal_2.get_confusor_list()) == 0
@@ -277,20 +332,24 @@ def test_Pair2():
     target_1 = pair._goal_1.get_target_list()[0]
     target_2 = pair._goal_2.get_target_list()[0]
     if containerize:
-        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
-                get_parent(target_1, scene_1['objects']))
-        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
-                get_parent(target_2, scene_2['objects']))
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'],
+                                          get_parent(target_1, scene_1['objects']))
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'],
+                                              get_parent(target_2, scene_2['objects']))
     else:
-        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
-        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+        assert verify_immediately_visible(
+            pair._goal_1.get_performer_start(),
+            scene_1['objects'],
+            target_1)
+        assert verify_not_immediately_visible(
+            pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
 
     assert len(pair._goal_1.get_confusor_list()) == 0
     assert len(pair._goal_2.get_confusor_list()) == 0
     assert len(pair._goal_1.get_obstructor_list()) == 0
     assert len(pair._goal_2.get_obstructor_list()) == 1
 
-    assert verify_obstructor(pair._goal_2, scene_2, obstruct_vision = True)
+    assert verify_obstructor(pair._goal_2, scene_2, obstruct_vision=True)
 
 
 def test_Pair3():
@@ -298,8 +357,14 @@ def test_Pair3():
     assert pair
     scene_1, scene_2 = pair.get_scenes()
     containerize = pair._options.target_containerize == pairs.BoolPairOption.YES_YES
-    # The target's position is NOT the same if it's in a box because of how the confusor's positioned next to it.
-    assert verify_pair(pair, scene_1, scene_2, target_same_position = (not containerize))
+    # The target's position is NOT the same if it's in a box because of how
+    # the confusor's positioned next to it.
+    assert verify_pair(
+        pair,
+        scene_1,
+        scene_2,
+        target_same_position=(
+            not containerize))
 
     assert len(pair._goal_1.get_confusor_list()) == 0
     assert len(pair._goal_2.get_confusor_list()) == 1
@@ -337,8 +402,8 @@ def test_Pair4():
     if containerize:
         assert target_1['locationParent']
         assert target_2['locationParent'] != confusor_2['locationParent']
-        assert not geometry.are_adjacent(get_parent(target_2, scene_2['objects']), \
-                get_parent(confusor_2, scene_2['objects']))
+        assert not geometry.are_adjacent(get_parent(target_2, scene_2['objects']),
+                                         get_parent(confusor_2, scene_2['objects']))
     else:
         assert not 'locationParent' in target_1
         assert not 'locationParent' in target_2
@@ -351,9 +416,10 @@ def test_Pair5():
     assert pair
     scene_1, scene_2 = pair.get_scenes()
     containerize = pair._options.target_containerize == pairs.BoolPairOption.YES_YES
-    # The target's position is NOT the same if it's in a box because of how the confusor's positioned next to it.
-    assert verify_pair(pair, scene_1, scene_2, target_same_position = (not containerize), \
-            confusor_same_position = False, confusor_parent_same = False)
+    # The target's position is NOT the same if it's in a box because of how
+    # the confusor's positioned next to it.
+    assert verify_pair(pair, scene_1, scene_2, target_same_position=(not containerize),
+                       confusor_same_position=False, confusor_parent_same=False)
 
     assert len(pair._goal_1.get_confusor_list()) == 1
     assert len(pair._goal_2.get_confusor_list()) == 1
@@ -368,8 +434,8 @@ def test_Pair5():
     if containerize:
         assert target_1['locationParent'] == confusor_1['locationParent']
         assert target_2['locationParent'] != confusor_2['locationParent']
-        assert not geometry.are_adjacent(get_parent(target_2, scene_2['objects']), \
-                get_parent(confusor_2, scene_2['objects']))
+        assert not geometry.are_adjacent(get_parent(target_2, scene_2['objects']),
+                                         get_parent(confusor_2, scene_2['objects']))
     else:
         assert not 'locationParent' in target_1
         assert not 'locationParent' in target_2
@@ -383,10 +449,11 @@ def test_Pair6():
     assert pair
     scene_1, scene_2 = pair.get_scenes()
     containerize = pair._options.target_containerize == pairs.BoolPairOption.YES_YES
-    # The object's position is the same if it's in a box because only its box will have a different position.
-    assert verify_pair(pair, scene_1, scene_2, target_same_position = containerize, \
-            confusor_same_position = containerize, target_parent_same_position = False,
-            confusor_parent_same_position = False)
+    # The object's position is the same if it's in a box because only its box
+    # will have a different position.
+    assert verify_pair(pair, scene_1, scene_2, target_same_position=containerize,
+                       confusor_same_position=containerize, target_parent_same_position=False,
+                       confusor_parent_same_position=False)
 
     assert len(pair._goal_1.get_confusor_list()) == 1
     assert len(pair._goal_2.get_confusor_list()) == 1
@@ -400,33 +467,43 @@ def test_Pair6():
     if containerize:
         assert target_1['locationParent'] != confusor_1['locationParent']
         assert target_2['locationParent'] != confusor_2['locationParent']
-        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
-                get_parent(target_1, scene_1['objects']))
-        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
-                get_parent(target_2, scene_2['objects']))
-        assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
-                get_parent(confusor_1, scene_1['objects']), 'confusor')
-        assert verify_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
-                get_parent(confusor_2, scene_2['objects']), 'confusor')
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'],
+                                          get_parent(target_1, scene_1['objects']))
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'],
+                                              get_parent(target_2, scene_2['objects']))
+        assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'],
+                                              get_parent(confusor_1, scene_1['objects']), 'confusor')
+        assert verify_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'],
+                                          get_parent(confusor_2, scene_2['objects']), 'confusor')
     else:
         assert not 'locationParent' in target_1
         assert not 'locationParent' in target_2
         assert not 'locationParent' in confusor_1
         assert not 'locationParent' in confusor_2
-        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
-        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
-        assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], confusor_1, \
-                'confusor')
-        assert verify_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], confusor_2, \
-                'confusor')
+        assert verify_immediately_visible(
+            pair._goal_1.get_performer_start(),
+            scene_1['objects'],
+            target_1)
+        assert verify_not_immediately_visible(
+            pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+        assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], confusor_1,
+                                              'confusor')
+        assert verify_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], confusor_2,
+                                          'confusor')
 
 
 def test_Pair7():
     pair = pairs.Pair7(BODY_TEMPLATE)
     assert pair
     scene_1, scene_2 = pair.get_scenes()
-    # The target's position is the same if it's in a box because only its box will have a different position.
-    assert verify_pair(pair, scene_1, scene_2, confusor_same_position = False, target_parent_same_position = False)
+    # The target's position is the same if it's in a box because only its box
+    # will have a different position.
+    assert verify_pair(
+        pair,
+        scene_1,
+        scene_2,
+        confusor_same_position=False,
+        target_parent_same_position=False)
 
     assert len(pair._goal_1.get_confusor_list()) == 1
     assert len(pair._goal_2.get_confusor_list()) == 1
@@ -437,24 +514,33 @@ def test_Pair7():
     target_2 = pair._goal_2.get_target_list()[0]
     confusor_1 = pair._goal_1.get_confusor_list()[0]
     confusor_2 = pair._goal_2.get_confusor_list()[0]
-    assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], confusor_1, \
-            'confusor')
-    assert verify_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], confusor_2, 'confusor')
+    assert verify_not_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], confusor_1,
+                                          'confusor')
+    assert verify_immediately_visible(
+        pair._goal_2.get_performer_start(),
+        scene_2['objects'],
+        confusor_2,
+        'confusor')
     assert 'locationParent' in target_1
     assert 'locationParent' in target_2
     assert not 'locationParent' in confusor_1
     assert not 'locationParent' in confusor_2
-    assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
-            get_parent(target_1, scene_1['objects']))
-    assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
-            get_parent(target_2, scene_2['objects']))
+    assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'],
+                                      get_parent(target_1, scene_1['objects']))
+    assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'],
+                                          get_parent(target_2, scene_2['objects']))
 
 
 def test_Pair8():
     pair = pairs.Pair8(BODY_TEMPLATE)
     assert pair
     scene_1, scene_2 = pair.get_scenes()
-    assert verify_pair(pair, scene_1, scene_2, target_same_position = False, target_parent_same = False)
+    assert verify_pair(
+        pair,
+        scene_1,
+        scene_2,
+        target_same_position=False,
+        target_parent_same=False)
 
     assert len(pair._goal_1.get_confusor_list()) == 1
     assert len(pair._goal_2.get_confusor_list()) == 1
@@ -466,7 +552,11 @@ def test_Pair8():
     confusor_1 = pair._goal_1.get_confusor_list()[0]
     confusor_2 = pair._goal_2.get_confusor_list()[0]
     assert geometry.are_adjacent(target_1, confusor_1)
-    assert geometry.are_adjacent(get_parent(target_2, scene_2['objects']), confusor_2)
+    assert geometry.are_adjacent(
+        get_parent(
+            target_2,
+            scene_2['objects']),
+        confusor_2)
     assert not 'locationParent' in target_1
     assert 'locationParent' in target_2
     assert not 'locationParent' in confusor_1
@@ -483,34 +573,49 @@ def test_Pair9():
     target_1 = pair._goal_1.get_target_list()[0]
     target_2 = pair._goal_2.get_target_list()[0]
     if containerize:
-        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], \
-                get_parent(target_1, scene_1['objects']))
-        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], \
-                get_parent(target_2, scene_2['objects']))
+        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'],
+                                          get_parent(target_1, scene_1['objects']))
+        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'],
+                                              get_parent(target_2, scene_2['objects']))
     else:
-        assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
-        assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+        assert verify_immediately_visible(
+            pair._goal_1.get_performer_start(),
+            scene_1['objects'],
+            target_1)
+        assert verify_not_immediately_visible(
+            pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
 
     assert len(pair._goal_1.get_confusor_list()) == 0
     assert len(pair._goal_2.get_confusor_list()) == 0
     assert len(pair._goal_1.get_obstructor_list()) == 0
     assert len(pair._goal_2.get_obstructor_list()) == 1
 
-    assert verify_obstructor(pair._goal_2, scene_2, obstruct_vision = False)
+    assert verify_obstructor(pair._goal_2, scene_2, obstruct_vision=False)
 
 
 def test_Pair11():
     pair = pairs.Pair11(BODY_TEMPLATE)
     assert pair
     scene_1, scene_2 = pair.get_scenes()
-    assert verify_pair(pair, scene_1, scene_2, target_same_position = False, confusor_same_position = False)
+    assert verify_pair(
+        pair,
+        scene_1,
+        scene_2,
+        target_same_position=False,
+        confusor_same_position=False)
 
     target_1 = pair._goal_1.get_target_list()[0]
     target_2 = pair._goal_2.get_target_list()[0]
     confusor_1 = pair._goal_1.get_confusor_list()[0]
     confusor_2 = pair._goal_2.get_confusor_list()[0]
-    assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
-    assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+    assert verify_immediately_visible(
+        pair._goal_1.get_performer_start(),
+        scene_1['objects'],
+        target_1)
+    assert verify_not_immediately_visible(
+        pair._goal_2.get_performer_start(),
+        scene_2['objects'],
+        target_2)
     """
     assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], confusor_1, 'confusor')
     assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], confusor_2, \
@@ -529,23 +634,33 @@ def test_Pair2_sofa_target_sofa_obstructor():
     sofa = util.finalize_object_definition(objects.get('SOFA_1'))
     sofa = util.finalize_object_materials_and_colors(sofa)[0]
     # Same SceneOptions as Pair2
-    scene_options = pairs.SceneOptions(target_definition = sofa, \
-            target_location = pairs.TargetLocationPairOption.FRONT_FRONT, \
-            obstructor = pairs.ObstructorPairOption.NONE_VISION, obstructor_definition = copy.deepcopy(sofa))
-    pair = pairs.InteractionPair(2, BODY_TEMPLATE, 'Traversal', False, scene_options)
+    scene_options = pairs.SceneOptions(target_definition=sofa,
+                                       target_location=pairs.TargetLocationPairOption.FRONT_FRONT,
+                                       obstructor=pairs.ObstructorPairOption.NONE_VISION, obstructor_definition=copy.deepcopy(sofa))
+    pair = pairs.InteractionPair(
+        2,
+        BODY_TEMPLATE,
+        'Traversal',
+        False,
+        scene_options)
     assert pair
     scene_1, scene_2 = pair.get_scenes()
     assert verify_pair(pair, scene_1, scene_2)
 
     target_1 = pair._goal_1.get_target_list()[0]
     target_2 = pair._goal_2.get_target_list()[0]
-    assert verify_immediately_visible(pair._goal_1.get_performer_start(), scene_1['objects'], target_1)
-    assert verify_not_immediately_visible(pair._goal_2.get_performer_start(), scene_2['objects'], target_2)
+    assert verify_immediately_visible(
+        pair._goal_1.get_performer_start(),
+        scene_1['objects'],
+        target_1)
+    assert verify_not_immediately_visible(
+        pair._goal_2.get_performer_start(),
+        scene_2['objects'],
+        target_2)
 
     assert len(pair._goal_1.get_confusor_list()) == 0
     assert len(pair._goal_2.get_confusor_list()) == 0
     assert len(pair._goal_1.get_obstructor_list()) == 0
     assert len(pair._goal_2.get_obstructor_list()) == 1
 
-    assert verify_obstructor(pair._goal_2, scene_2, obstruct_vision = True)
-
+    assert verify_obstructor(pair._goal_2, scene_2, obstruct_vision=True)

--- a/scene_generator/pretty_json/pretty_json.py
+++ b/scene_generator/pretty_json/pretty_json.py
@@ -2,12 +2,16 @@ from _ctypes import PyObj_FromPtr
 import json
 import re
 
-# From https://stackoverflow.com/questions/13249415/how-to-implement-custom-indentation-when-pretty-printing-with-the-json-module
+# From
+# https://stackoverflow.com/questions/13249415/how-to-implement-custom-indentation-when-pretty-printing-with-the-json-module
+
 
 class PrettyJsonNoIndent(object):
     """ Value wrapper. """
+
     def __init__(self, value):
         self.value = value
+
 
 class PrettyJsonEncoder(json.JSONEncoder):
     FORMAT_SPEC = '@@{}@@'
@@ -33,11 +37,19 @@ class PrettyJsonEncoder(json.JSONEncoder):
             # see https://stackoverflow.com/a/15012814/355230
             id = int(match.group(1))
             no_indent = PyObj_FromPtr(id)
-            json_obj_repr = json.dumps(no_indent.value, cls=PrettyJsonEncoder, sort_keys=self.__sort_keys, separators=(',', ':'))
+            json_obj_repr = json.dumps(
+                no_indent.value,
+                cls=PrettyJsonEncoder,
+                sort_keys=self.__sort_keys,
+                separators=(
+                    ',',
+                    ':'))
 
             # Replace the matched id string with json formatted representation
             # of the corresponding Python object.
-            json_repr = json_repr.replace('"{}"'.format(format_spec.format(id)), json_obj_repr)
+            json_repr = json_repr.replace(
+                '"{}"'.format(
+                    format_spec.format(id)),
+                json_obj_repr)
 
         return json_repr
-        

--- a/scene_generator/quartets.py
+++ b/scene_generator/quartets.py
@@ -21,7 +21,7 @@ def get_position_step(target: Dict[str, Any], x_position: float,
         rang = range(len(positions))
         counting_up = not left_to_right
     else:
-        rang = range(len(positions)-1, -1, -1)
+        rang = range(len(positions) - 1, -1, -1)
         counting_up = left_to_right
 
     for i in rang:
@@ -29,15 +29,18 @@ def get_position_step(target: Dict[str, Any], x_position: float,
         if counting_up and pos > x_position or \
            not counting_up and pos < x_position:
             return i
-    logging.error(f'left_to_right={left_to_right}\tforwards={forwards}\tpositions: {positions}')
-    raise exceptions.SceneException(f'cannot find step for position: {x_position}')
+    logging.error(
+        f'left_to_right={left_to_right}\tforwards={forwards}\tpositions: {positions}')
+    raise exceptions.SceneException(
+        f'cannot find step for position: {x_position}')
 
 
 class Quartet(ABC):
-    def __init__(self, template: Dict[str, Any], find_path: bool, goal: intphys_goals.IntPhysGoal):
+    def __init__(self, template: Dict[str, Any],
+                 find_path: bool, goal: intphys_goals.IntPhysGoal):
         self._template = template
         self._find_path = find_path
-        self._scenes: List[Optional[Dict[str, Any]]] = [None]*4
+        self._scenes: List[Optional[Dict[str, Any]]] = [None] * 4
         self._scene_template = copy.deepcopy(self._template)
         self._goal = goal
         self._goal.update_body(self._scene_template, self._find_path)
@@ -49,7 +52,12 @@ class Quartet(ABC):
 
 class ObjectPermanenceQuartet(Quartet):
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(ObjectPermanenceQuartet, self).__init__(template, find_path, intphys_goals.ObjectPermanenceGoal())
+        super(
+            ObjectPermanenceQuartet,
+            self).__init__(
+            template,
+            find_path,
+            intphys_goals.ObjectPermanenceGoal())
         logging.debug(f'OPQ: setup = f{self._goal._object_creator}')
 
     def _appear_behind_occluder(self, body: Dict[str, Any]) -> None:
@@ -57,7 +65,8 @@ class ObjectPermanenceQuartet(Quartet):
         target = [obj for obj in body['objects'] if obj['id'] == target_id][0]
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
             implausible_event_index = target['intphysOption']['occluder_indices'][0]
-            implausible_event_step = implausible_event_index + target['forces'][0]['stepBegin']
+            implausible_event_step = implausible_event_index + \
+                target['forces'][0]['stepBegin']
             implausible_event_x = target['intphysOption']['position_by_step'][implausible_event_index]
             target['shows'][0]['position']['x'] = implausible_event_x
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
@@ -65,7 +74,8 @@ class ObjectPermanenceQuartet(Quartet):
             implausible_event_step = 8 + target['shows'][0]['stepBegin']
             target['shows'][0]['position']['y'] = target['intphysOption']['positionY']
         else:
-            raise ValueError('unknown object creation function, cannot update scene')
+            raise ValueError(
+                'unknown object creation function, cannot update scene')
         target['shows'][0]['stepBegin'] = implausible_event_step
 
     def _disappear_behind_occluder(self, body: Dict[str, Any]) -> None:
@@ -78,7 +88,8 @@ class ObjectPermanenceQuartet(Quartet):
             # 8 is enough steps for anything to fall to the ground
             implausible_event_step = 8 + target['shows'][0]['stepBegin']
         else:
-            raise ValueError('unknown object creation function, cannot update scene')
+            raise ValueError(
+                'unknown object creation function, cannot update scene')
         target['hides'] = [{
             'stepBegin': implausible_event_step
         }]
@@ -90,20 +101,24 @@ class ObjectPermanenceQuartet(Quartet):
             return self._scenes[q - 1]
         scene = copy.deepcopy(self._scene_template)
         if q == 1:
-            scene['goal']['type_list'].append(tags.INTPHYS_OBJECT_PERMANENCE_Q1)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_OBJECT_PERMANENCE_Q1)
         elif q == 2:
             # target moves behind occluder and disappears (implausible)
             scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
-            scene['goal']['type_list'].append(tags.INTPHYS_OBJECT_PERMANENCE_Q2)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_OBJECT_PERMANENCE_Q2)
             self._disappear_behind_occluder(scene)
         elif q == 3:
             # target first appears from behind occluder (implausible)
             scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
-            scene['goal']['type_list'].append(tags.INTPHYS_OBJECT_PERMANENCE_Q3)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_OBJECT_PERMANENCE_Q3)
             self._appear_behind_occluder(scene)
         elif q == 4:
             # target not in the scene (plausible)
-            scene['goal']['type_list'].append(tags.INTPHYS_OBJECT_PERMANENCE_Q4)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_OBJECT_PERMANENCE_Q4)
             target_id = self._goal._tag_to_objects['target'][0]['id']
             for i in range(len(scene['objects'])):
                 obj = scene['objects'][i]
@@ -116,8 +131,8 @@ class ObjectPermanenceQuartet(Quartet):
 
 class SpatioTemporalContinuityQuartet(Quartet):
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(SpatioTemporalContinuityQuartet, self).__init__(template, find_path, \
-                intphys_goals.SpatioTemporalContinuityGoal())
+        super(SpatioTemporalContinuityQuartet, self).__init__(template, find_path,
+                                                              intphys_goals.SpatioTemporalContinuityGoal())
         logging.debug(f'STCQ: setup = f{self._goal._object_creator}')
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
             self._check_stepBegin(self._scene_template)
@@ -127,14 +142,19 @@ class SpatioTemporalContinuityQuartet(Quartet):
         implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
         implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
         orig_stepBegin = target['shows'][0]['stepBegin']
-        new_stepBegin = orig_stepBegin + abs(implausible_event_index1 - implausible_event_index2)
-        max_stepBegin = scene['goal']['last_step'] - len(target['intphysOption']['position_by_step'])
+        new_stepBegin = orig_stepBegin + \
+            abs(implausible_event_index1 - implausible_event_index2)
+        max_stepBegin = scene['goal']['last_step'] - \
+            len(target['intphysOption']['position_by_step'])
         if new_stepBegin > max_stepBegin:
-            # need to adjust the original to accomodate what we need for scene #4
+            # need to adjust the original to accomodate what we need for scene
+            # #4
             diff = new_stepBegin - max_stepBegin
             if diff > orig_stepBegin:
-                print(f'new_sb={new_stepBegin}\tmax_sb={max_stepBegin}\torig_sb={orig_stepBegin}')
-                raise exceptions.SceneException('cannot fix start times for this goal, must start over')
+                print(
+                    f'new_sb={new_stepBegin}\tmax_sb={max_stepBegin}\torig_sb={orig_stepBegin}')
+                raise exceptions.SceneException(
+                    'cannot fix start times for this goal, must start over')
             target['shows'][0]['stepBegin'] -= diff
             if 'forces' in target:
                 target['forces'][0]['stepBegin'] -= diff
@@ -146,17 +166,21 @@ class SpatioTemporalContinuityQuartet(Quartet):
         other_object_id = None
         for obj in scene['objects']:
             if obj.get('intphysOption', {}).get('is_occluder', False):
-                occluded_id = obj.get('intphysOption', {}).get('occluded_id', None)
+                occluded_id = obj.get(
+                    'intphysOption', {}).get(
+                    'occluded_id', None)
                 if occluded_id != target_id:
                     other_occluder = obj
                     other_object_id = occluded_id
                     break
         if other_occluder is None:
-            raise exceptions.SceneException('cannot find a second occluder, error generating scene')
+            raise exceptions.SceneException(
+                'cannot find a second occluder, error generating scene')
         if other_object_id is None:
             other_object = None
         else:
-            other_object = next((obj for obj in scene['objects'] if obj['id'] == other_object_id))
+            other_object = next(
+                (obj for obj in scene['objects'] if obj['id'] == other_object_id))
         return other_occluder, other_object
 
     def _teleport_forward(self, scene: Dict[str, Any]) -> None:
@@ -174,7 +198,8 @@ class SpatioTemporalContinuityQuartet(Quartet):
                 implausible_event_index = implausible_event_index2
                 destination_index = implausible_event_index1
                 destination_x = target['intphysOption']['position_by_step'][destination_index]
-            implausible_event_step = implausible_event_index + target['forces'][0]['stepBegin']
+            implausible_event_step = implausible_event_index + \
+                target['forces'][0]['stepBegin']
             position = {
                 'x': destination_x,
                 'y': target['intphysOption']['positionY'],
@@ -187,7 +212,8 @@ class SpatioTemporalContinuityQuartet(Quartet):
                     'stepBegin': target['shows'][0]['stepBegin'] + destination_index + 1,
                     'position': position
                 })
-                scene['goal']['type_list'].append(tags.INTPHYS_TELEPORT_DELAYED)
+                scene['goal']['type_list'].append(
+                    tags.INTPHYS_TELEPORT_DELAYED)
             else:
                 # teleport the target
                 target['teleports'] = [{
@@ -195,13 +221,15 @@ class SpatioTemporalContinuityQuartet(Quartet):
                     'stepEnd': implausible_event_step,
                     'position': position
                 }]
-                scene['goal']['type_list'].append(tags.INTPHYS_TELEPORT_INSTANTANEOUS)
+                scene['goal']['type_list'].append(
+                    tags.INTPHYS_TELEPORT_INSTANTANEOUS)
 
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             # 8 is enough for it to fall to the ground
             implausible_event_step = 8 + target['shows'][0]['stepBegin']
             # find another occluder besides the target's
-            other_occluder, other_object = self._find_other_occluder(target, scene)
+            other_occluder, other_object = self._find_other_occluder(
+                target, scene)
             # teleport the target behind the other occluder
             factor = intphys_goals.IntPhysGoal.NEAR_X_PERSPECTIVE_FACTOR \
                 if target['shows'][0]['position']['z'] == intphys_goals.IntPhysGoal.OBJECT_NEAR_Z \
@@ -229,7 +257,8 @@ class SpatioTemporalContinuityQuartet(Quartet):
                 }
             }]
         else:
-            raise ValueError('unknown object creation function, cannot update scene')
+            raise ValueError(
+                'unknown object creation function, cannot update scene')
 
     def _teleport_backward(self, scene: Dict[str, Any]) -> None:
         target = self._goal._tag_to_objects['target'][0]
@@ -245,12 +274,14 @@ class SpatioTemporalContinuityQuartet(Quartet):
                 implausible_event_index = implausible_event_index2
                 destination_index = implausible_event_index1
                 destination_x = target['intphysOption']['position_by_step'][destination_index]
-            implausible_event_step = implausible_event_index + target['forces'][0]['stepBegin']
+            implausible_event_step = implausible_event_index + \
+                target['forces'][0]['stepBegin']
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             # 8 is enough for it to fall to the ground
             implausible_event_step = 8 + target['shows'][0]['stepBegin']
             # find another occluder besides the target's
-            other_occluder, other_object = self._find_other_occluder(target, scene)
+            other_occluder, other_object = self._find_other_occluder(
+                target, scene)
             # start behind the other occluder
             original_position = target['shows'][0]['position'].copy()
             factor = intphys_goals.IntPhysGoal.NEAR_X_PERSPECTIVE_FACTOR \
@@ -274,7 +305,8 @@ class SpatioTemporalContinuityQuartet(Quartet):
                 }]
                 other_object['shows'][0]['position'] = original_position
         else:
-            raise ValueError('unknown object creation function, cannot update scene')
+            raise ValueError(
+                'unknown object creation function, cannot update scene')
         target['teleports'] = [{
             'stepBegin': implausible_event_step,
             'stepEnd': implausible_event_step,
@@ -290,13 +322,16 @@ class SpatioTemporalContinuityQuartet(Quartet):
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
             implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
             implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
-            adjustment = abs(implausible_event_index1 - implausible_event_index2)
+            adjustment = abs(
+                implausible_event_index1 -
+                implausible_event_index2)
             target['shows'][0]['stepBegin'] += adjustment
             if 'forces' in target:
                 target['forces'][0]['stepBegin'] += adjustment
         elif self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_falling_down:
             # find another occluder besides the target's
-            other_occluder, other_object = self._find_other_occluder(target, scene)
+            other_occluder, other_object = self._find_other_occluder(
+                target, scene)
             # move target behind the other occluder
             original_position = target['shows'][0]['position'].copy()
             factor = intphys_goals.IntPhysGoal.NEAR_X_PERSPECTIVE_FACTOR \
@@ -308,7 +343,8 @@ class SpatioTemporalContinuityQuartet(Quartet):
             if other_object is not None:
                 other_object['shows'][0]['position'] = original_position
         else:
-            raise ValueError('unknown object creation function, cannot update scene')
+            raise ValueError(
+                'unknown object creation function, cannot update scene')
 
     def get_scene(self, q: int) -> Dict[str, Any]:
         if q < 1 or q > 4:
@@ -317,17 +353,21 @@ class SpatioTemporalContinuityQuartet(Quartet):
             return self._scenes[q - 1]
         scene = copy.deepcopy(self._scene_template)
         if q == 1:
-            scene['goal']['type_list'].append(tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q1)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q1)
         elif q == 2:
             scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
-            scene['goal']['type_list'].append(tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q2)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q2)
             self._teleport_forward(scene)
         elif q == 3:
             scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
-            scene['goal']['type_list'].append(tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q3)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q3)
             self._teleport_backward(scene)
         elif q == 4:
-            scene['goal']['type_list'].append(tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q4)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_SPATIO_TEMPORAL_CONTINUITY_Q4)
             self._move_later(scene)
         self._scenes[q - 1] = scene
         return scene
@@ -340,7 +380,12 @@ class ShapeConstancyQuartet(Quartet):
     """
 
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(ShapeConstancyQuartet, self).__init__(template, find_path, intphys_goals.ShapeConstancyGoal())
+        super(
+            ShapeConstancyQuartet,
+            self).__init__(
+            template,
+            find_path,
+            intphys_goals.ShapeConstancyGoal())
         logging.debug(f'SCQ: setup = f{self._goal._object_creator}')
         # we need the b object for 3/4 of the scenes, so generate it now
         self._b = self._create_b(self._scene_template)
@@ -348,7 +393,8 @@ class ShapeConstancyQuartet(Quartet):
     def _create_b(self, scene: Dict[str, Any]) -> Dict[str, Any]:
         a = scene['objects'][0]
         possible_defs = []
-        # Use the X dimensions because the performer will always be facing that side of the object.
+        # Use the X dimensions because the performer will always be facing that
+        # side of the object.
         a_size = a['dimensions']['x']
         for obj_def in self._goal._object_defs:
             if obj_def['type'] != a['type']:
@@ -357,10 +403,12 @@ class ShapeConstancyQuartet(Quartet):
                         (a_size - util.MAX_SIZE_DIFFERENCE):
                     possible_defs.append(obj_def)
         if len(possible_defs) == 0:
-            raise exceptions.SceneException(f'no valid choices for "b" object. a = {a}')
+            raise exceptions.SceneException(
+                f'no valid choices for "b" object. a = {a}')
         b_def = random.choice(possible_defs)
         b_def = util.finalize_object_definition(b_def)
-        b = util.instantiate_object(b_def, a['originalLocation'], a['materialsList'])
+        b = util.instantiate_object(
+            b_def, a['originalLocation'], a['materialsList'])
         b['id'] = a['id']
         logging.debug(f'a type: {a["type"]}\tb type: {b["type"]}')
         return b
@@ -370,7 +418,8 @@ class ShapeConstancyQuartet(Quartet):
         b = copy.deepcopy(self._b)
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
             implausible_event_index = a['intphysOption']['occluder_indices'][0]
-            implausible_event_step = implausible_event_index + a['forces'][0]['stepBegin']
+            implausible_event_step = implausible_event_index + \
+                a['forces'][0]['stepBegin']
             implausible_event_x = a['intphysOption']['position_by_step'][implausible_event_index]
             b['shows'][0]['position']['x'] = implausible_event_x
             b['forces'] = copy.deepcopy(a['forces'])
@@ -380,7 +429,8 @@ class ShapeConstancyQuartet(Quartet):
             b['shows'][0]['position']['x'] = a['shows'][0]['position']['x']
             b['shows'][0]['position']['y'] = a['intphysOption']['positionY']
         else:
-            raise ValueError(f'unknown object creation function, cannot update scene: {self._goal._object_creator}')
+            raise ValueError(
+                f'unknown object creation function, cannot update scene: {self._goal._object_creator}')
         b['shows'][0]['position']['z'] = a['shows'][0]['position']['z']
         b['shows'][0]['stepBegin'] = implausible_event_step
         logging.debug(f'hiding a ({a["id"]}) at step {implausible_event_step}')
@@ -395,7 +445,8 @@ class ShapeConstancyQuartet(Quartet):
         b['shows'][0]['position']['x'] = a['shows'][0]['position']['x']
         if self._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
             implausible_event_index = a['intphysOption']['occluder_indices'][0]
-            implausible_event_step = implausible_event_index + a['forces'][0]['stepBegin']
+            implausible_event_step = implausible_event_index + \
+                a['forces'][0]['stepBegin']
             implausible_event_x = a['intphysOption']['position_by_step'][implausible_event_index]
             b['forces'] = copy.deepcopy(a['forces'])
             a['shows'][0]['position']['x'] = implausible_event_x
@@ -404,7 +455,8 @@ class ShapeConstancyQuartet(Quartet):
             b['shows'][0]['position']['y'] = a['shows'][0]['position']['y']
             a['shows'][0]['position']['y'] = a['intphysOption']['positionY']
         else:
-            raise ValueError(f'unknown object creation function, cannot update scene: {self._goal._object_creator}')
+            raise ValueError(
+                f'unknown object creation function, cannot update scene: {self._goal._object_creator}')
         b['shows'][0]['stepBegin'] = a['shows'][0]['stepBegin']
         a['shows'][0]['stepBegin'] = implausible_event_step
         b['shows'][0]['position']['z'] = a['shows'][0]['position']['z']
@@ -417,7 +469,8 @@ class ShapeConstancyQuartet(Quartet):
     def _b_replaces_a(self, scene: Dict[str, Any]) -> None:
         a = scene['objects'][0]
         b = copy.deepcopy(self._b)
-        # Don't accidentally copy the 'rotation' from the 'shows' list because it's unique per object.
+        # Don't accidentally copy the 'rotation' from the 'shows' list because
+        # it's unique per object.
         b['shows'][0]['stepBegin'] = a['shows'][0]['stepBegin']
         b['shows'][0]['position'] = a['shows'][0]['position']
         if 'forces' in a:
@@ -453,10 +506,11 @@ class ShapeConstancyQuartet(Quartet):
         # May have added and/or deleted an object, so regenerate
         # goal.info_list
         del scene['goal']['info_list']
-        scene['info_list'] = self._goal.update_goal_info_list(scene['goal'].get('info_list', []), \
-                self._goal._tag_to_objects)
+        scene['info_list'] = self._goal.update_goal_info_list(scene['goal'].get('info_list', []),
+                                                              self._goal._tag_to_objects)
         self._scenes[q - 1] = scene
-        logging.debug(f'get_scene: q={q}\thides? {scene["objects"][0].get("hides", None)}')
+        logging.debug(
+            f'get_scene: q={q}\thides? {scene["objects"][0].get("hides", None)}')
         return scene
 
 
@@ -475,8 +529,8 @@ class GravityQuartet(Quartet):
     RAMP_45_TOP_OFFSET = -1
 
     def __init__(self, template: Dict[str, Any], find_path: bool):
-        super(GravityQuartet, self).__init__(template, find_path, \
-                intphys_goals.GravityGoal(roll_down = False, use_fastest = True))
+        super(GravityQuartet, self).__init__(template, find_path,
+                                             intphys_goals.GravityGoal(roll_down=False, use_fastest=True))
 
     def get_scene(self, q: int) -> Dict[str, Any]:
         if q < 1 or q > 4:
@@ -491,7 +545,8 @@ class GravityQuartet(Quartet):
         self._scenes[q - 1] = scene
         return scene
 
-    def _get_steep_scene(self, scene: Dict[str, Any], q: int) -> Dict[str, Any]:
+    def _get_steep_scene(
+            self, scene: Dict[str, Any], q: int) -> Dict[str, Any]:
         target = scene['objects'][0]
         if q == 2 or q == 4:
             # switch the target to use lowest force.x
@@ -513,7 +568,7 @@ class GravityQuartet(Quartet):
             implausible_step = get_position_step(target, implausible_x_start,
                                                  self._goal.is_left_to_right(),
                                                  False) - 1 + \
-                                                 target['shows'][0]['stepBegin']
+                target['shows'][0]['stepBegin']
             new_force = copy.deepcopy(target['forces'][0])
             new_force['stepBegin'] = implausible_step
             factor = 2 if q == 3 else 0.5
@@ -522,29 +577,38 @@ class GravityQuartet(Quartet):
             target['forces'][0]['stepEnd'] = implausible_step - 1
 
         if q == 1:
-            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_TRAJECTORY_Q1)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_GRAVITY_TRAJECTORY_Q1)
         elif q == 2:
-            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_TRAJECTORY_Q2)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_GRAVITY_TRAJECTORY_Q2)
         elif q == 3:
-            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_TRAJECTORY_Q3)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_GRAVITY_TRAJECTORY_Q3)
         elif q == 4:
-            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_TRAJECTORY_Q4)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_GRAVITY_TRAJECTORY_Q4)
 
         return scene
 
-    def _get_gentle_scene(self, scene: Dict[str, Any], q: int) -> Dict[str, Any]:
+    def _get_gentle_scene(
+            self, scene: Dict[str, Any], q: int) -> Dict[str, Any]:
         if q == 1:
-            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_ACCELERATION_Q1)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_GRAVITY_ACCELERATION_Q1)
         elif q == 2:
-            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_ACCELERATION_Q2)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_GRAVITY_ACCELERATION_Q2)
             self._make_roll_down(scene)
         elif q == 3:
             scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
-            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_ACCELERATION_Q3)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_GRAVITY_ACCELERATION_Q3)
             self._make_object_faster(scene)
         elif q == 4:
             scene['answer']['choice'] = intphys_goals.IntPhysGoal.IMPLAUSIBLE
-            scene['goal']['type_list'].append(tags.INTPHYS_GRAVITY_ACCELERATION_Q4)
+            scene['goal']['type_list'].append(
+                tags.INTPHYS_GRAVITY_ACCELERATION_Q4)
             self._make_roll_down(scene)
             self._make_object_slower(scene)
         return scene
@@ -559,10 +623,12 @@ class GravityQuartet(Quartet):
                 obj['shows'][0]['position']['y'] += ramps.RAMP_OBJECT_HEIGHTS[ramp_type]
                 # Add a downward force to all objects moving down the
                 # ramps so that they will move more realistically.
-                obj['forces'][0]['vector']['y'] = obj['mass'] * intphys_goals.IntPhysGoal.RAMP_DOWNWARD_FORCE
+                obj['forces'][0]['vector']['y'] = obj['mass'] * \
+                    intphys_goals.IntPhysGoal.RAMP_DOWNWARD_FORCE
 
     def _get_ramp_offsets(self) -> Tuple[float, float]:
-        bottom_offset, top_offset = GravityQuartet.RAMP_OFFSETS[self._goal.get_ramp_type()]
+        bottom_offset, top_offset = GravityQuartet.RAMP_OFFSETS[self._goal.get_ramp_type(
+        )]
         left_to_right = self._goal.is_left_to_right()
         if left_to_right:
             bottom_offset *= -1
@@ -577,7 +643,7 @@ class GravityQuartet(Quartet):
         implausible_step = get_position_step(target, implausible_x_start,
                                              self._goal.is_left_to_right(),
                                              True) + \
-                                             target['shows'][0]['stepBegin']
+            target['shows'][0]['stepBegin']
         new_force = copy.deepcopy(target['forces'][0])
         new_force['stepBegin'] = implausible_step
         new_force['vector']['x'] *= 2
@@ -592,7 +658,7 @@ class GravityQuartet(Quartet):
         implausible_step = get_position_step(target, implausible_x_start,
                                              self._goal.is_left_to_right(),
                                              False) + \
-                                             target['shows'][0]['stepBegin']
+            target['shows'][0]['stepBegin']
         new_force = copy.deepcopy(target['forces'][0])
         new_force['stepBegin'] = implausible_step
         new_force['vector']['x'] /= 2.0
@@ -601,7 +667,10 @@ class GravityQuartet(Quartet):
         pass
 
 
-QUARTET_TYPES: List[Type[Quartet]] = [GravityQuartet, ObjectPermanenceQuartet, ShapeConstancyQuartet, SpatioTemporalContinuityQuartet]
+QUARTET_TYPES: List[Type[Quartet]] = [GravityQuartet,
+                                      ObjectPermanenceQuartet,
+                                      ShapeConstancyQuartet,
+                                      SpatioTemporalContinuityQuartet]
 
 
 def get_quartet_class(name: str) -> Type[Quartet]:

--- a/scene_generator/quartets_test.py
+++ b/scene_generator/quartets_test.py
@@ -2,11 +2,12 @@ import intphys_goals
 import objects
 import pytest
 from quartets import GravityQuartet, ShapeConstancyQuartet, ObjectPermanenceQuartet, SpatioTemporalContinuityQuartet, \
-        get_position_step
+    get_position_step
 import util
 
 
 TEMPLATE = {'wallMaterial': 'dummy', 'wallColors': ['color']}
+
 
 def test_get_position_step():
     target = {
@@ -29,10 +30,11 @@ def test_STCQ_get_scene():
         scene = quartet.get_scene(q)
         assert scene is not None
         assert scene['goal']['last_step'] == scene_1['goal']['last_step']
-        assert scene['goal']['action_list'] == [['Pass']] * scene['goal']['last_step']
+        assert scene['goal']['action_list'] == [
+            ['Pass']] * scene['goal']['last_step']
         assert scene['goal']['category'] == 'intphys'
-        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', \
-                'object permanence'])
+        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion',
+                                                         'object permanence'])
         assert 'passive' in scene['goal']['type_list']
         assert 'action none' in scene['goal']['type_list']
         assert 'intphys' in scene['goal']['type_list']
@@ -67,7 +69,9 @@ def test_STCQ_get_scene_2_teleport_forward():
         if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
             implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
             implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
-            assert target['teleports'][0]['stepBegin'] == min(implausible_event_index1, implausible_event_index2) + target['forces'][0]['stepBegin']
+            assert target['teleports'][0]['stepBegin'] == min(
+                implausible_event_index1,
+                implausible_event_index2) + target['forces'][0]['stepBegin']
         else:
             assert target['teleports'][0]['stepBegin'] >= 8
     # TODO MCS-82 Test behavior if 'hides' in target
@@ -84,7 +88,9 @@ def test_STCQ_get_scene_3_teleport_backward():
     if quartet._goal._object_creator == intphys_goals.IntPhysGoal._get_objects_and_occluders_moving_across:
         implausible_event_index1 = target['intphysOption']['occluder_indices'][0]
         implausible_event_index2 = target['intphysOption']['occluder_indices'][1]
-        assert target['teleports'][0]['stepBegin'] == max(implausible_event_index1, implausible_event_index2) + target['forces'][0]['stepBegin']
+        assert target['teleports'][0]['stepBegin'] == max(
+            implausible_event_index1,
+            implausible_event_index2) + target['forces'][0]['stepBegin']
     else:
         assert target['teleports'][0]['stepBegin'] >= 8
 
@@ -110,7 +116,8 @@ def test_ShapeConstancyQuartet():
     a = quartet._scene_template['objects'][0]
     assert a['type'] != quartet._b['type']
     assert a['id'] == quartet._b['id']
-    assert a['dimensions']['x'] == pytest.approx(quartet._b['dimensions']['x'], abs=util.MAX_SIZE_DIFFERENCE)
+    assert a['dimensions']['x'] == pytest.approx(
+        quartet._b['dimensions']['x'], abs=util.MAX_SIZE_DIFFERENCE)
     assert a['materials'] == quartet._b['materials']
 
 
@@ -125,10 +132,11 @@ def test_ShapeConstancyQuartet_get_scene():
         scene = quartet.get_scene(q)
         assert scene is not None
         assert scene['goal']['last_step'] == scene_1['goal']['last_step']
-        assert scene['goal']['action_list'] == [['Pass']] * scene['goal']['last_step']
+        assert scene['goal']['action_list'] == [
+            ['Pass']] * scene['goal']['last_step']
         assert scene['goal']['category'] == 'intphys'
-        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', \
-                'object permanence'])
+        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion',
+                                                         'object permanence'])
         assert 'passive' in scene['goal']['type_list']
         assert 'action none' in scene['goal']['type_list']
         assert 'intphys' in scene['goal']['type_list']
@@ -204,10 +212,11 @@ def test_ObjectPermanenceQuartet_get_scene():
         scene = quartet.get_scene(q)
         assert scene is not None
         assert scene['goal']['last_step'] == scene_1['goal']['last_step']
-        assert scene['goal']['action_list'] == [['Pass']] * scene['goal']['last_step']
+        assert scene['goal']['action_list'] == [
+            ['Pass']] * scene['goal']['last_step']
         assert scene['goal']['category'] == 'intphys'
-        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', \
-                'object permanence'])
+        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion',
+                                                         'object permanence'])
         assert 'passive' in scene['goal']['type_list']
         assert 'action none' in scene['goal']['type_list']
         assert 'intphys' in scene['goal']['type_list']
@@ -264,18 +273,20 @@ def test_GravityQuartet_get_scene():
         scene = quartet.get_scene(q)
         assert scene is not None
         assert scene['goal']['last_step'] == scene_1['goal']['last_step']
-        assert scene['goal']['action_list'] == [['Pass']] * scene['goal']['last_step']
+        assert scene['goal']['action_list'] == [
+            ['Pass']] * scene['goal']['last_step']
         assert scene['goal']['category'] == 'intphys'
-        assert set(scene['goal']['domain_list']) == set(['objects', 'object solidity', 'object motion', 'gravity'])
+        assert set(scene['goal']['domain_list']) == set(
+            ['objects', 'object solidity', 'object motion', 'gravity'])
         assert 'passive' in scene['goal']['type_list']
         assert 'action none' in scene['goal']['type_list']
         assert 'intphys' in scene['goal']['type_list']
         assert 'gravity' in scene['goal']['type_list']
         assert ('ramp 30-degree' in scene['goal']['type_list']) or \
-                ('ramp 45-degree' in scene['goal']['type_list']) or \
-                ('ramp 90-degree' in scene['goal']['type_list']) or \
-                ('ramp 30-degree-90-degree' in scene['goal']['type_list']) or \
-                ('ramp 45-degree-90-degree' in scene['goal']['type_list'])
+            ('ramp 45-degree' in scene['goal']['type_list']) or \
+            ('ramp 90-degree' in scene['goal']['type_list']) or \
+            ('ramp 30-degree-90-degree' in scene['goal']['type_list']) or \
+            ('ramp 45-degree-90-degree' in scene['goal']['type_list'])
         assert len(scene['objects']) >= 1
 
 
@@ -284,7 +295,7 @@ def test_GravityQuartet_get_scene_1():
     scene = quartet.get_scene(1)
     assert scene['answer']['choice'] == 'plausible'
     assert ('gravity ramp fast further' in scene['goal']['type_list']) or \
-            ('gravity ramp up slower' in scene['goal']['type_list'])
+        ('gravity ramp up slower' in scene['goal']['type_list'])
     # TODO MCS-82 More asserts to test specific behavior
 
 
@@ -293,7 +304,7 @@ def test_GravityQuartet_get_scene_2():
     scene = quartet.get_scene(2)
     assert scene['answer']['choice'] == 'plausible'
     assert ('gravity ramp slow shorter' in scene['goal']['type_list']) or \
-            ('gravity ramp down faster' in scene['goal']['type_list'])
+        ('gravity ramp down faster' in scene['goal']['type_list'])
     # TODO MCS-82 More asserts to test specific behavior
 
 
@@ -302,7 +313,7 @@ def test_GravityQuartet_get_scene_3():
     scene = quartet.get_scene(3)
     assert scene['answer']['choice'] == 'implausible'
     assert ('gravity ramp fast shorter' in scene['goal']['type_list']) or \
-            ('gravity ramp up faster' in scene['goal']['type_list'])
+        ('gravity ramp up faster' in scene['goal']['type_list'])
     # TODO MCS-82 More asserts to test specific behavior
 
 
@@ -311,7 +322,5 @@ def test_GravityQuartet_get_scene_4():
     scene = quartet.get_scene(4)
     assert scene['answer']['choice'] == 'implausible'
     assert ('gravity ramp slow further' in scene['goal']['type_list']) or \
-            ('gravity ramp down slower' in scene['goal']['type_list'])
+        ('gravity ramp down slower' in scene['goal']['type_list'])
     # TODO MCS-82 More asserts to test specific behavior
-
-

--- a/scene_generator/ramps.py
+++ b/scene_generator/ramps.py
@@ -327,12 +327,13 @@ RAMP_OBJECT_HEIGHTS = {
 def create_ramp(material_string: str, x_position_percent: float,
                 left_to_right: bool,
                 ramp_type: Optional[Ramp] = None) -> \
-                Tuple[Ramp, float, List[Dict[str, Any]]]:
+        Tuple[Ramp, float, List[Dict[str, Any]]]:
     """Create a ramp of a random type. Returns a tuple of (ramp_type,
     x_term, list of objects that make up the ramp).
     """
     if x_position_percent < 0 or x_position_percent > 1:
-        raise ValueError(f'x_position_percent must be between 0 and 1 (inclusive), was {x_position_percent}')
+        raise ValueError(
+            f'x_position_percent must be between 0 and 1 (inclusive), was {x_position_percent}')
     if ramp_type is None:
         ramp_type = random.choice(list(Ramp))
     template_info = _RAMP_TEMPLATE_INFO[ramp_type]

--- a/scene_generator/requirements.txt
+++ b/scene_generator/requirements.txt
@@ -1,10 +1,12 @@
 -i https://pypi.org/simple
 ./..
 ai2thor==2.2.0
+autopep8==1.5.4
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2
 extremitypathfinder==1.1.0
+flake8==3.8.3
 flask==1.1.2
 idna==2.9
 itsdangerous==1.1.0

--- a/scene_generator/scene_generator.py
+++ b/scene_generator/scene_generator.py
@@ -55,7 +55,8 @@ def strip_debug_info(body: Dict[str, Any]) -> None:
     body.pop('wallColors', None)
     for obj in body['objects']:
         clean_object(obj)
-    for goal_key in ('domain_list', 'type_list', 'task_list', 'info_list', 'series_id'):
+    for goal_key in ('domain_list', 'type_list',
+                     'task_list', 'info_list', 'series_id'):
         body['goal'].pop(goal_key, None)
     if 'metadata' in body['goal']:
         metadata = body['goal']['metadata']
@@ -101,7 +102,8 @@ def generate_body_template(name: str) -> Dict[str, Any]:
     return body
 
 
-def generate_scene(name: str, goal_type: str, find_path: bool) -> Dict[str, Any]:
+def generate_scene(name: str, goal_type: str,
+                   find_path: bool) -> Dict[str, Any]:
     body = generate_body_template(name)
     goal_obj = goals.choose_goal(goal_type)
     goal_obj.update_body(body, find_path)
@@ -123,24 +125,32 @@ def write_scene(name: str, scene: Dict[str, Any]) -> None:
     # Use PrettyJsonNoIndent on some of the lists and dicts in the
     # output body because the indentation from the normal Python JSON
     # module spaces them out far too much.
-    wrap_with_json_no_indent(body['goal'], ['action_list', 'domain_list', 'type_list', 'task_list', 'info_list'])
+    wrap_with_json_no_indent(
+        body['goal'], [
+            'action_list', 'domain_list', 'type_list', 'task_list', 'info_list'])
     if 'metadata' in body['goal']:
         for target in ['target', 'target_1', 'target_2']:
             if target in body['goal']['metadata']:
-                wrap_with_json_no_indent(body['goal']['metadata'][target], ['info', 'image'])
+                wrap_with_json_no_indent(
+                    body['goal']['metadata'][target], [
+                        'info', 'image'])
 
     for object_config in body['objects']:
-        wrap_with_json_no_indent(object_config, ['info', 'materials', 'salientMaterials'])
+        wrap_with_json_no_indent(
+            object_config, [
+                'info', 'materials', 'salientMaterials'])
 
     with open(name, 'w') as out:
-        # PrettyJsonEncoder doesn't work with json.dump so use json.dumps here instead.
+        # PrettyJsonEncoder doesn't work with json.dump so use json.dumps here
+        # instead.
         try:
             out.write(json.dumps(body, cls=PrettyJsonEncoder, indent=2))
         except Exception as e:
             logging.error(body, e)
 
 
-def wrap_with_json_no_indent(data: Dict[str, Any], prop_list: List[str]) -> None:
+def wrap_with_json_no_indent(
+        data: Dict[str, Any], prop_list: List[str]) -> None:
     for prop in prop_list:
         if prop in data:
             data[prop] = PrettyJsonNoIndent(data[prop])
@@ -153,7 +163,7 @@ def generate_name(prefix: str, count: int, scene: int = None) -> str:
 
 
 def generate_single(prefix: str, count: int, goal_type: str, find_path: bool,
-                           stop_on_error: bool) -> None:
+                    stop_on_error: bool) -> None:
     # skip existing files
     index = 1
 
@@ -174,8 +184,8 @@ def generate_single(prefix: str, count: int, goal_type: str, find_path: bool,
             logging.warning(f'failed to create a file: {e}')
 
 
-def generate_quartet(prefix: str, count: int, quartet_name: str, goal_name: str, find_path: bool, \
-        stop_on_error: bool) -> None:
+def generate_quartet(prefix: str, count: int, quartet_name: str, goal_name: str, find_path: bool,
+                     stop_on_error: bool) -> None:
 
     template = generate_body_template('')
     quartet_class = quartets.get_quartet_class(quartet_name)
@@ -190,7 +200,8 @@ def generate_quartet(prefix: str, count: int, quartet_name: str, goal_name: str,
             try:
                 scene = quartet.get_scene(q)
                 scene['name'] = name
-                scene['goal']['series_id'] = 'quartet_' + quartet_name + '_' + quartet_id
+                scene['goal']['series_id'] = 'quartet_' + \
+                    quartet_name + '_' + quartet_id
                 scene_copy = copy.deepcopy(scene)
                 write_file(name, scene_copy)
                 break
@@ -201,17 +212,24 @@ def generate_quartet(prefix: str, count: int, quartet_name: str, goal_name: str,
         logging.debug(f'end generation of\t{name}')
 
 
-def generate_quartets(prefix: str, count: int, quartet_name: str, goal_name: str, find_path: bool, \
-        stop_on_error: bool) -> None:
+def generate_quartets(prefix: str, count: int, quartet_name: str, goal_name: str, find_path: bool,
+                      stop_on_error: bool) -> None:
 
     index = 1
     while count > 0:
         while True:
-            file_exists = os.path.exists(generate_name(prefix, index, 1) + '.json')
+            file_exists = os.path.exists(
+                generate_name(prefix, index, 1) + '.json')
             if not file_exists:
                 break
             index += 1
-        generate_quartet(prefix, index, quartet_name, goal_name, find_path, stop_on_error)
+        generate_quartet(
+            prefix,
+            index,
+            quartet_name,
+            goal_name,
+            find_path,
+            stop_on_error)
         count -= 1
 
 
@@ -221,8 +239,8 @@ def write_scene_of_pair(scene: Dict[str, Any], name: str) -> None:
     write_file(name, scene_copy)
 
 
-def generate_pair(prefix: str, count: int, pair_name: str, goal_name: str, find_path: bool, \
-        stop_on_error: bool) -> None:
+def generate_pair(prefix: str, count: int, pair_name: str, goal_name: str, find_path: bool,
+                  stop_on_error: bool) -> None:
 
     template = generate_body_template('')
     pair_class = pairs.get_pair_class(pair_name)
@@ -231,8 +249,10 @@ def generate_pair(prefix: str, count: int, pair_name: str, goal_name: str, find_
     while True:
         try:
             scenes = pair.get_scenes()
-            scenes[0]['goal']['series_id'] = pair.get_name().replace(' ', '_') + '_' + pair_id
-            scenes[1]['goal']['series_id'] = pair.get_name().replace(' ', '_') + '_' + pair_id
+            scenes[0]['goal']['series_id'] = pair.get_name().replace(
+                ' ', '_') + '_' + pair_id
+            scenes[1]['goal']['series_id'] = pair.get_name().replace(
+                ' ', '_') + '_' + pair_id
             write_scene_of_pair(scenes[0], generate_name(prefix, count, 1))
             write_scene_of_pair(scenes[1], generate_name(prefix, count, 2))
             break
@@ -242,20 +262,27 @@ def generate_pair(prefix: str, count: int, pair_name: str, goal_name: str, find_
             logging.warning(f'failed to create a pair: {e}')
 
 
-def generate_pairs(prefix: str, total: int, pair_name: str, goal_name: str, find_path: bool, \
-        stop_on_error: bool) -> None:
+def generate_pairs(prefix: str, total: int, pair_name: str, goal_name: str, find_path: bool,
+                   stop_on_error: bool) -> None:
 
     index = 1
     count = 0
     while count < total:
         while True:
-            file_exists = os.path.exists(generate_name(prefix, index, 1) + '.json')
+            file_exists = os.path.exists(
+                generate_name(prefix, index, 1) + '.json')
             if not file_exists:
                 break
             index += 1
         count += 1
         logging.debug(f'\n\ngenerate pair {count} / {total}\n')
-        generate_pair(prefix, index, pair_name, goal_name, find_path, stop_on_error)
+        generate_pair(
+            prefix,
+            index,
+            pair_name,
+            goal_name,
+            find_path,
+            stop_on_error)
 
 
 class FilesetType(Enum):
@@ -271,22 +298,47 @@ def generate_fileset(prefix: str, count: int, type_name: str, goal_name: str, fi
         os.makedirs(dirname, exist_ok=True)
 
     if fileset_type == FilesetType.QUARTET:
-        generate_quartets(prefix, count, type_name, goal_name, find_path, stop_on_error)
+        generate_quartets(
+            prefix,
+            count,
+            type_name,
+            goal_name,
+            find_path,
+            stop_on_error)
     elif fileset_type == FilesetType.PAIR:
-        generate_pairs(prefix, count, type_name, goal_name, find_path, stop_on_error)
+        generate_pairs(
+            prefix,
+            count,
+            type_name,
+            goal_name,
+            find_path,
+            stop_on_error)
     elif fileset_type == FilesetType.SINGLE:
         generate_single(prefix, count, goal_name, find_path, stop_on_error)
 
 
 def main(argv):
-    parser = argparse.ArgumentParser(description='Create one or more scene descriptions')
-    parser.add_argument('--prefix', required=True, help='Prefix for output filenames')
-    parser.add_argument('-c', '--count', type=int, default=1, help='How many scenes or quartets to generate [default=1]')
-    parser.add_argument('--seed', type=int, default=None, help='Random number seed [default=None]')
+    parser = argparse.ArgumentParser(
+        description='Create one or more scene descriptions')
+    parser.add_argument(
+        '--prefix',
+        required=True,
+        help='Prefix for output filenames')
+    parser.add_argument(
+        '-c',
+        '--count',
+        type=int,
+        default=1,
+        help='How many scenes or quartets to generate [default=1]')
+    parser.add_argument(
+        '--seed',
+        type=int,
+        default=None,
+        help='Random number seed [default=None]')
     group = parser.add_mutually_exclusive_group()
     parser.add_argument('--goal', default=None, choices=goals.get_goal_types(),
-                       help='Generate a goal of the specified type [default is to not generate a goal]. Lowercase '
-                       'goals are categories; capitalized goals are specific goals.')
+                        help='Generate a goal of the specified type [default is to not generate a goal]. Lowercase '
+                        'goals are categories; capitalized goals are specific goals.')
     group.add_argument('--quartet', default=None, choices=quartets.get_quartet_types(),
                        help='Generate a passive scene quartet of the specified type with random setups.')
     group.add_argument('--pair', default=None, choices=pairs.get_pair_types(),
@@ -296,7 +348,10 @@ def main(argv):
     parser.add_argument('--stop-on-error', default=False, action='store_true',
                         help='Stop immediately if there is an error generating a file [default is print a warning but '
                              'do not stop]')
-    parser.add_argument('--loglevel', choices=LOG_LEVELS, help='set logging level')
+    parser.add_argument(
+        '--loglevel',
+        choices=LOG_LEVELS,
+        help='set logging level')
 
     args = parser.parse_args(argv[1:])
     random.seed(args.seed)
@@ -321,7 +376,14 @@ def main(argv):
         type_name = None
         fileset_type = FilesetType.SINGLE
 
-    generate_fileset(args.prefix, args.count, type_name, goal_name, args.find_path, args.stop_on_error, fileset_type)
+    generate_fileset(
+        args.prefix,
+        args.count,
+        type_name,
+        goal_name,
+        args.find_path,
+        args.stop_on_error,
+        fileset_type)
 
 
 if __name__ == '__main__':

--- a/scene_generator/scene_generator_test.py
+++ b/scene_generator/scene_generator_test.py
@@ -14,10 +14,10 @@ def test_clean_object():
         'info': ['a', 'b', 'c', 'd'],
         'goalString': 'abcd',
         'materialCategory': ['wood'],
-        'dimensions': { 'x': 13, 'z': 42 },
-        'offset': { 'x': 13, 'z': 42 },
-        'closedDimensions': { 'x': 13, 'z': 42 },
-        'closedOffset': { 'x': 13, 'z': 42 },
+        'dimensions': {'x': 13, 'z': 42},
+        'offset': {'x': 13, 'z': 42},
+        'closedDimensions': {'x': 13, 'z': 42},
+        'closedOffset': {'x': 13, 'z': 42},
         'enclosedAreas': [{}],
         'openAreas': [{}],
         'intphysOption': 'stuff',
@@ -40,4 +40,3 @@ def test_clean_object():
     }
     clean_object(obj)
     assert obj == expected
-

--- a/scene_generator/separating_axis_theorem.py
+++ b/scene_generator/separating_axis_theorem.py
@@ -19,7 +19,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-# Copied from https://github.com/JuantAldea/Separating-Axis-Theorem/blob/master/python/separation_axis_theorem.py
+# Copied from
+# https://github.com/JuantAldea/Separating-Axis-Theorem/blob/master/python/separation_axis_theorem.py
 
 # Rewriting things to handle our dict format
 from typing import List, Dict
@@ -44,7 +45,7 @@ def orthogonal(v):
 
 
 def vertices_to_edges(vertices):
-    return [edge_direction(vertices[i], vertices[(i + 1) % len(vertices)]) \
+    return [edge_direction(vertices[i], vertices[(i + 1) % len(vertices)])
             for i in range(len(vertices))]
 
 

--- a/scene_generator/set_target_visibility.py
+++ b/scene_generator/set_target_visibility.py
@@ -25,15 +25,17 @@ def update_file(controller, filename, keep_backups):
     output = controller.start_scene(config_data)
 
     metadata = config_data['goal']['metadata']
-    target_ids = [metadata[key]['id'] for key in ('target', 'target_1', 'target_2') if key in metadata]
+    target_ids = [metadata[key]['id']
+                  for key in ('target', 'target_1', 'target_2') if key in metadata]
     logging.debug(f'target_ids: {target_ids}')
     logging.debug(f'num objects = {len(output.object_list)}')
-    
+
     targets_visible = False
     targets_not_visible = False
     for obj in output.object_list:
         if obj.uuid in target_ids:
-            # If it's in the object list to begin with, it should be visible, but just to make sure...
+            # If it's in the object list to begin with, it should be visible,
+            # but just to make sure...
             if obj.visible:
                 targets_visible = True
                 target_ids.remove(obj.uuid)
@@ -61,12 +63,32 @@ def update_file(controller, filename, keep_backups):
 
 
 def main(argv):
-    parser = argparse.ArgumentParser(description='Update scene descriptions with target visibility info')
-    parser.add_argument('--app', metavar='UNITY_MCS_APP', required=True, help='Path to Unity MCS application')
-    parser.add_argument('--debug', action='store_true', default=False, help='Enable debugging output')
-    parser.add_argument('--backup', action='store_true', default=False, help='Keep backup files')
-    parser.add_argument('--loglevel', choices=LOG_LEVELS, help='set logging level')
-    parser.add_argument('scene_files', metavar='SCENE_FILE', nargs='+', help='scene file to update')
+    parser = argparse.ArgumentParser(
+        description='Update scene descriptions with target visibility info')
+    parser.add_argument(
+        '--app',
+        metavar='UNITY_MCS_APP',
+        required=True,
+        help='Path to Unity MCS application')
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        default=False,
+        help='Enable debugging output')
+    parser.add_argument(
+        '--backup',
+        action='store_true',
+        default=False,
+        help='Keep backup files')
+    parser.add_argument(
+        '--loglevel',
+        choices=LOG_LEVELS,
+        help='set logging level')
+    parser.add_argument(
+        'scene_files',
+        metavar='SCENE_FILE',
+        nargs='+',
+        help='scene file to update')
 
     args = parser.parse_args(argv[1:])
 
@@ -76,7 +98,7 @@ def main(argv):
         logging.getLogger().setLevel(logging.DEBUG)
 
     controller = MCS.create_controller(args.app, args.debug)
-    
+
     for f in args.scene_files:
         update_file(controller, f, args.backup)
 

--- a/scene_generator/tags.py
+++ b/scene_generator/tags.py
@@ -66,15 +66,20 @@ OBJECT_LOCATION_FRONT = 'location in front of performer start'
 OBJECT_LOCATION_RANDOM = 'location random'
 
 
-def append_object_tags(tags: List[str], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> List[str]:
+def append_object_tags(
+        tags: List[str], tag_to_objects: Dict[str, List[Dict[str, Any]]]) -> List[str]:
     append_object_tags_of_type(tags, tag_to_objects['target'], 'target')
     if 'confusor' in tag_to_objects:
-        append_object_tags_of_type(tags, tag_to_objects['confusor'], 'confusor')
+        append_object_tags_of_type(
+            tags, tag_to_objects['confusor'], 'confusor')
     if 'distractor' in tag_to_objects:
-        append_object_tags_of_type(tags, tag_to_objects['distractor'], 'distractor')
+        append_object_tags_of_type(
+            tags, tag_to_objects['distractor'], 'distractor')
     if 'obstructor' in tag_to_objects:
-        append_object_tags_of_type(tags, tag_to_objects['obstructor'], 'obstructor')
-    for item in ['background object', 'confusor', 'distractor', 'obstructor', 'occluder', 'target', 'wall']:
+        append_object_tags_of_type(
+            tags, tag_to_objects['obstructor'], 'obstructor')
+    for item in ['background object', 'confusor', 'distractor',
+                 'obstructor', 'occluder', 'target', 'wall']:
         if item in tag_to_objects:
             number = len(tag_to_objects[item])
             if item == 'occluder':
@@ -83,16 +88,24 @@ def append_object_tags(tags: List[str], tag_to_objects: Dict[str, List[Dict[str,
     return tags
 
 
-def append_object_tags_of_type(tags: List[str], objs: List[Dict[str, Any]], name: str) -> List[str]:
+def append_object_tags_of_type(
+        tags: List[str], objs: List[Dict[str, Any]], name: str) -> List[str]:
     for obj in objs:
-        enclosed_tag = (name + ' not enclosed') if obj.get('locationParent', None) is None else (name + ' enclosed')
+        enclosed_tag = (
+            name +
+            ' not enclosed') if obj.get(
+            'locationParent',
+            None) is None else (
+            name +
+            ' enclosed')
         novel_color_tag = (name + ' novel color') if 'novelColor' in obj and obj['novelColor'] else \
-                (name + ' not novel color')
+            (name + ' not novel color')
         novel_combination_tag = (name + ' novel combination') if 'novelCombination' in obj and \
-                obj['novelCombination'] else (name + ' not novel combination')
+            obj['novelCombination'] else (name + ' not novel combination')
         novel_shape_tag = (name + ' novel shape') if 'novelShape' in obj and obj['novelShape'] else \
-                (name + ' not novel shape')
-        for new_tag in [enclosed_tag, novel_color_tag, novel_combination_tag, novel_shape_tag]:
+            (name + ' not novel shape')
+        for new_tag in [enclosed_tag, novel_color_tag,
+                        novel_combination_tag, novel_shape_tag]:
             if new_tag not in tags:
                 tags.append(new_tag)
     return tags
@@ -112,4 +125,3 @@ def get_obstruct_vision_tag(obstruct_vision: bool) -> str:
 
 def get_ramp_tag(ramp_type_string: str) -> str:
     return 'ramp ' + ramp_type_string
-

--- a/scene_generator/util.py
+++ b/scene_generator/util.py
@@ -16,7 +16,8 @@ PERFORMER_WIDTH = 0.1
 PERFORMER_HALF_WIDTH = PERFORMER_WIDTH / 2.0
 
 
-def random_real(a: float, b: float, step: float = MIN_RANDOM_INTERVAL) -> float:
+def random_real(a: float, b: float,
+                step: float = MIN_RANDOM_INTERVAL) -> float:
     """Return a random real number N where a <= N <= b and N - a is divisible by step."""
     steps = int((b - a) / step)
     try:
@@ -26,8 +27,8 @@ def random_real(a: float, b: float, step: float = MIN_RANDOM_INTERVAL) -> float:
     return a + (n * step)
 
 
-def finalize_object_definition(object_def: Dict[str, Any], choice_material: Optional[Dict[str, Any]] = None, \
-        choice_size: Optional[Dict[str, Any]] = None, choice_type: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def finalize_object_definition(object_def: Dict[str, Any], choice_material: Optional[Dict[str, Any]] = None,
+                               choice_size: Optional[Dict[str, Any]] = None, choice_type: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     object_def_copy = copy.deepcopy(object_def)
 
     if choice_material is None and 'chooseMaterial' in object_def_copy:
@@ -63,34 +64,40 @@ def generate_materials_lists(material_category_list, previous_materials_lists):
 
     output_materials_lists = []
     material_category = material_category_list[0]
-    for material_and_color in getattr(materials, material_category.upper() + '_MATERIALS'):
+    for material_and_color in getattr(
+            materials, material_category.upper() + '_MATERIALS'):
         if not previous_materials_lists:
             output_materials_lists.append([material_and_color])
         else:
             for material_list in previous_materials_lists:
-                output_materials_lists.append(copy.deepcopy(material_list) + [material_and_color])
-    return generate_materials_lists(material_category_list[1:], output_materials_lists)
+                output_materials_lists.append(
+                    copy.deepcopy(material_list) + [material_and_color])
+    return generate_materials_lists(
+        material_category_list[1:], output_materials_lists)
 
 
-def finalize_object_materials_and_colors(object_definition: Dict[str, Any], \
-        override_materials_list: Optional[List[Tuple[str, List[str]]]] = None) -> List[Dict[str, Any]]:
+def finalize_object_materials_and_colors(object_definition: Dict[str, Any],
+                                         override_materials_list: Optional[List[Tuple[str, List[str]]]] = None) -> List[Dict[str, Any]]:
     """Finalizes each possible choice of materials (patterns/textures) and colors as a copy of the given object
     definition and returns the list."""
 
-    materials_lists = [override_materials_list] if override_materials_list else []
+    materials_lists = [
+        override_materials_list] if override_materials_list else []
 
     if not 'materialCategory' in object_definition:
         object_definition['materialCategory'] = []
 
     if not materials_lists:
-        materials_lists = generate_materials_lists(object_definition['materialCategory'], [])
+        materials_lists = generate_materials_lists(
+            object_definition['materialCategory'], [])
 
     if not materials_lists:
         object_definition_copy = copy.deepcopy(object_definition)
-        object_definition_copy['color'] = object_definition_copy['color'] if 'color' in object_definition_copy else []
+        object_definition_copy['color'] = object_definition_copy['color'] if 'color' in object_definition_copy else [
+        ]
         object_definition_copy['materialsList'] = []
         object_definition_copy['materials'] = object_definition_copy['materials'] if 'materials' in \
-                object_definition_copy else []
+            object_definition_copy else []
         return [object_definition_copy]
 
     object_definition_list = []
@@ -98,7 +105,8 @@ def finalize_object_materials_and_colors(object_definition: Dict[str, Any], \
         object_definition_copy = copy.deepcopy(object_definition)
         object_definition_copy['color'] = []
         object_definition_copy['materialsList'] = materials_list
-        object_definition_copy['materials'] = [material_and_color[0] for material_and_color in materials_list]
+        object_definition_copy['materials'] = [
+            material_and_color[0] for material_and_color in materials_list]
         for material_and_color in materials_list:
             if material_and_color[0] in materials.NOVEL_COLOR_LIST:
                 object_definition_copy['novelColor'] = True
@@ -112,13 +120,14 @@ def finalize_object_materials_and_colors(object_definition: Dict[str, Any], \
 def instantiate_object(object_def: Dict[str, Any],
                        object_location: Dict[str, Any],
                        materials_list: Optional[List[Tuple[str, List[str]]]] = None) \
-                       -> Dict[str, Any]:
+        -> Dict[str, Any]:
     """Create a new object from an object definition (as from the objects.json file). object_location will be modified
     by this function."""
     if object_def is None or object_location is None:
         raise ValueError('instantiate_object cannot take None parameters')
 
-    # Call the finalize function here in case it wasn't called before now (calling it twice shouldn't hurt anything).
+    # Call the finalize function here in case it wasn't called before now
+    # (calling it twice shouldn't hurt anything).
     object_def = finalize_object_definition(object_def)
 
     new_object = {
@@ -136,7 +145,8 @@ def instantiate_object(object_def: Dict[str, Any],
     if 'dimensions' in object_def:
         new_object['dimensions'] = object_def['dimensions']
     else:
-        raise exceptions.SceneException(f'object definition "{object_def["type"]}" doesn\'t have dimensions')
+        raise exceptions.SceneException(
+            f'object definition "{object_def["type"]}" doesn\'t have dimensions')
 
     for attribute in object_def['attributes']:
         new_object[attribute] = True
@@ -148,7 +158,8 @@ def instantiate_object(object_def: Dict[str, Any],
         object_location['position']['x'] -= object_def['offset']['x']
         object_location['position']['z'] -= object_def['offset']['z']
 
-    new_object['offset'] = object_def['offset'] if 'offset' in object_def else {'x': 0, 'y': 0, 'z': 0}
+    new_object['offset'] = object_def['offset'] if 'offset' in object_def else {
+        'x': 0, 'y': 0, 'z': 0}
 
     if not 'rotation' in object_def:
         object_def['rotation'] = {'x': 0, 'y': 0, 'z': 0}
@@ -166,14 +177,16 @@ def instantiate_object(object_def: Dict[str, Any],
     object_location['scale'] = object_def['scale']
 
     if 'color' not in object_def or 'materials' not in object_def:
-        object_def = random.choice(finalize_object_materials_and_colors(object_def, materials_list))
+        object_def = random.choice(
+            finalize_object_materials_and_colors(
+                object_def, materials_list))
 
     # need the materials list for quartets
     new_object['materialsList'] = object_def['materialsList']
     new_object['materials'] = object_def['materials']
     new_object['color'] = object_def['color']
     new_object['novelColor'] = (object_def['novelColor'] if 'novelColor' in object_def else False) or \
-            new_object['novelColor']
+        new_object['novelColor']
 
     # The info list contains words that we can use to filter on specific object tags in the UI.
     # Start with this specific ordering of object tags in the info list needed for making the goalString:
@@ -205,18 +218,26 @@ def instantiate_object(object_def: Dict[str, Any],
     if new_object['novelShape']:
         new_object['info'].append('novel ' + ' '.join(new_object['shape']))
 
-    # This object can't be marked as a novel combination if it's a novel color or a novel shape.
-    if new_object['novelCombination'] and (new_object['novelColor'] or new_object['novelShape']):
+    # This object can't be marked as a novel combination if it's a novel color
+    # or a novel shape.
+    if new_object['novelCombination'] and (
+            new_object['novelColor'] or new_object['novelShape']):
         new_object['novelCombination'] = False
 
     if new_object['novelCombination']:
         for color in list(new_object['color']):
-            new_object['info'].append('novel ' + color + ' ' + ' '.join(new_object['shape']))
+            new_object['info'].append(
+                'novel ' +
+                color +
+                ' ' +
+                ' '.join(
+                    new_object['shape']))
 
     return new_object
 
 
-def get_similar_definition(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+def get_similar_definition(
+        obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """Get an object definition similar to obj but different in one of
     type, material, or scale. It is possible but unlikely that no such
     definition can be found, in which case it returns None.
@@ -245,7 +266,8 @@ def check_same_and_different(a: Dict[str, Any], b: Dict[str, Any],
     same_ok = True
     for prop in same:
         if prop == 'dimensions':
-            # Look at the dimensions as well as the size tag (tiny/small/medium/large/huge/etc.)
+            # Look at the dimensions as well as the size tag
+            # (tiny/small/medium/large/huge/etc.)
             if b[prop]['x'] > (a[prop]['x'] + MAX_SIZE_DIFFERENCE) or \
                     b[prop]['x'] < (a[prop]['x'] - MAX_SIZE_DIFFERENCE) or \
                     b[prop]['y'] > (a[prop]['y'] + MAX_SIZE_DIFFERENCE) or \
@@ -265,7 +287,8 @@ def check_same_and_different(a: Dict[str, Any], b: Dict[str, Any],
     diff_ok = True
     for prop in different:
         if prop == 'dimensions':
-            # Look at the dimensions as well as the size tag (tiny/small/medium/large/huge/etc.)
+            # Look at the dimensions as well as the size tag
+            # (tiny/small/medium/large/huge/etc.)
             if b[prop]['x'] <= (a[prop]['x'] + MAX_SIZE_DIFFERENCE) and \
                     b[prop]['x'] >= (a[prop]['x'] - MAX_SIZE_DIFFERENCE) and \
                     b[prop]['y'] <= (a[prop]['y'] + MAX_SIZE_DIFFERENCE) and \
@@ -282,7 +305,8 @@ def check_same_and_different(a: Dict[str, Any], b: Dict[str, Any],
     return diff_ok
 
 
-def finalize_each_object_definition_choice(object_definition: Dict[str, Any]) -> List[Dict[str, Any]]:
+def finalize_each_object_definition_choice(
+        object_definition: Dict[str, Any]) -> List[Dict[str, Any]]:
     choice_list = []
     for prop in ['chooseMaterial', 'chooseSize', 'chooseType']:
         if prop in object_definition and len(object_definition[prop]) > 0:
@@ -290,7 +314,10 @@ def finalize_each_object_definition_choice(object_definition: Dict[str, Any]) ->
             next_choice_list = []
             for choice_string in object_definition[prop]:
                 if not previous_choice_list:
-                    choice_dict = {'chooseMaterial': None, 'chooseSize': None, 'chooseType': None}
+                    choice_dict = {
+                        'chooseMaterial': None,
+                        'chooseSize': None,
+                        'chooseType': None}
                     choice_dict[prop] = choice_string
                     next_choice_list.append(choice_dict)
                 else:
@@ -305,9 +332,10 @@ def finalize_each_object_definition_choice(object_definition: Dict[str, Any]) ->
 
     output_list = []
     for choice_dict in choice_list:
-        output_list.append(finalize_object_definition(copy.deepcopy(object_definition), \
-                choice_material = choice_dict['chooseMaterial'], choice_size = choice_dict['chooseSize'], \
-                choice_type = choice_dict['chooseType']))
+        output_list.append(finalize_object_definition(copy.deepcopy(object_definition),
+                                                      choice_material=choice_dict[
+                                                          'chooseMaterial'], choice_size=choice_dict['chooseSize'],
+                                                      choice_type=choice_dict['chooseType']))
     random.shuffle(output_list)
     return output_list
 
@@ -322,15 +350,19 @@ def get_similar_defs(obj: Dict[str, Any], all_defs: List[Dict[str, Any]], same: 
     for obj_def in all_defs:
         possible_obj_defs = finalize_each_object_definition_choice(obj_def)
         for possible_obj_def_template in possible_obj_defs:
-            possible_obj_def_list = finalize_object_materials_and_colors(possible_obj_def_template)
+            possible_obj_def_list = finalize_object_materials_and_colors(
+                possible_obj_def_template)
             for possible_obj_def in possible_obj_def_list:
-                if check_same_and_different(possible_obj_def, obj, same, different):
+                if check_same_and_different(
+                        possible_obj_def, obj, same, different):
                     valid_defs.append(possible_obj_def)
     return valid_defs
 
 
-def get_def_with_new_shape(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, all_defs, ('color', 'dimensions'), ('shape',))
+def get_def_with_new_shape(
+        obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(
+        obj, all_defs, ('color', 'dimensions'), ('shape',))
     if len(valid_defs) == 0:
         return None
     obj_def = random.choice(valid_defs)
@@ -339,8 +371,10 @@ def get_def_with_new_shape(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) 
     return obj_def
 
 
-def get_def_with_new_color(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, all_defs, ('shape', 'dimensions'), ('color',))
+def get_def_with_new_color(
+        obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(
+        obj, all_defs, ('shape', 'dimensions'), ('color',))
     if len(valid_defs) == 0:
         return None
     obj_def = random.choice(valid_defs)
@@ -349,8 +383,10 @@ def get_def_with_new_color(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) 
     return obj_def
 
 
-def get_def_with_new_size(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
-    valid_defs = get_similar_defs(obj, all_defs, ('shape', 'color'), ('dimensions',))
+def get_def_with_new_size(
+        obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    valid_defs = get_similar_defs(
+        obj, all_defs, ('shape', 'color'), ('dimensions',))
     if len(valid_defs) == 0:
         return None
     obj_def = random.choice(valid_defs)
@@ -359,8 +395,8 @@ def get_def_with_new_size(obj: Dict[str, Any], all_defs: List[Dict[str, Any]]) -
     return obj_def
 
 
-def move_to_location(object_definition: Dict[str, Any], object_instance: Dict[str, Any], location: Dict[str, Any], \
-        object_bounds: List[Dict[str, float]], previous_definition: Dict[str, Any]) -> Dict[str, Any]:
+def move_to_location(object_definition: Dict[str, Any], object_instance: Dict[str, Any], location: Dict[str, Any],
+                     object_bounds: List[Dict[str, float]], previous_definition: Dict[str, Any]) -> Dict[str, Any]:
     """Move the given object to a new location and return the object."""
     new_location = copy.deepcopy(location)
     if previous_definition and 'offset' in previous_definition:
@@ -375,11 +411,12 @@ def move_to_location(object_definition: Dict[str, Any], object_instance: Dict[st
     return object_instance
 
 
-def retrieve_full_object_definition_list(base_definition_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def retrieve_full_object_definition_list(
+        base_definition_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Return the given object definition list in which finalize_object_definition was called on each definition with
     each possible choice."""
     object_definition_list = []
     for base_object_definition in base_definition_list:
-        object_definition_list = object_definition_list + finalize_each_object_definition_choice(base_object_definition)
+        object_definition_list = object_definition_list + \
+            finalize_each_object_definition_choice(base_object_definition)
     return object_definition_list
-

--- a/scene_generator/util_test.py
+++ b/scene_generator/util_test.py
@@ -5,7 +5,7 @@ import materials
 import objects
 from goals import *
 from util import finalize_object_definition, instantiate_object, check_same_and_different, get_similar_defs, \
-        random_real, move_to_location, retrieve_full_object_definition_list
+    random_real, move_to_location, retrieve_full_object_definition_list
 
 
 PACIFIER = {
@@ -38,7 +38,8 @@ PACIFIER = {
 def test_random_real():
     n = random_real(0, 1, 0.1)
     assert 0 <= n <= 1
-    # need to multiply by 10 and mod by 1 instead of 0.1 to avoid weird roundoff
+    # need to multiply by 10 and mod by 1 instead of 0.1 to avoid weird
+    # roundoff
     assert n * 10 % 1 < 1e-8
 
 
@@ -89,7 +90,7 @@ def test_instantiate_object():
         }
     }
     obj = instantiate_object(object_def, object_location)
-    assert type(obj['id']) is str
+    assert isinstance(obj['id'], str)
     assert obj['type'] == 'sofa_1'
     assert obj['dimensions'] == object_def['dimensions']
     assert obj['goalString'] == 'huge massive sofa'
@@ -419,9 +420,12 @@ def test_check_same_and_different():
         'ignore': 42
     }
     assert check_same_and_different(a, b, [], []) is True
-    assert check_same_and_different(a, b, ('shape', 'size'), ('color',)) is True
-    assert check_same_and_different(a, b, ('shape', 'color'), ('size',)) is False
-    assert check_same_and_different(a, b, ('color', 'size'), ('shape',)) is False
+    assert check_same_and_different(
+        a, b, ('shape', 'size'), ('color',)) is True
+    assert check_same_and_different(
+        a, b, ('shape', 'color'), ('size',)) is False
+    assert check_same_and_different(
+        a, b, ('color', 'size'), ('shape',)) is False
 
 
 def test_check_same_and_different_with_list():
@@ -484,52 +488,80 @@ def test_check_same_and_different_with_dimensions():
         'dimensions': {'x': 0.8, 'y': 0.8, 'z': 0.8},
         'size': 'medium'
     }
-    assert check_same_and_different(object_1, object_2, ('shape','dimensions'), ('id',)) is True
-    assert check_same_and_different(object_1, object_3, ('shape','dimensions'), ('id',)) is True
-    assert check_same_and_different(object_1, object_4, ('shape','dimensions'), ('id',)) is True
-    assert check_same_and_different(object_1, object_5, ('shape','dimensions'), ('id',)) is False
-    assert check_same_and_different(object_1, object_6, ('shape','dimensions'), ('id',)) is False
-    assert check_same_and_different(object_1, object_2, ('shape',), ('id','dimensions')) is False
-    assert check_same_and_different(object_1, object_3, ('shape',), ('id','dimensions')) is False
-    assert check_same_and_different(object_1, object_4, ('shape',), ('id','dimensions')) is False
-    assert check_same_and_different(object_1, object_5, ('shape',), ('id','dimensions')) is True
-    assert check_same_and_different(object_1, object_6, ('shape',), ('id','dimensions')) is True
+    assert check_same_and_different(
+        object_1, object_2, ('shape', 'dimensions'), ('id',)) is True
+    assert check_same_and_different(
+        object_1, object_3, ('shape', 'dimensions'), ('id',)) is True
+    assert check_same_and_different(
+        object_1, object_4, ('shape', 'dimensions'), ('id',)) is True
+    assert check_same_and_different(
+        object_1, object_5, ('shape', 'dimensions'), ('id',)) is False
+    assert check_same_and_different(
+        object_1, object_6, ('shape', 'dimensions'), ('id',)) is False
+    assert check_same_and_different(
+        object_1, object_2, ('shape',), ('id', 'dimensions')) is False
+    assert check_same_and_different(
+        object_1, object_3, ('shape',), ('id', 'dimensions')) is False
+    assert check_same_and_different(
+        object_1, object_4, ('shape',), ('id', 'dimensions')) is False
+    assert check_same_and_different(
+        object_1, object_5, ('shape',), ('id', 'dimensions')) is True
+    assert check_same_and_different(
+        object_1, object_6, ('shape',), ('id', 'dimensions')) is True
 
 
 def test_check_same_and_different_pacifier():
-    assert check_same_and_different(PACIFIER, PACIFIER, ('shape', 'dimensions'), ('materialCategory',)) is False
-    assert check_same_and_different(PACIFIER, PACIFIER, ('shape', 'materialCategory'), ('dimensions',)) is False
-    assert check_same_and_different(PACIFIER, PACIFIER, ('dimensions', 'materialCategory'), ('shape',)) is False
+    assert check_same_and_different(
+        PACIFIER, PACIFIER, ('shape', 'dimensions'), ('materialCategory',)) is False
+    assert check_same_and_different(
+        PACIFIER, PACIFIER, ('shape', 'materialCategory'), ('dimensions',)) is False
+    assert check_same_and_different(
+        PACIFIER, PACIFIER, ('dimensions', 'materialCategory'), ('shape',)) is False
 
 
 def test_get_similar_defs_color():
-    object_definition_list = retrieve_full_object_definition_list(objects.get('ALL'))
+    object_definition_list = retrieve_full_object_definition_list(
+        objects.get('ALL'))
     for object_definition in object_definition_list:
-        object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
-        similar_list = get_similar_defs(object_instance, object_definition_list, ('dimensions', 'shape'), ('color',))
+        object_instance = instantiate_object(
+            object_definition, geometry.ORIGIN_LOCATION)
+        similar_list = get_similar_defs(
+            object_instance, object_definition_list, ('dimensions', 'shape'), ('color',))
         for similar_definition in similar_list:
-            similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
-            assert check_same_and_different(similar_instance, object_instance, ('dimensions', 'shape'), ('color',))
+            similar_instance = instantiate_object(
+                similar_definition, geometry.ORIGIN_LOCATION)
+            assert check_same_and_different(
+                similar_instance, object_instance, ('dimensions', 'shape'), ('color',))
 
 
 def test_get_similar_defs_shape():
-    object_definition_list = retrieve_full_object_definition_list(objects.get('ALL'))
+    object_definition_list = retrieve_full_object_definition_list(
+        objects.get('ALL'))
     for object_definition in object_definition_list:
-        object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
-        similar_list = get_similar_defs(object_instance, object_definition_list, ('color', 'dimensions'), ('shape',))
+        object_instance = instantiate_object(
+            object_definition, geometry.ORIGIN_LOCATION)
+        similar_list = get_similar_defs(
+            object_instance, object_definition_list, ('color', 'dimensions'), ('shape',))
         for similar_definition in similar_list:
-            similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
-            assert check_same_and_different(similar_instance, object_instance, ('color', 'dimensions'), ('shape',))
+            similar_instance = instantiate_object(
+                similar_definition, geometry.ORIGIN_LOCATION)
+            assert check_same_and_different(
+                similar_instance, object_instance, ('color', 'dimensions'), ('shape',))
 
 
 def test_get_similar_defs_size():
-    object_definition_list = retrieve_full_object_definition_list(objects.get('ALL'))
+    object_definition_list = retrieve_full_object_definition_list(
+        objects.get('ALL'))
     for object_definition in object_definition_list:
-        object_instance = instantiate_object(object_definition, geometry.ORIGIN_LOCATION)
-        similar_list = get_similar_defs(object_instance, object_definition_list, ('color', 'shape'), ('dimensions',))
+        object_instance = instantiate_object(
+            object_definition, geometry.ORIGIN_LOCATION)
+        similar_list = get_similar_defs(
+            object_instance, object_definition_list, ('color', 'shape'), ('dimensions',))
         for similar_definition in similar_list:
-            similar_instance = instantiate_object(similar_definition, geometry.ORIGIN_LOCATION)
-            assert check_same_and_different(similar_instance, object_instance, ('color', 'shape'), ('dimensions',))
+            similar_instance = instantiate_object(
+                similar_definition, geometry.ORIGIN_LOCATION)
+            assert check_same_and_different(
+                similar_instance, object_instance, ('color', 'shape'), ('dimensions',))
 
 
 def test_instantiate_object_novel_color():
@@ -559,7 +591,14 @@ def test_instantiate_object_novel_color():
     }
     obj = instantiate_object(object_def, object_location)
     assert obj['goalString'] == 'huge massive blue yellow sofa'
-    assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel blue', 'novel yellow']
+    assert obj['info'] == [
+        'huge',
+        'massive',
+        'blue',
+        'yellow',
+        'sofa',
+        'novel blue',
+        'novel yellow']
 
 
 def test_instantiate_object_novel_combination():
@@ -589,7 +628,14 @@ def test_instantiate_object_novel_combination():
     }
     obj = instantiate_object(object_def, object_location)
     assert obj['goalString'] == 'huge massive blue yellow sofa'
-    assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel blue sofa', 'novel yellow sofa']
+    assert obj['info'] == [
+        'huge',
+        'massive',
+        'blue',
+        'yellow',
+        'sofa',
+        'novel blue sofa',
+        'novel yellow sofa']
 
 
 def test_instantiate_object_novel_shape():
@@ -619,20 +665,31 @@ def test_instantiate_object_novel_shape():
     }
     obj = instantiate_object(object_def, object_location)
     assert obj['goalString'] == 'huge massive blue yellow sofa'
-    assert obj['info'] == ['huge', 'massive', 'blue', 'yellow', 'sofa', 'novel sofa']
+    assert obj['info'] == [
+        'huge',
+        'massive',
+        'blue',
+        'yellow',
+        'sofa',
+        'novel sofa']
 
 
 def test_move_to_location():
-    instance = {'shows': [{'position': {'x': -1, 'y': 0, 'z': -1}, 'rotation': {'x': 0, 'y': 90, 'z': 0}}]}
-    bounds = [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, {'x': 1, 'z': 3}]
-    location = {'position': {'x': 2, 'y': 0, 'z': 2}, 'rotation': {'x': 0, 'y': 0, 'z': 0}}
+    instance = {'shows': [{'position': {'x': -1, 'y': 0,
+                                        'z': -1}, 'rotation': {'x': 0, 'y': 90, 'z': 0}}]}
+    bounds = [{'x': 3, 'z': 3}, {'x': 3, 'z': 1},
+              {'x': 1, 'z': 1}, {'x': 1, 'z': 3}]
+    location = {
+        'position': {
+            'x': 2, 'y': 0, 'z': 2}, 'rotation': {
+            'x': 0, 'y': 0, 'z': 0}}
 
     actual = move_to_location({}, instance, location, bounds, {})
     assert actual == instance
     assert instance['shows'][0]['position'] == {'x': 2, 'y': 0, 'z': 2}
     assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
-    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
-            {'x': 1, 'z': 3}]
+    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1},
+                                                   {'x': 1, 'z': 3}]
 
     definition = {'offset': {'x': 0.1, 'z': -0.5}}
 
@@ -640,8 +697,8 @@ def test_move_to_location():
     assert actual == instance
     assert instance['shows'][0]['position'] == {'x': 1.9, 'y': 0, 'z': 2.5}
     assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
-    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
-            {'x': 1, 'z': 3}]
+    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1},
+                                                   {'x': 1, 'z': 3}]
 
     previous = {'offset': {'x': 0.2, 'z': -0.4}}
 
@@ -649,37 +706,36 @@ def test_move_to_location():
     assert actual == instance
     assert instance['shows'][0]['position'] == {'x': 2.2, 'y': 0, 'z': 1.6}
     assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
-    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
-            {'x': 1, 'z': 3}]
+    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1},
+                                                   {'x': 1, 'z': 3}]
 
     actual = move_to_location(definition, instance, location, bounds, previous)
     assert actual == instance
     assert instance['shows'][0]['position'] == {'x': 2.1, 'y': 0, 'z': 2.1}
     assert instance['shows'][0]['rotation'] == {'x': 0, 'y': 0, 'z': 0}
-    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1}, \
-            {'x': 1, 'z': 3}]
+    assert instance['shows'][0]['boundingBox'] == [{'x': 3, 'z': 3}, {'x': 3, 'z': 1}, {'x': 1, 'z': 1},
+                                                   {'x': 1, 'z': 3}]
 
 
 def test_retrieve_full_object_definition_list():
-    list_1 = [{ 'type': 'ball', 'mass': 1 }]
+    list_1 = [{'type': 'ball', 'mass': 1}]
     actual_1 = retrieve_full_object_definition_list(list_1)
     assert len(actual_1) == 1
 
-    list_2 = [{ 'type': 'ball', 'chooseSize': [{ 'mass': 1 }, { 'mass': 2 }] }]
+    list_2 = [{'type': 'ball', 'chooseSize': [{'mass': 1}, {'mass': 2}]}]
     actual_2 = retrieve_full_object_definition_list(list_2)
     assert len(actual_2) == 2
 
     list_3 = [
-        { 'type': 'sofa' },
-        { 'type': 'ball', 'chooseSize': [{ 'mass': 1 }, { 'mass': 2 }] }
+        {'type': 'sofa'},
+        {'type': 'ball', 'chooseSize': [{'mass': 1}, {'mass': 2}]}
     ]
     actual_3 = retrieve_full_object_definition_list(list_3)
     assert len(actual_3) == 3
 
     list_4 = [
-        { 'type': 'sofa', 'chooseSize': [{ 'mass': 1 }, { 'mass': 3 }] },
-        { 'type': 'ball', 'chooseSize': [{ 'mass': 1 }, { 'mass': 2 }] }
+        {'type': 'sofa', 'chooseSize': [{'mass': 1}, {'mass': 3}]},
+        {'type': 'ball', 'chooseSize': [{'mass': 1}, {'mass': 2}]}
     ]
     actual_4 = retrieve_full_object_definition_list(list_4)
     assert len(actual_4) == 4
-


### PR DESCRIPTION
(Take 2)

Still need to fix additional linter errors, so the scene_generator code hasn't yet been added to the pre-commit hook (there will be an additional PR for this). I added a vscode settings file for the scene generator, so that should cover any automatically fixable formatting issues for the time being. Also added autopep8 and flake8 to the scene generator's requirements.txt since I had left that out before.

@ThomasSchellenbergNextCentury Ran autopep8 on a lower aggressiveness level -- should fix the way line breaks were done per argument on long function names, but if there's still any issue with how the autoformatter works, please let me know (see lines 10 and 176 in containers.py for a couple examples). 
 