### PR TITLE
MCS-383: Add History Enabled Flag

### DIFF
--- a/python_api/API.md
+++ b/python_api/API.md
@@ -32,7 +32,7 @@ Defines utility functions for machine learning modules to create MCS
 controllers and handle config data files.
 
 
-#### static create_controller(unity_app_file_path, debug=False, enable_noise=False, seed=None, size=None, depth_masks=False, object_masks=False)
+#### static create_controller(unity_app_file_path, debug=False, enable_noise=False, seed=None, size=None, depth_masks=False, object_masks=False, history_enabled=True)
 Creates and returns a new MCS Controller object.
 
 
@@ -53,6 +53,9 @@ Creates and returns a new MCS Controller object.
 
     * **seed** (*int**, **optional*) – A seed for the Python random number generator.
     (default None)
+
+    * **history_enabled** (*boolean**, **optional*) – Whether to save all the history files and generated image history to local disk or not.
+    (default False)
 
 
 

--- a/python_api/README.md
+++ b/python_api/README.md
@@ -131,6 +131,7 @@ Run options:
 - `--object_masks`
 - `--seed <python_random_seed>`
 - `--size <screen_width_450_or_more>`
+- `--history_enabled`
 
 ## Run with Scene Timer
 

--- a/python_api/machine_common_sense/controller_ai2thor.py
+++ b/python_api/machine_common_sense/controller_ai2thor.py
@@ -305,7 +305,11 @@ class ControllerAI2THOR(Controller):
         self.__scene_configuration = config_data
         self.__step_number = 0
         self._goal = self.retrieve_goal(self.__scene_configuration)
-        self.__history_writer = HistoryWriter(config_data)
+
+        if self.__history_writer is None:
+            self.__history_writer = HistoryWriter(config_data)
+        else:
+            self.__history_writer.check_file_written()
 
         skip_preview_phase = (True if 'goal' in config_data and
                               'skip_preview_phase' in config_data['goal']

--- a/python_api/machine_common_sense/controller_ai2thor.py
+++ b/python_api/machine_common_sense/controller_ai2thor.py
@@ -73,7 +73,8 @@ class ControllerAI2THOR(Controller):
         A seed for the Python random number generator.
         (default None)
     history_enabled: boolean, optional
-        Whether to save all the history files and generated image history to local disk or not.
+        Whether to save all the history files and generated image
+        history to local disk or not.
         (default False)
     """
 
@@ -158,7 +159,7 @@ class ControllerAI2THOR(Controller):
 
     def __init__(self, unity_app_file_path, debug=False,
                  enable_noise=False, seed=None, size=None,
-                 depth_masks=False, object_masks=False, 
+                 depth_masks=False, object_masks=False,
                  history_enabled=True):
         super().__init__()
 
@@ -193,7 +194,7 @@ class ControllerAI2THOR(Controller):
             self.__screen_height = size / 3 * 2
 
     def _update_internal_config(self, enable_noise=None, seed=None,
-                                depth_masks=None, object_masks=None, 
+                                depth_masks=None, object_masks=None,
                                 history_enabled=None):
 
         if enable_noise is not None:
@@ -261,7 +262,6 @@ class ControllerAI2THOR(Controller):
     def get_seed_value(self):
         return self.__seed
 
-
     # Override
     def end_scene(self, choice, confidence=1.0):
         """
@@ -281,7 +281,6 @@ class ControllerAI2THOR(Controller):
 
         super().end_scene(choice, confidence)
         self.__history_writer.write_history_file(choice, confidence)
-
 
     # Override
     def start_scene(self, config_data):
@@ -648,7 +647,6 @@ class ControllerAI2THOR(Controller):
                     'ContentType': 'image/png',
                 }
             )
-
 
     def generate_time(self):
         return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/python_api/machine_common_sense/controller_ai2thor.py
+++ b/python_api/machine_common_sense/controller_ai2thor.py
@@ -36,6 +36,7 @@ from .reward import Reward
 from .scene_history import SceneHistory
 from .step_metadata import StepMetadata
 from .util import Util
+from .history_writer import HistoryWriter
 
 # From https://github.com/NextCenturyCorporation/ai2thor/blob/master/ai2thor/server.py#L232-L240 # noqa: E501
 
@@ -71,6 +72,9 @@ class ControllerAI2THOR(Controller):
     seed : int, optional
         A seed for the Python random number generator.
         (default None)
