### PR TITLE
MCS-358 - Add plausability parameters to step function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ python_api/scenes/images/*.gif
 
 **/SCENE_HISTORY
 
+# test run script for Python API
+python_api/machine_common_sense/run_mcs_env.py
+
 # python docs
 python_api/machine_common_sense/docs
 python_api/machine_common_sense/venv

--- a/python_api/API.md
+++ b/python_api/API.md
@@ -155,7 +155,7 @@ returns the scene output data object.
 
 
 
-#### step(action: str, choice: str = None, confidence: float = None, violations_xy_list: List[Dict[str, float]] = None, heatmap_img: <module 'PIL.Image' from '/Users/rartiss/MCS/MCS-repo/python_api/machine_common_sense/venv/lib/python3.8/site-packages/PIL/Image.py'> = None, internal_state: object = None, \*\*kwargs)
+#### step(action: str, choice: str = None, confidence: float = None, violations_xy_list: List[Dict[str, float]] = None, heatmap_img: PIL.Image = None, internal_state: object = None, \*\*kwargs)
 Runs the given action within the current scene and unpauses the scene’s
 physics simulation for a few frames. Can also optionally send
 information about scene plausability if applicable.

--- a/python_api/API.md
+++ b/python_api/API.md
@@ -155,7 +155,7 @@ returns the scene output data object.
 
 
 
-#### step(action: str, choice: str = None, confidence: float = None, violations_xy_list: List[Dict[str, float]] = None, heatmap_img: PIL.Image = None, internal_state: object = None, \*\*kwargs)
+#### step(action: str, choice: str = None, confidence: float = None, violations_xy_list: List[Dict[str, float]] = None, heatmap_img: PIL.Image.Image = None, internal_state: object = None, \*\*kwargs)
 Runs the given action within the current scene and unpauses the scene’s
 physics simulation for a few frames. Can also optionally send
 information about scene plausability if applicable.
@@ -182,7 +182,7 @@ information about scene plausability if applicable.
     on each step for passive tasks. (default None)
 
 
-    * **heatmap_img** (*PIL.Image**, **optional*) – An image representing scene plausiblility at a particular
+    * **heatmap_img** (*PIL.Image.Image**, **optional*) – An image representing scene plausiblility at a particular
     moment. Will be saved as a .png type. (default None)
 
 

--- a/python_api/API.md
+++ b/python_api/API.md
@@ -155,7 +155,7 @@ returns the scene output data object.
 
 
 
-#### step(action, choice=None, confidence=None, heatmap_img=None, internal_state=None, \*\*kwargs)
+#### step(action: str, choice: str = None, confidence: float = None, heatmap_img: <module 'PIL.Image' from '/Users/rartiss/MCS/MCS-repo/python_api/machine_common_sense/venv/lib/python3.8/site-packages/PIL/Image.py'> = None, internal_state: object = None, \*\*kwargs)
 Runs the given action within the current scene and unpauses the scene’s
 physics simulation for a few frames. Can also optionally send
 information about scene plausability if applicable.
@@ -177,8 +177,8 @@ information about scene plausability if applicable.
     Is not required for other goals. (default None)
 
 
-    * **heatmap_img** (*string**, **optional*) – An image representing scene plausiblility at a particular
-    moment (default None)
+    * **heatmap_img** (*PIL.Image**, **optional*) – An image representing scene plausiblility at a particular
+    moment. Will be saved as a .png type. (default None)
 
 
     * **internal_state** (*object**, **optional*) – A properly formatted json object representing various kinds of

--- a/python_api/API.md
+++ b/python_api/API.md
@@ -155,7 +155,7 @@ returns the scene output data object.
 
 
 
-#### step(action: str, choice: str = None, confidence: float = None, heatmap_img: <module 'PIL.Image' from '/Users/rartiss/MCS/MCS-repo/python_api/machine_common_sense/venv/lib/python3.8/site-packages/PIL/Image.py'> = None, internal_state: object = None, \*\*kwargs)
+#### step(action: str, choice: str = None, confidence: float = None, violations_xy_list: List[Dict[str, float]] = None, heatmap_img: <module 'PIL.Image' from '/Users/rartiss/MCS/MCS-repo/python_api/machine_common_sense/venv/lib/python3.8/site-packages/PIL/Image.py'> = None, internal_state: object = None, \*\*kwargs)
 Runs the given action within the current scene and unpauses the scene’s
 physics simulation for a few frames. Can also optionally send
 information about scene plausability if applicable.
