### PR TITLE
MCS-411 Splitting action step into step and prediction

### DIFF
--- a/machine_common_sense/API.md
+++ b/machine_common_sense/API.md
@@ -78,6 +78,50 @@ numerical action parameters enable_noise is True.
 :rtype: float
 
 
+#### make_step_prediction(choice: str = None, confidence: float = None, violations_xy_list: List[Dict[str, float]] = None, heatmap_img: PIL.Image.Image = None, internal_state: object = None)
+Make a prediction on the previously taken step/action.
+
+
+* **Parameters**
+
+    
+    * **choice** (*string**, **optional*) – The selected choice required by the end of scenes with
+    violation-of-expectation or classification goals.
+    Is not required for other goals. (default None)
+
+
+    * **confidence** (*float**, **optional*) – The choice confidence between 0 and 1 required by the end of
+    scenes with violation-of-expectation or classification goals.
+    Is not required for other goals. (default None)
+
+
+    * **violations_xy_list** (*List**[**Dict**[**str**, **float**]**]**, **optional*) – A list of one or more (x, y) locations (ex: [{“x”: 1, “y”: 3.4}]),
+    each representing a potential violation-of-expectation. Required
+    on each step for passive tasks. (default None)
+
+
+    * **heatmap_img** (*PIL.Image.Image**, **optional*) – An image representing scene plausiblility at a particular
+    moment. Will be saved as a .png type. (default None)
+
+
+    * **internal_state** (*object**, **optional*) – A properly formatted json object representing various kinds of
+    internal states at a particular moment. Examples include the
+    estimated position of the agent, current map of the world, etc.
+    (default None)
+
+
+
+* **Returns**
+
+    
+
+
+* **Return type**
+
+    None
+
+
+
 #### start_scene(config_data)
 Starts a new scene using the given scene configuration data dict and
 returns the scene output data object.
@@ -102,41 +146,14 @@ returns the scene output data object.
 
 
 
-#### step(action: str, choice: str = None, confidence: float = None, violations_xy_list: List[Dict[str, float]] = None, heatmap_img: PIL.Image.Image = None, internal_state: object = None, \*\*kwargs)
-Runs the given action within the current scene and unpauses the scene’s
-physics simulation for a few frames. Can also optionally send
-information about scene plausability if applicable.
+#### step(action: str, \*\*kwargs)
+Runs the given action within the current scene.
 
 
 * **Parameters**
 
     
     * **action** (*string*) – A selected action string from the list of available actions.
-
-
-    * **choice** (*string**, **optional*) – The selected choice required by the end of scenes with
-    violation-of-expectation or classification goals.
-    Is not required for other goals. (default None)
-
-
-    * **confidence** (*float**, **optional*) – The choice confidence between 0 and 1 required by the end of
-    scenes with violation-of-expectation or classification goals.
-    Is not required for other goals. (default None)
-
-
-    * **violations_xy_list** (*List**[**Dict**[**str**, **float**]**]**, **optional*) – A list of one or more (x, y) locations (ex: [{“x”: 1, “y”: 3.4}]),
-    each representing a potential violation-of-expectation. Required
-    on each step for passive tasks. (default None)
-
-
-    * **heatmap_img** (*PIL.Image.Image**, **optional*) – An image representing scene plausiblility at a particular
-    moment. Will be saved as a .png type. (default None)
-
-
-    * **internal_state** (*object**, **optional*) – A properly formatted json object representing various kinds of
-    internal states at a particular moment. Examples include the
-    estimated position of the agent, current map of the world, etc.
-    (default None)
 
 
     * **\*\*kwargs** – Zero or more key-and-value parameters for the action.


### PR DESCRIPTION
Moving VOE prediction into a separate function. The prediction function appends attributes to the step's history item before adding it to the history writer. The current step's history item is added to the history writer on the following step or when end scene is called.

```
#loop
output = controller.step(action)
# calculate voe prediction
controller.make_step_prediction(confidence=1.0, ...)
#end loop
controller.end_scene()
```

A user of the package isn't forced to call make_step_prediction and will still get scene history. The prediction values (confidence etc) will be null.
```
#loop
output = controller.step(action)
#end loop
controller.end_scene()