+    history_enabled: boolean, optional
+        Whether to save all the history files and generated image history to local disk or not.
+        (default False)
     """
 
     ACTION_LIST = [item.value for item in Action]
@@ -128,8 +132,6 @@ class ControllerAI2THOR(Controller):
     OBJECT_MOVE_ACTIONS = ["CloseObject", "OpenObject"]
     MOVE_ACTIONS = ["MoveAhead", "MoveLeft", "MoveRight", "MoveBack"]
 
-    HISTORY_DIRECTORY = "SCENE_HISTORY"
-
     CONFIG_FILE = os.getenv('MCS_CONFIG_FILE_PATH', './mcs_config.yaml')
 
     AWS_CREDENTIALS_FOLDER = os.path.expanduser('~') + '/.aws/'
@@ -156,7 +158,8 @@ class ControllerAI2THOR(Controller):
 
     def __init__(self, unity_app_file_path, debug=False,
                  enable_noise=False, seed=None, size=None,
-                 depth_masks=False, object_masks=False):
+                 depth_masks=False, object_masks=False, 
+                 history_enabled=True):
         super().__init__()
 
         self._update_screen_size(size)
@@ -180,7 +183,7 @@ class ControllerAI2THOR(Controller):
         )
 
         self._on_init(debug, enable_noise, seed, depth_masks,
-                      object_masks)
+                      object_masks, history_enabled)
 
     def _update_screen_size(self, size=None):
         self.__screen_width = self.SCREEN_WIDTH_DEFAULT
@@ -190,7 +193,8 @@ class ControllerAI2THOR(Controller):
             self.__screen_height = size / 3 * 2
 
     def _update_internal_config(self, enable_noise=None, seed=None,
-                                depth_masks=None, object_masks=None):
+                                depth_masks=None, object_masks=None, 
+                                history_enabled=None):
 
         if enable_noise is not None:
             self.__enable_noise = enable_noise
@@ -200,9 +204,11 @@ class ControllerAI2THOR(Controller):
             self.__depth_masks = depth_masks
         if object_masks is not None:
             self.__object_masks = object_masks
+        if history_enabled is not None:
+            self.__history_enabled = history_enabled
 
     def _on_init(self, debug=False, enable_noise=False, seed=None,
-                 depth_masks=False, object_masks=False):
+                 depth_masks=False, object_masks=False, history_enabled=True):
 
         self.__debug_to_file = True if (
             debug is True or debug == 'file') else False
@@ -213,21 +219,18 @@ class ControllerAI2THOR(Controller):
         self.__depth_masks = depth_masks
         self.__object_masks = object_masks
         self.__seed = seed
+        self.__history_enabled = history_enabled
 
         if self.__seed:
             random.seed(self.__seed)
 
         self._goal = GoalMetadata()
         self.__head_tilt = 0.0
-        self.__history_list = []
         self.__output_folder = None  # Save output image files to debug
         self.__scene_configuration = None
-        self.__scene_history_file = None
         self.__step_number = 0
         self.__s3_client = None
-
-        if not os.path.exists(self.HISTORY_DIRECTORY):
-            os.makedirs(self.HISTORY_DIRECTORY)
+        self.__history_writer = None
 
         self._config = self.read_config_file()
 
@@ -258,12 +261,6 @@ class ControllerAI2THOR(Controller):
     def get_seed_value(self):
         return self.__seed
 
-    # Write the history file
-    def write_history_file(self, history_string):
-        if self.__scene_history_file:
-            with open(self.__scene_history_file, "a+") as history_file:
-                history_file.write(json.dumps(
-                    json.loads(history_string)) + '\n')
 
     # Override
     def end_scene(self, choice, confidence=1.0):
@@ -283,11 +280,8 @@ class ControllerAI2THOR(Controller):
         """
 
         super().end_scene(choice, confidence)
+        self.__history_writer.write_history_file(choice, confidence)
 
-        history_item = '{"classification": "' + choice + \
-            '", "confidence": ' + str(confidence) + '}'
-        self.__history_list.append(history_item)
-        self.write_history_file(history_item)
 
     # Override
     def start_scene(self, config_data):
@@ -311,14 +305,9 @@ class ControllerAI2THOR(Controller):
 
         self.__scene_configuration = config_data
         self.__step_number = 0