@@ -177,14 +177,18 @@ information about scene plausability if applicable.
     Is not required for other goals. (default None)
 
 
+    * **violations_xy_list** (*List**[**Dict**[**str**, **float**]**]**, **optional*) – A list of one or more (x, y) locations (ex: [{“x”: 1, “y”: 3.4}]),
+    each representing a potential violation-of-expectation. Required
+    on each step for passive tasks. (default None)
+
+
     * **heatmap_img** (*PIL.Image**, **optional*) – An image representing scene plausiblility at a particular
     moment. Will be saved as a .png type. (default None)
 
 
     * **internal_state** (*object**, **optional*) – A properly formatted json object representing various kinds of
     internal states at a particular moment. Examples include the
-    estimated position of the agent, details on spatial
-    location of the VoE, current map of the world, etc.
+    estimated position of the agent, current map of the world, etc.
     (default None)
 
 

--- a/python_api/API.md
+++ b/python_api/API.md
@@ -155,15 +155,37 @@ returns the scene output data object.
 
 
 
-#### step(action, \*\*kwargs)
+#### step(action, choice=None, confidence=None, heatmap_img=None, internal_state=None, \*\*kwargs)
 Runs the given action within the current scene and unpauses the scene’s
-physics simulation for a few frames.
+physics simulation for a few frames. Can also optionally send
+information about scene plausability if applicable.
 
 
 * **Parameters**
 
     
     * **action** (*string*) – A selected action string from the list of available actions.
+
+
+    * **choice** (*string**, **optional*) – The selected choice required by the end of scenes with
+    violation-of-expectation or classification goals.
+    Is not required for other goals. (default None)
+
+
+    * **confidence** (*float**, **optional*) – The choice confidence between 0 and 1 required by the end of
+    scenes with violation-of-expectation or classification goals.
+    Is not required for other goals. (default None)
+
+
+    * **heatmap_img** (*string**, **optional*) – An image representing scene plausiblility at a particular
+    moment (default None)
+
+
+    * **internal_state** (*object**, **optional*) – A properly formatted json object representing various kinds of
+    internal states at a particular moment. Examples include the
+    estimated position of the agent, details on spatial
+    location of the VoE, current map of the world, etc.
+    (default None)
 
 
     * **\*\*kwargs** – Zero or more key-and-value parameters for the action.

--- a/python_api/machine_common_sense/controller.py
+++ b/python_api/machine_common_sense/controller.py
@@ -1,6 +1,7 @@
 from .step_metadata import StepMetadata
 import random
 import PIL
+from typing import Dict, List
 
 
 class Controller:
@@ -52,7 +53,9 @@ class Controller:
         return StepMetadata()
 
     def step(self, action: str, choice: str = None,
-             confidence: float = None, heatmap_img: PIL.Image = None,
+             confidence: float = None,
+             violations_xy_list: List[Dict[str, float]] = None,
+             heatmap_img: PIL.Image = None,
              internal_state: object = None,
              **kwargs) -> StepMetadata:
         """
@@ -72,14 +75,17 @@ class Controller:
             The choice confidence between 0 and 1 required by the end of
             scenes with violation-of-expectation or classification goals.
             Is not required for other goals. (default None)
+        violations_xy_list : List[Dict[str, float]], optional
+            A list of one or more (x, y) locations (ex: [{"x": 1, "y": 3.4}]),
+            each representing a potential violation-of-expectation. Required
+            on each step for passive tasks. (default None)
         heatmap_img : PIL.Image, optional
             An image representing scene plausiblility at a particular
             moment. Will be saved as a .png type. (default None)
         internal_state : object, optional
             A properly formatted json object representing various kinds of
             internal states at a particular moment. Examples include the
-            estimated position of the agent, details on spatial
-            location of the VoE, current map of the world, etc.
+            estimated position of the agent, current map of the world, etc.
             (default None)
         **kwargs
             Zero or more key-and-value parameters for the action.

--- a/python_api/machine_common_sense/controller.py
+++ b/python_api/machine_common_sense/controller.py
@@ -55,7 +55,7 @@ class Controller:
     def step(self, action: str, choice: str = None,
              confidence: float = None,
              violations_xy_list: List[Dict[str, float]] = None,
-             heatmap_img: PIL.Image = None,
+             heatmap_img: PIL.Image.Image = None,
              internal_state: object = None,
              **kwargs) -> StepMetadata:
         """