-        self.__history_list = []
         self._goal = self.retrieve_goal(self.__scene_configuration)
-        if 'screenshot' in config_data and config_data['screenshot']:
-            self.__scene_history_file = None
-        else:
-            self.__scene_history_file = os.path.join(
-                self.HISTORY_DIRECTORY, config_data['name'].replace(
-                    '.json', '') + "-" + self.generate_time() + ".txt")
+        self.__history_writer = HistoryWriter(config_data)
+
         skip_preview_phase = (True if 'goal' in config_data and
                               'skip_preview_phase' in config_data['goal']
                               else False)
@@ -617,9 +606,7 @@ class ControllerAI2THOR(Controller):
             violations_xy_list=violations_xy_list,
             internal_state=internal_state,
             output=output_copy)
-        self.__history_list.append(history_item)
-        filtered_history_item = self.filter_history_images(history_item)
-        self.write_history_file(str(filtered_history_item))
+        self.__history_writer.add_step(history_item)
 
         if(heatmap_img is not None and
            isinstance(heatmap_img, PIL.Image.Image)):
@@ -662,16 +649,6 @@ class ControllerAI2THOR(Controller):
                 }
             )
 
-    def filter_history_images(
-            self,
-            history: SceneHistory) -> SceneHistory:
-        if 'target' in history.output.goal.metadata.keys():
-            del history.output.goal.metadata['target']['image']
-        if 'target_1' in history.output.goal.metadata.keys():
-            del history.output.goal.metadata['target_1']['image']
-        if 'target_2' in history.output.goal.metadata.keys():
-            del history.output.goal.metadata['target_2']['image']
-        return history
 
     def generate_time(self):
         return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/python_api/machine_common_sense/goal_metadata.py
+++ b/python_api/machine_common_sense/goal_metadata.py
@@ -88,7 +88,6 @@ class GoalMetadata:
     def __str__(self):
         return Util.class_to_str(self)
 
-
     # Allows converting the class to a dictionary, along with allowing
     #   certain fields to be left out of output file
     def __iter__(self):

--- a/python_api/machine_common_sense/goal_metadata.py
+++ b/python_api/machine_common_sense/goal_metadata.py
@@ -89,6 +89,20 @@ class GoalMetadata:
         return Util.class_to_str(self)
 
 
+    # Allows converting the class to a dictionary, along with allowing
+    #   certain fields to be left out of output file
+    def __iter__(self):
+        yield 'action_list', self.action_list
+        yield 'category', self.category
+        yield 'description', self.description
+        yield 'domain_list', self.domain_list
+        yield 'info_list', self.info_list
+        yield 'last_preview_phase_step', self.last_preview_phase_step
+        yield 'last_step', self.last_step
+        yield 'type_list', self.type_list
+        yield 'metadata', self.metadata
+
+
 @unique
 class GoalCategory(Enum):
     """

--- a/python_api/machine_common_sense/history_writer.py
+++ b/python_api/machine_common_sense/history_writer.py
@@ -52,8 +52,8 @@ class HistoryWriter(object):
         return history
 
     # Add a new step to the array of history steps
-    def add_step(self, stepObj=Dict):
-        self.current_steps.append(dict(self.filter_history_images(stepObj)))
+    def add_step(self, step_obj: Dict):
+        self.current_steps.append(dict(self.filter_history_images(step_obj)))
 
     # Add the end score obj, create the object that will be written to file
     def write_history_file(self, classification, confidence):
@@ -65,6 +65,12 @@ class HistoryWriter(object):
         self.history_obj["score"] = self.end_score
 
         self.write_file()
+
+    # Will check to see if the file has been written, if not,
+    #   it will write out what is currently in the history object
+    def check_file_written(self):
+        if not os.path.exists(self.scene_history_file):
+            self.write_history_file("", "")
 
     def __str__(self):
         return Util.class_to_str(self)

--- a/python_api/machine_common_sense/history_writer.py
+++ b/python_api/machine_common_sense/history_writer.py
@@ -1,0 +1,71 @@
+from .util import Util
+from .scene_history import SceneHistory
+from typing import Dict, List
+import json
+import os
+import datetime
+
+class HistoryWriter(object):
+    def __init__(self, scene_config_data=None):
+        self.info_obj = {}
+        self.current_steps = []
+        self.end_score = {}
+        self.scene_history_file = None
+        self.history_obj = {}
+        self.HISTORY_DIRECTORY = "SCENE_HISTORY"
+
+        if not os.path.exists(self.HISTORY_DIRECTORY):
+            os.makedirs(self.HISTORY_DIRECTORY)
+
+        if 'screenshot' not in scene_config_data or not scene_config_data['screenshot']:
+            self.scene_history_file = os.path.join(
+                self.HISTORY_DIRECTORY, scene_config_data['name'].replace(
+                    '.json', '') + "-" + self.generate_time() + ".json")
+
+        self.info_obj['name'] = scene_config_data['name']
+
+    # Generate a date time
+    def generate_time(self):
+        return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        
+
+    # Write the history file
+    def write_file(self):
+        if self.scene_history_file:
+            with open(self.scene_history_file, "a+") as history_file:
+                history_file.write(json.dumps(self.history_obj, 
+                    indent = 4))
+
+
+    # filter out images from the step history data
+    def filter_history_images(
+            self,
+            history: SceneHistory) -> SceneHistory:
+        if 'target' in history.output.goal.metadata.keys():
+            del history.output.goal.metadata['target']['image']
+        if 'target_1' in history.output.goal.metadata.keys():
+            del history.output.goal.metadata['target_1']['image']
+        if 'target_2' in history.output.goal.metadata.keys():
+            del history.output.goal.metadata['target_2']['image']
+        return history
+
+
+    # Add a new step to the array of history steps
+    def add_step(self, stepObj=Dict):
+        self.current_steps.append(dict(self.filter_history_images(stepObj)))
+
+
+    # Add the end score obj, create the object that will be written to file
+    def write_history_file(self, classification, confidence):
+        self.end_score["classification"] = classification
+        self.end_score["confidence"] = str(confidence)
+
+        self.history_obj["info"] = self.info_obj
+        self.history_obj["steps"] = self.current_steps
+        self.history_obj["score"] = self.end_score
+
+        self.write_file()
+
+
+    def __str__(self):
+        return Util.class_to_str(self)

--- a/python_api/machine_common_sense/history_writer.py
+++ b/python_api/machine_common_sense/history_writer.py
@@ -24,7 +24,8 @@ class HistoryWriter(object):
                 self.HISTORY_DIRECTORY, scene_config_data['name'].replace(
                     '.json', '') + "-" + self.generate_time() + ".json")
 
-        self.info_obj['name'] = scene_config_data['name']
+        self.info_obj['name'] = scene_config_data['name'].replace(
+            '.json', '')
 
     # Generate a date time
     def generate_time(self):
@@ -41,12 +42,13 @@ class HistoryWriter(object):
     def filter_history_images(
             self,
             history: SceneHistory) -> SceneHistory:
-        if 'target' in history.output.goal.metadata.keys():
-            del history.output.goal.metadata['target']['image']
-        if 'target_1' in history.output.goal.metadata.keys():
-            del history.output.goal.metadata['target_1']['image']
-        if 'target_2' in history.output.goal.metadata.keys():
-            del history.output.goal.metadata['target_2']['image']
+        if history.output:
+            if 'target' in history.output.goal.metadata.keys():
+                del history.output.goal.metadata['target']['image']
+            if 'target_1' in history.output.goal.metadata.keys():
+                del history.output.goal.metadata['target_1']['image']
+            if 'target_2' in history.output.goal.metadata.keys():
+                del history.output.goal.metadata['target_2']['image']
         return history
 
     # Add a new step to the array of history steps

--- a/python_api/machine_common_sense/history_writer.py
+++ b/python_api/machine_common_sense/history_writer.py
@@ -27,21 +27,19 @@ class HistoryWriter(object):
         self.info_obj['name'] = scene_config_data['name'].replace(
             '.json', '')
 
-    # Generate a date time
     def generate_time(self):
         return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
 
-    # Write the history file
     def write_file(self):
         if self.scene_history_file:
             with open(self.scene_history_file, "a+") as history_file:
                 history_file.write(json.dumps(
                     self.history_obj, indent=4))
 
-    # filter out images from the step history data
     def filter_history_images(
             self,
             history: SceneHistory) -> SceneHistory:
+        """ filter out images from the step history data"""
         if history.output:
             if 'target' in history.output.goal.metadata.keys():
                 del history.output.goal.metadata['target']['image']
@@ -51,12 +49,13 @@ class HistoryWriter(object):
                 del history.output.goal.metadata['target_2']['image']
         return history
 
-    # Add a new step to the array of history steps
     def add_step(self, step_obj: Dict):
+        """ Add a new step to the array of history steps"""
         self.current_steps.append(dict(self.filter_history_images(step_obj)))
 
-    # Add the end score obj, create the object that will be written to file
     def write_history_file(self, classification, confidence):
+        """ Add the end score obj, create the object
+            that will be written to file"""
         self.end_score["classification"] = classification
         self.end_score["confidence"] = str(confidence)
 
@@ -66,9 +65,9 @@ class HistoryWriter(object):
 
         self.write_file()
 
-    # Will check to see if the file has been written, if not,
-    #   it will write out what is currently in the history object
     def check_file_written(self):
+        """ Will check to see if the file has been written, if not,
+            it will write out what is currently in the history object"""
         if not os.path.exists(self.scene_history_file):
             self.write_history_file("", "")
 

--- a/python_api/machine_common_sense/history_writer.py
+++ b/python_api/machine_common_sense/history_writer.py
@@ -1,9 +1,10 @@
 from .util import Util
 from .scene_history import SceneHistory
-from typing import Dict, List
+from typing import Dict
 import json
 import os
 import datetime
+
 
 class HistoryWriter(object):
     def __init__(self, scene_config_data=None):
@@ -17,7 +18,8 @@ class HistoryWriter(object):
         if not os.path.exists(self.HISTORY_DIRECTORY):
             os.makedirs(self.HISTORY_DIRECTORY)
 
-        if 'screenshot' not in scene_config_data or not scene_config_data['screenshot']:
+        if ('screenshot' not in scene_config_data or
+                not scene_config_data['screenshot']):
             self.scene_history_file = os.path.join(
                 self.HISTORY_DIRECTORY, scene_config_data['name'].replace(
                     '.json', '') + "-" + self.generate_time() + ".json")
@@ -27,15 +29,13 @@ class HistoryWriter(object):
     # Generate a date time
     def generate_time(self):
         return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-        
 
     # Write the history file
     def write_file(self):
         if self.scene_history_file:
             with open(self.scene_history_file, "a+") as history_file:
-                history_file.write(json.dumps(self.history_obj, 
-                    indent = 4))
-
+                history_file.write(json.dumps(
+                    self.history_obj, indent=4))
 
     # filter out images from the step history data
     def filter_history_images(
@@ -49,11 +49,9 @@ class HistoryWriter(object):
             del history.output.goal.metadata['target_2']['image']
         return history
 
-
     # Add a new step to the array of history steps
     def add_step(self, stepObj=Dict):
         self.current_steps.append(dict(self.filter_history_images(stepObj)))
-
 
     # Add the end score obj, create the object that will be written to file
     def write_history_file(self, classification, confidence):
@@ -65,7 +63,6 @@ class HistoryWriter(object):
         self.history_obj["score"] = self.end_score
 
         self.write_file()
-
 
     def __str__(self):
         return Util.class_to_str(self)

--- a/python_api/machine_common_sense/mcs.py
+++ b/python_api/machine_common_sense/mcs.py
@@ -47,7 +47,8 @@ class MCS:
             A seed for the Python random number generator.
             (default None)
         history_enabled: boolean, optional
-            Whether to save all the history files and generated image history to local disk or not.
+            Whether to save all the history files and generated image history
+            to local disk or not.
             (default False)
 
         Returns

--- a/python_api/machine_common_sense/mcs.py
+++ b/python_api/machine_common_sense/mcs.py
@@ -28,7 +28,7 @@ class MCS:
     @staticmethod
     def create_controller(unity_app_file_path, debug=False, enable_noise=False,
                           seed=None, size=None, depth_masks=False,
-                          object_masks=False):
+                          object_masks=False, history_enabled=True):
         """
         Creates and returns a new MCS Controller object.
 