@@ -79,7 +79,7 @@ class Controller:
             A list of one or more (x, y) locations (ex: [{"x": 1, "y": 3.4}]),
             each representing a potential violation-of-expectation. Required
             on each step for passive tasks. (default None)
-        heatmap_img : PIL.Image, optional
+        heatmap_img : PIL.Image.Image, optional
             An image representing scene plausiblility at a particular
             moment. Will be saved as a .png type. (default None)
         internal_state : object, optional

--- a/python_api/machine_common_sense/controller.py
+++ b/python_api/machine_common_sense/controller.py
@@ -50,15 +50,34 @@ class Controller:
         # TODO Override
         return StepMetadata()
 
-    def step(self, action, **kwargs):
+    def step(self, action, choice=None, confidence=None, heatmap_img=None,
+             internal_state=None, **kwargs):
         """
         Runs the given action within the current scene and unpauses the scene's
-        physics simulation for a few frames.
+        physics simulation for a few frames. Can also optionally send
+        information about scene plausability if applicable.
 
         Parameters
         ----------
         action : string
             A selected action string from the list of available actions.
+        choice : string, optional
+            The selected choice required by the end of scenes with
+            violation-of-expectation or classification goals.
+            Is not required for other goals. (default None)
+        confidence : float, optional
+            The choice confidence between 0 and 1 required by the end of
+            scenes with violation-of-expectation or classification goals.
+            Is not required for other goals. (default None)
+        heatmap_img : string, optional
+            An image representing scene plausiblility at a particular
+            moment (default None)
+        internal_state : object, optional
+            A properly formatted json object representing various kinds of
+            internal states at a particular moment. Examples include the
+            estimated position of the agent, details on spatial
+            location of the VoE, current map of the world, etc.
+            (default None)
         **kwargs
             Zero or more key-and-value parameters for the action.
 

--- a/python_api/machine_common_sense/controller.py
+++ b/python_api/machine_common_sense/controller.py
@@ -1,5 +1,6 @@
 from .step_metadata import StepMetadata
 import random
+import PIL
 
 
 class Controller:
@@ -50,8 +51,10 @@ class Controller:
         # TODO Override
         return StepMetadata()
 
-    def step(self, action, choice=None, confidence=None, heatmap_img=None,
-             internal_state=None, **kwargs):
+    def step(self, action: str, choice: str = None,
+             confidence: float = None, heatmap_img: PIL.Image = None,
+             internal_state: object = None,
+             **kwargs) -> StepMetadata:
         """
         Runs the given action within the current scene and unpauses the scene's
         physics simulation for a few frames. Can also optionally send
@@ -69,9 +72,9 @@ class Controller:
             The choice confidence between 0 and 1 required by the end of
             scenes with violation-of-expectation or classification goals.
             Is not required for other goals. (default None)
-        heatmap_img : string, optional
+        heatmap_img : PIL.Image, optional
             An image representing scene plausiblility at a particular
-            moment (default None)
+            moment. Will be saved as a .png type. (default None)
         internal_state : object, optional
             A properly formatted json object representing various kinds of
             internal states at a particular moment. Examples include the

--- a/python_api/machine_common_sense/controller_ai2thor.py
+++ b/python_api/machine_common_sense/controller_ai2thor.py
@@ -8,6 +8,7 @@ import random
 import sys
 import yaml
 import PIL
+from typing import Dict, List
 
 import ai2thor.controller
 import ai2thor.server
@@ -507,7 +508,9 @@ class ControllerAI2THOR(Controller):
 
     # Override
     def step(self, action: str, choice: str = None,
-             confidence: float = None, heatmap_img: PIL.Image = None,
+             confidence: float = None,
+             violations_xy_list: List[Dict[str, float]] = None,
+             heatmap_img: PIL.Image = None,
              internal_state: object = None,
              **kwargs) -> StepMetadata:
         """
@@ -527,14 +530,17 @@ class ControllerAI2THOR(Controller):
             The choice confidence between 0 and 1 required by the end of
             scenes with violation-of-expectation or classification goals.
             Is not required for other goals. (default None)
+        violations_xy_list : List[Dict[str, float]], optional
+            A list of one or more (x, y) locations (ex: [{"x": 1, "y": 3.4}]),
+            each representing a potential violation-of-expectation. Required
+            on each step for passive tasks. (default None)
         heatmap_img : PIL.Image, optional
             An image representing scene plausiblility at a particular
             moment. Will be saved as a .png type. (default None)
         internal_state : object, optional
             A properly formatted json object representing various kinds of
             internal states at a particular moment. Examples include the
-            estimated position of the agent, details on spatial
-            location of the VoE, current map of the world, etc.
+            estimated position of the agent, current map of the world, etc.
             (default None)
         **kwargs
             Zero or more key-and-value parameters for the action.
@@ -547,8 +553,8 @@ class ControllerAI2THOR(Controller):
             "last_step" of this scene.
         """
 
-        super().step(action, choice, confidence, heatmap_img,
-                     internal_state, **kwargs)
+        super().step(action, choice, confidence, violations_xy_list,
+                     heatmap_img, internal_state, **kwargs)
 
         if (self._goal.last_step is not None and
                 self._goal.last_step == self.__step_number):
@@ -608,6 +614,7 @@ class ControllerAI2THOR(Controller):
             params=params,
             classification=choice,
             confidence=confidence,
+            violations_xy_list=violations_xy_list,
             internal_state=internal_state,
             output=output_copy)
         self.__history_list.append(history_item)

--- a/python_api/machine_common_sense/controller_ai2thor.py
+++ b/python_api/machine_common_sense/controller_ai2thor.py
@@ -510,7 +510,7 @@ class ControllerAI2THOR(Controller):
     def step(self, action: str, choice: str = None,
              confidence: float = None,
              violations_xy_list: List[Dict[str, float]] = None,
-             heatmap_img: PIL.Image = None,
+             heatmap_img: PIL.Image.Image = None,
              internal_state: object = None,
              **kwargs) -> StepMetadata:
         """
@@ -534,7 +534,7 @@ class ControllerAI2THOR(Controller):
             A list of one or more (x, y) locations (ex: [{"x": 1, "y": 3.4}]),
             each representing a potential violation-of-expectation. Required
             on each step for passive tasks. (default None)
-        heatmap_img : PIL.Image, optional
+        heatmap_img : PIL.Image.Image, optional
             An image representing scene plausiblility at a particular
             moment. Will be saved as a .png type. (default None)
         internal_state : object, optional

--- a/python_api/machine_common_sense/controller_ai2thor.py
+++ b/python_api/machine_common_sense/controller_ai2thor.py
@@ -7,7 +7,7 @@ import os
 import random
 import sys
 import yaml
-from PIL import Image
+import PIL
 
 import ai2thor.controller
 import ai2thor.server
@@ -150,6 +150,8 @@ class ControllerAI2THOR(Controller):
     CONFIG_SAVE_IMAGES_TO_S3_BUCKET = 'save_images_to_s3_bucket'
     CONFIG_SAVE_IMAGES_TO_S3_FOLDER = 'save_images_to_s3_folder'
     CONFIG_TEAM = 'team'
+
+    HEATMAP_IMAGE_PREFIX = 'heatmap'
 
     def __init__(self, unity_app_file_path, debug=False,
                  enable_noise=False, seed=None, size=None,
@@ -504,9 +506,10 @@ class ControllerAI2THOR(Controller):
         )
 
     # Override
-    # TODO: MCS-358: is heatmap_img a filepath?
-    def step(self, action, choice=None, confidence=None, heatmap_img=None,
-             internal_state=None, **kwargs):
+    def step(self, action: str, choice: str = None,
+             confidence: float = None, heatmap_img: PIL.Image = None,
+             internal_state: object = None,
+             **kwargs) -> StepMetadata:
         """
         Runs the given action within the current scene and unpauses the scene's
         physics simulation for a few frames. Can also optionally send