@@ -46,6 +46,9 @@ class MCS:
         seed : int, optional
             A seed for the Python random number generator.
             (default None)
+        history_enabled: boolean, optional
+            Whether to save all the history files and generated image history to local disk or not.
+            (default False)
 
         Returns
         -------
@@ -57,7 +60,8 @@ class MCS:
             with time_limit(TIME_LIMIT_SECONDS):
                 return ControllerAI2THOR(unity_app_file_path, debug,
                                          enable_noise, seed, size,
-                                         depth_masks, object_masks)
+                                         depth_masks, object_masks,
+                                         history_enabled)
         except Exception as Msg:
             print("Exception in create_controller()", Msg)
             return None

--- a/python_api/machine_common_sense/object_metadata.py
+++ b/python_api/machine_common_sense/object_metadata.py
@@ -90,7 +90,6 @@ class ObjectMetadata(object):
     def __str__(self):
         return Util.class_to_str(self)
 
-    
     # Allows converting the class to a dictionary, along with allowing
     #   certain fields to be left out of output file
     def __iter__(self):

--- a/python_api/machine_common_sense/object_metadata.py
+++ b/python_api/machine_common_sense/object_metadata.py
@@ -89,3 +89,23 @@ class ObjectMetadata(object):
 
     def __str__(self):
         return Util.class_to_str(self)