@@ -524,9 +527,9 @@ class ControllerAI2THOR(Controller):
             The choice confidence between 0 and 1 required by the end of
             scenes with violation-of-expectation or classification goals.
             Is not required for other goals. (default None)
-        heatmap_img : string, optional
+        heatmap_img : PIL.Image, optional
             An image representing scene plausiblility at a particular
-            moment (default None)
+            moment. Will be saved as a .png type. (default None)
         internal_state : object, optional
             A properly formatted json object representing various kinds of
             internal states at a particular moment. Examples include the
@@ -608,11 +611,49 @@ class ControllerAI2THOR(Controller):
             internal_state=internal_state,
             output=output_copy)
         self.__history_list.append(history_item)
-        # TODO: MCS-358: add logic to upload heatmap image to s3
         filtered_history_item = self.filter_history_images(history_item)
         self.write_history_file(str(filtered_history_item))
 
+        if(heatmap_img is not None and
+           isinstance(heatmap_img, PIL.Image.Image)):
+
+            team_prefix = (self._config[self.CONFIG_TEAM] +
+                           '_') if self.CONFIG_TEAM in self._config else ''
+            file_name_prefix = team_prefix + self.HEATMAP_IMAGE_PREFIX + '_'
+
+            self.upload_image_to_s3(heatmap_img, file_name_prefix,
+                                    str(self.__step_number))
+
         return output
+
+    def upload_image_to_s3(self, image_to_upload: PIL.Image.Image,
+                           file_name_prefix: str,
+                           step_number_affix: str):
+        if self.__s3_client:
+            in_memory_file = io.BytesIO()
+            image_to_upload.save(fp=in_memory_file, format='png')
+            in_memory_file.seek(0)
+            s3_folder = (
+                (self._config[self.CONFIG_SAVE_IMAGES_TO_S3_FOLDER] + '/')
+                if self.CONFIG_SAVE_IMAGES_TO_S3_FOLDER in self._config
+                else ''
+            )
+            s3_file_name = s3_folder + file_name_prefix + \
+                self.__scene_configuration['name'].replace('.json', '') + \
+                '_' + step_number_affix + '_' + \
+                self.generate_time() + '.png'
+            print('SAVE TO S3 BUCKET ' +
+                  self._config[self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET] +
+                  ': ' + s3_file_name)
+            self.__s3_client.upload_fileobj(
+                in_memory_file,
+                self._config[self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET],
+                s3_file_name,
+                ExtraArgs={
+                    'ACL': 'public-read',
+                    'ContentType': 'image/png',
+                }
+            )
 
     def filter_history_images(
             self,
@@ -968,16 +1009,16 @@ class ControllerAI2THOR(Controller):
         object_mask_list = []
 
         for index, event in enumerate(scene_event.events):
-            scene_image = Image.fromarray(event.frame)
+            scene_image = PIL.Image.fromarray(event.frame)
             image_list.append(scene_image)
 
             if self.__depth_masks:
-                depth_mask = Image.fromarray(event.depth_frame)
+                depth_mask = PIL.Image.fromarray(event.depth_frame)
                 depth_mask = depth_mask.convert('L')
                 depth_mask_list.append(depth_mask)
 
             if self.__object_masks:
-                object_mask = Image.fromarray(
+                object_mask = PIL.Image.fromarray(
                     event.instance_segmentation_frame)
                 object_mask_list.append(object_mask)
 
@@ -994,33 +1035,13 @@ class ControllerAI2THOR(Controller):
                     object_mask.save(fp=self.__output_folder +
                                      'object_mask' + suffix)
 
-            if self.__s3_client:
-                in_memory_file = io.BytesIO()
-                scene_image.save(fp=in_memory_file, format='png')
-                in_memory_file.seek(0)
-                s3_folder = (
-                    (self._config[self.CONFIG_SAVE_IMAGES_TO_S3_FOLDER] + '/')
-                    if self.CONFIG_SAVE_IMAGES_TO_S3_FOLDER in self._config
-                    else ''
-                )
-                team_prefix = (self._config[self.CONFIG_TEAM] +
-                               '_') if self.CONFIG_TEAM in self._config else ''
-                s3_file_name = s3_folder + team_prefix + \
-                    self.__scene_configuration['name'].replace('.json', '') + \
-                    '_' + str(self.__step_number) + '_' + \
-                    str(index + 1) + '_' + self.generate_time() + '.png'
-                print('SAVE TO S3 BUCKET ' +
-                      self._config[self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET] +
-                      ': ' + s3_file_name)
-                self.__s3_client.upload_fileobj(
-                    in_memory_file,
-                    self._config[self.CONFIG_SAVE_IMAGES_TO_S3_BUCKET],
-                    s3_file_name,
-                    ExtraArgs={
-                        'ACL': 'public-read',
-                        'ContentType': 'image/png',
-                    }
-                )
+            team_prefix = (self._config[self.CONFIG_TEAM] +
+                           '_') if self.CONFIG_TEAM in self._config else ''
+            step_num_affix = (str(self.__step_number) + '_' +
+                              str(index + 1))
+
+            self.upload_image_to_s3(scene_image, team_prefix,
+                                    step_num_affix)
 
         return image_list, depth_mask_list, object_mask_list
 

--- a/python_api/machine_common_sense/scene_history.py
+++ b/python_api/machine_common_sense/scene_history.py
@@ -8,6 +8,9 @@ class SceneHistory(object):
         action=None,
         args=None,
         params=None,
+        classification: str = None,
+        confidence: float = None,
+        internal_state: object = None,
         output=None
     ):
         self.step = step
@@ -15,6 +18,9 @@ class SceneHistory(object):
         self.args = args
         self.params = params
         self.output = output
+        self.classification = classification
+        self.confidence = confidence
+        self.internal_state = internal_state
 
     def __str__(self):
         return Util.class_to_str(self)

--- a/python_api/machine_common_sense/scene_history.py
+++ b/python_api/machine_common_sense/scene_history.py
@@ -1,4 +1,5 @@
 from .util import Util
+from typing import Dict, List
 
 
 class SceneHistory(object):
@@ -10,6 +11,7 @@ class SceneHistory(object):
         params=None,
         classification: str = None,
         confidence: float = None,
+        violations_xy_list: List[Dict[str, float]] = None,
         internal_state: object = None,
         output=None
     ):