+
+    
+    # Allows converting the class to a dictionary, along with allowing
+    #   certain fields to be left out of output file
+    def __iter__(self):
+        yield 'uuid', self.uuid
+        yield 'color', self.color
+        yield 'dimensions', self.dimensions
+        yield 'direction', self.direction
+        yield 'distance', self.distance
+        yield 'distance_in_steps', self.distance_in_steps
+        yield 'distance_in_world', self.distance_in_world
+        yield 'held', self.held
+        yield 'mass', self.mass
+        yield 'material_list', self.material_list
+        yield 'position', self.position
+        yield 'rotation', self.rotation
+        yield 'shape', self.shape
+        yield 'texture_color_list', self.texture_color_list
+        yield 'visible', self.visible

--- a/python_api/machine_common_sense/run_human_input.py
+++ b/python_api/machine_common_sense/run_human_input.py
@@ -113,6 +113,7 @@ class HumanInputShell(cmd.Cmd):
 
     def do_exit(self, args) -> bool:
         print("Exiting Human Input Mode\n")
+        self.controller.end_scene("", 1)
         return True
 
     def do_print(self, args):
@@ -235,6 +236,11 @@ def main():
         action='store_true',
         help='Render and return object (instance segmentation) masks of ' +
         'each scene (will significantly decrease performance) [default=False]')
+    parser.add_argument(
+        '--history_enabled',
+        default=True,
+        help='Whether to save all the history files and generated image ' +
+        'history to local disk or not. [default=True]')
     args = parser.parse_args()
 
     config_data, status = MCS.load_config_json_file(args.mcs_config_json_file)
@@ -249,7 +255,8 @@ def main():
                                        seed=args.seed,
                                        size=args.size,
                                        depth_masks=args.depth_masks,
-                                       object_masks=args.object_masks)
+                                       object_masks=args.object_masks,
+                                       history_enabled=args.history_enabled)
 
     config_file_path = args.mcs_config_json_file
     config_file_name = config_file_path[config_file_path.rfind('/') + 1:]

--- a/python_api/machine_common_sense/scene_history.py
+++ b/python_api/machine_common_sense/scene_history.py
@@ -28,7 +28,6 @@ class SceneHistory(object):
     def __str__(self):
         return Util.class_to_str(self)
 
-    
     # Allows converting the class to a dictionary, along with allowing
     #   certain fields to be left out of output file
     def __iter__(self):
@@ -41,4 +40,3 @@ class SceneHistory(object):
         yield 'violations_xy_list', self.violations_xy_list
         yield 'internal_state', self.internal_state
         yield 'output', dict(self.output)
-

--- a/python_api/machine_common_sense/scene_history.py
+++ b/python_api/machine_common_sense/scene_history.py
@@ -27,3 +27,18 @@ class SceneHistory(object):
 
     def __str__(self):
         return Util.class_to_str(self)
+
+    
+    # Allows converting the class to a dictionary, along with allowing
+    #   certain fields to be left out of output file
+    def __iter__(self):
+        yield 'step', self.step
+        yield 'action', self.action
+        yield 'args', self.args
+        yield 'params', self.params
+        yield 'classification', self.classification
+        yield 'confidence', self.confidence
+        yield 'violations_xy_list', self.violations_xy_list
+        yield 'internal_state', self.internal_state
+        yield 'output', dict(self.output)
+

--- a/python_api/machine_common_sense/scene_history.py
+++ b/python_api/machine_common_sense/scene_history.py
@@ -39,4 +39,5 @@ class SceneHistory(object):
         yield 'confidence', self.confidence
         yield 'violations_xy_list', self.violations_xy_list
         yield 'internal_state', self.internal_state
-        yield 'output', dict(self.output)
+        yield 'output', dict(self.output) if(
+            self.output) is not None else self.output

--- a/python_api/machine_common_sense/step_metadata.py
+++ b/python_api/machine_common_sense/step_metadata.py
@@ -139,3 +139,24 @@ class StepMetadata:
 
     def __str__(self):
         return Util.class_to_str(self)
+
+    # Allows converting the class to a dictionary, along with allowing
+    #   certain fields to be left out of output file
+    def __iter__(self):
+        yield 'action_list', self.action_list
+        yield 'camera_aspect_ratio', self.camera_aspect_ratio
+        yield 'camera_clipping_planes', self.camera_clipping_planes
+        yield 'camera_field_of_view', self.camera_field_of_view
+        yield 'camera_height', self.camera_height
+        yield 'goal', dict(self.goal)
+        yield 'head_tilt', self.head_tilt
+        yield 'object_list', dict((obj.uuid, dict(obj)) 
+            for obj in self.object_list)
+        yield 'pose', self.pose
+        yield 'position', self.position
+        yield 'return_status', self.return_status
+        yield 'reward', self.reward
+        yield 'rotation', self.rotation
+        yield 'step_number', self.step_number
+        yield 'structural_object_list', dict((obj.uuid, dict(obj)) 
+            for obj in self.structural_object_list)

--- a/python_api/machine_common_sense/step_metadata.py
+++ b/python_api/machine_common_sense/step_metadata.py
@@ -150,13 +150,13 @@ class StepMetadata:
         yield 'camera_height', self.camera_height
         yield 'goal', dict(self.goal)
         yield 'head_tilt', self.head_tilt
-        yield 'object_list', dict((obj.uuid, dict(obj)) 
-            for obj in self.object_list)
+        yield 'object_list', dict((obj.uuid, dict(
+            obj)) for obj in self.object_list)
         yield 'pose', self.pose
         yield 'position', self.position
         yield 'return_status', self.return_status
         yield 'reward', self.reward
         yield 'rotation', self.rotation
         yield 'step_number', self.step_number
-        yield 'structural_object_list', dict((obj.uuid, dict(obj)) 
-            for obj in self.structural_object_list)
+        yield 'structural_object_list', dict((obj.uuid, dict(
+            obj)) for obj in self.structural_object_list)

--- a/python_api/test/test_controller_ai2thor.py
+++ b/python_api/test/test_controller_ai2thor.py
@@ -488,9 +488,6 @@ class Test_ControllerAI2THOR(unittest.TestCase):
         output = self.controller.step('MoveAhead')
         self.assertIsNone(output)
 
-    def test_step_write_history(self):
-        # TODO
-        pass
 
     def test_step_validate_action(self):
         output = self.controller.step('Foobar')

--- a/python_api/test/test_controller_ai2thor.py
+++ b/python_api/test/test_controller_ai2thor.py
@@ -437,6 +437,7 @@ class Test_ControllerAI2THOR(unittest.TestCase):
 
     def test_step(self):
         self.controller.render_mask_images()
+        output = self.controller.start_scene({'name': 'test name'})
         output = self.controller.step('MoveAhead')
         self.assertIsNotNone(output)
         self.assertEqual(
@@ -478,6 +479,7 @@ class Test_ControllerAI2THOR(unittest.TestCase):
                          len(MOCK_VARIABLES['metadata']['structuralObjects']))
 
     def test_step_last_step(self):
+        output = self.controller.start_scene({'name': 'test name'})
         self.controller.set_goal(GoalMetadata(last_step=0))
         output = self.controller.step('MoveAhead')
         self.assertIsNone(output)
@@ -497,6 +499,7 @@ class Test_ControllerAI2THOR(unittest.TestCase):
         output = self.controller.step('MoveAhead')
         self.assertIsNone(output)
 