@@ -21,6 +23,7 @@ class SceneHistory(object):
         self.classification = classification
         self.confidence = confidence
         self.internal_state = internal_state
+        self.violations_xy_list = violations_xy_list
 
     def __str__(self):
         return Util.class_to_str(self)

--- a/python_api/machine_common_sense/scene_history.py
+++ b/python_api/machine_common_sense/scene_history.py
@@ -19,11 +19,11 @@ class SceneHistory(object):
         self.action = action
         self.args = args
         self.params = params
-        self.output = output
         self.classification = classification
         self.confidence = confidence
-        self.internal_state = internal_state
         self.violations_xy_list = violations_xy_list
+        self.internal_state = internal_state
+        self.output = output
 
     def __str__(self):
         return Util.class_to_str(self)

--- a/python_api/machine_common_sense/util.py
+++ b/python_api/machine_common_sense/util.py
@@ -74,7 +74,9 @@ class Util:
             [
                 metadata.uuid,
                 metadata.shape,
-                ", ".join(metadata.texture_color_list),
+                ", ".join(
+                    metadata.texture_color_list) if(
+                    metadata.texture_color_list is not None) else metadata.texture_color_list,  # noqa: E501
                 metadata.held,
                 Util.vector_to_string(metadata.position),
                 Util.vector_to_string(metadata.dimensions),

--- a/python_api/machine_common_sense/util.py
+++ b/python_api/machine_common_sense/util.py
@@ -198,7 +198,7 @@ class Util:
                 print(
                     'Value of ' +
                     label +
-                    'needs to be a number. Will be set to 0.')
+                    ' needs to be a number. Will be set to 0.')
             return False
 
     """

--- a/python_api/requirements.txt
+++ b/python_api/requirements.txt
@@ -4,3 +4,4 @@ Pillow
 autopep8
 flake8
 pre-commit
+boto3


### PR DESCRIPTION
See updated API description below for more detail on the new parameters. 

The following will be added to the scene history: choice, confidence, violations_xy_list, internal_state. 

If a heatmap_img is set in the step function, that will be uploaded to S3 (but the appropriate AWS config file values need to be set for this to work). 