+        output = self.controller.start_scene({'name': 'test name'})
         self.controller.set_goal(
             GoalMetadata(
                 action_list=[
@@ -508,6 +511,7 @@ class Test_ControllerAI2THOR(unittest.TestCase):
         self.assertIsNone(output)
 
     def test_step_validate_parameters_move(self):
+        output = self.controller.start_scene({'name': 'test name'})
         self.controller.step('MoveAhead', amount=1)
         self.assertEquals(
             self.controller.get_last_step_data(),
@@ -540,6 +544,7 @@ class Test_ControllerAI2THOR(unittest.TestCase):
                 MAX_MOVE_DISTANCE))
 
     def test_step_validate_parameters_rotate(self):
+        output = self.controller.start_scene({'name': 'test name'})
         self.controller.step('RotateLook', rotation=12, horizon=34)
         self.assertEquals(
             self.controller.get_last_step_data(),
@@ -559,6 +564,7 @@ class Test_ControllerAI2THOR(unittest.TestCase):
                     'y': -12}))
 
     def test_step_validate_parameters_force_object(self):
+        output = self.controller.start_scene({'name': 'test name'})
         self.controller.step('PushObject', force=1, objectId='test_id_1')
         self.assertEquals(
             self.controller.get_last_step_data(),
@@ -611,6 +617,7 @@ class Test_ControllerAI2THOR(unittest.TestCase):
                     'z': 3}))
 
     def test_step_validate_parameters_open_close(self):
+        output = self.controller.start_scene({'name': 'test name'})
         self.controller.step(
             'OpenObject',
             amount=1,
@@ -1487,6 +1494,8 @@ class Test_ControllerAI2THOR(unittest.TestCase):
             self.create_mock_scene_event(mock_scene_event_data)
         )
         self.assertEqual(ret_status, Pose.LYING.name)
+
+        output = self.controller.start_scene({'name': 'test name'})
 
         # Testing retrieving proper pose depending on action made
         # Check basics

--- a/python_api/test/test_history_writer.py
+++ b/python_api/test/test_history_writer.py
@@ -1,0 +1,61 @@
+import unittest
+import os
+
+from machine_common_sense.history_writer import HistoryWriter
+from machine_common_sense.scene_history import SceneHistory
+
+
+class Test_HistoryWriter(unittest.TestCase):
+
+    def test_init(self):
+        config_data = {"name": "test_scene_file.json"}
+        writer = HistoryWriter(config_data)
+
+        self.assertEqual(writer.info_obj['name'], "test_scene_file")
+        self.assertTrue(os.path.exists(writer.HISTORY_DIRECTORY))
+
+    def test_add_step(self):
+        config_data = {"name": "test_scene_file.json"}
+        writer = HistoryWriter(config_data)
+
+        history_item = SceneHistory(
+            step=1,
+            action="MoveAhead")
+        writer.add_step(history_item)
+
+        self.assertEqual(len(writer.current_steps), 1)
+        self.assertEqual(writer.current_steps[0]["action"], "MoveAhead")
+
+        history_item = SceneHistory(
+            step=2,
+            action="MoveLeft")
+        writer.add_step(history_item)
+
+        self.assertEqual(len(writer.current_steps), 2)
+        self.assertEqual(writer.current_steps[1]["action"], "MoveLeft")
+
+    def test_write_history_file(self):
+        config_data = {"name": "test_scene_file.json"}
+        writer = HistoryWriter(config_data)
+
+        history_item = SceneHistory(
+            step=1,
+            action="MoveAhead")
+        writer.add_step(history_item)
+
+        history_item = SceneHistory(
+            step=2,
+            action="MoveLeft")
+        writer.add_step(history_item)
+
+        writer.write_history_file("Plausible", 0.75)
+
+        self.assertEqual(writer.end_score["classification"], "Plausible")
+        self.assertEqual(writer.end_score["confidence"], "0.75")
+
+        self.assertEqual(writer.history_obj["info"]["name"], "test_scene_file")
+        self.assertEqual(len(writer.history_obj["steps"]), 2)
+        self.assertEqual(writer.history_obj["score"]["classification"], "Plausible")
+        self.assertEqual(writer.history_obj["score"]["confidence"], "0.75")
+
+        self.assertTrue(os.path.exists(writer.scene_history_file))


### PR DESCRIPTION
This code review is doing multiple things:
1.  Adds the flag for history_enabled so that a user could turn off the history file logging if wanted
2. Moves all the history file code to a new module
3. Cleans up the history txt file and makes it a proper json file

In another ticket we will add all the new fields Thomas created in the scene files to the history file.