### PR TITLE
Make sure image data is an array and not a string (MCS-405).

### DIFF
--- a/machine_common_sense/API.md
+++ b/machine_common_sense/API.md
@@ -1080,7 +1080,7 @@ of movement (kinematics, gravity, friction, etc.).
     * **target.id** (*string*) – The objectId of the target object to retrieve.
 
 
-    * **target.image** (*list of lists of lists of integers*) – An image of the target object to retrieve, given as a 3D RGB pixel
+    * **target.image** (*list of numpy arrays*) – An image of the target object to retrieve, given as a 3D RGB pixel
     array.
 
 
@@ -1120,7 +1120,7 @@ of movement (kinematics, gravity, friction, etc.).
     second target object.
 
 
-    * **target_1.image** (*list of lists of lists of integers*) – An image of the first target object to pickup and transfer to the
+    * **target_1.image** (*list of numpy arrays*) – An image of the first target object to pickup and transfer to the
     second target object, given as a 3D RGB pixel array.
 
 
@@ -1139,7 +1139,7 @@ of movement (kinematics, gravity, friction, etc.).
     object must be transferred.
 
 
-    * **target_2.image** (*list of lists of lists of integers*) – An image of the second target object to which the first target object
+    * **target_2.image** (*list of numpy arrays*) – An image of the second target object to which the first target object
     must be transferred, given as a 3D RGB pixel array.
 
 
@@ -1169,7 +1169,7 @@ obstacles).
     * **target.id** (*string*) – The objectId of the target object to find and move next to.
 
 
-    * **target.image** (*list of lists of lists of integers*) – An image of the target object to find and move next to, given as a 3D
+    * **target.image** (*list of numpy arrays*) – An image of the target object to find and move next to, given as a 3D
     RGB pixel array.
 
 

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -9,6 +9,7 @@ import random
 import sys
 import yaml
 import PIL
+import ast
 from typing import Dict, List
 
 import ai2thor.controller
@@ -733,6 +734,32 @@ class Controller():
                 'image' in goal_output.metadata['target_2']
             ):
                 goal_output.metadata['target_2']['image'] = None
+        else:
+            # need to convert goal image data from string to array
+            if (
+                'target' in goal_output.metadata and
+                'image' in goal_output.metadata['target'] and
+                isinstance(goal_output.metadata['target']['image'], str)
+            ):
+                image_list_string = goal_output.metadata['target']['image']
+                goal_output.metadata['target']['image'] = numpy.array(
+                    ast.literal_eval(image_list_string)).tolist()
+            if (
+                'target_1' in goal_output.metadata and
+                'image' in goal_output.metadata['target_1'] and
+                isinstance(goal_output.metadata['target_1']['image'], str)
+            ):
+                image_list_string = goal_output.metadata['target_1']['image']
+                goal_output.metadata['target_1']['image'] = numpy.array(
+                    ast.literal_eval(image_list_string)).tolist()
+            if (
+                'target_2' in goal_output.metadata and
+                'image' in goal_output.metadata['target_2'] and
+                isinstance(goal_output.metadata['target_2']['image'], str)
+            ):
+                image_list_string = goal_output.metadata['target_2']['image']
+                goal_output.metadata['target_2']['image'] = numpy.array(
+                    ast.literal_eval(image_list_string)).tolist()
 
         return goal_output
 

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -715,51 +715,28 @@ class Controller():
         return {}
 
     def restrict_goal_output_metadata(self, goal_output):
-        if (
-            self._metadata_tier == self.CONFIG_METADATA_TIER_LEVEL_1 or
-            self._metadata_tier == self.CONFIG_METADATA_TIER_LEVEL_2
-        ):
+        target_name_list = ['target', 'target_1', 'target_2']
+
+        for target_name in target_name_list:
             if (
-                'target' in goal_output.metadata and
-                'image' in goal_output.metadata['target']
+                self._metadata_tier == self.CONFIG_METADATA_TIER_LEVEL_1 or
+                self._metadata_tier == self.CONFIG_METADATA_TIER_LEVEL_2
             ):
-                goal_output.metadata['target']['image'] = None
-            if (
-                'target_1' in goal_output.metadata and
-                'image' in goal_output.metadata['target_1']
-            ):
-                goal_output.metadata['target_1']['image'] = None
-            if (
-                'target_2' in goal_output.metadata and
-                'image' in goal_output.metadata['target_2']
-            ):
-                goal_output.metadata['target_2']['image'] = None
-        else:
-            # need to convert goal image data from string to array
-            if (
-                'target' in goal_output.metadata and
-                'image' in goal_output.metadata['target'] and
-                isinstance(goal_output.metadata['target']['image'], str)
-            ):
-                image_list_string = goal_output.metadata['target']['image']
-                goal_output.metadata['target']['image'] = numpy.array(
-                    ast.literal_eval(image_list_string)).tolist()
-            if (
-                'target_1' in goal_output.metadata and
-                'image' in goal_output.metadata['target_1'] and
-                isinstance(goal_output.metadata['target_1']['image'], str)
-            ):
-                image_list_string = goal_output.metadata['target_1']['image']
-                goal_output.metadata['target_1']['image'] = numpy.array(
-                    ast.literal_eval(image_list_string)).tolist()
-            if (
-                'target_2' in goal_output.metadata and
-                'image' in goal_output.metadata['target_2'] and
-                isinstance(goal_output.metadata['target_2']['image'], str)
-            ):
-                image_list_string = goal_output.metadata['target_2']['image']
-                goal_output.metadata['target_2']['image'] = numpy.array(
-                    ast.literal_eval(image_list_string)).tolist()
+                if (
+                    target_name in goal_output.metadata and
+                    'image' in goal_output.metadata[target_name]
+                ):
+                    goal_output.metadata[target_name]['image'] = None
+            else:
+                # need to convert goal image data from string to array
+                if (
+                    target_name in goal_output.metadata and
+                    'image' in goal_output.metadata[target_name] and
+                    isinstance(goal_output.metadata[target_name]['image'], str)
+                ):
+                    image_list_string = goal_output.metadata[target_name]['image']  # noqa: E501
+                    goal_output.metadata[target_name]['image'] = numpy.array(
+                        ast.literal_eval(image_list_string)).tolist()
 
         return goal_output
 

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -131,7 +131,7 @@ class GoalCategory(Enum):
     target.id : string
         The objectId of the target object to retrieve.
 
-    target.image : list of lists of lists of integers
+    target.image : list of numpy arrays
         An image of the target object to retrieve, given as a 3D RGB pixel
         array.
 
@@ -170,7 +170,7 @@ class GoalCategory(Enum):
         The objectId of the first target object to pickup and transfer to the
         second target object.
 
-    target_1.image : list of lists of lists of integers
+    target_1.image : list of numpy arrays
         An image of the first target object to pickup and transfer to the
         second target object, given as a 3D RGB pixel array.
 
@@ -189,7 +189,7 @@ class GoalCategory(Enum):
         The objectId of the second target object to which the first target
         object must be transferred.
 
-    target_2.image : list of lists of lists of integers
+    target_2.image : list of numpy arrays
         An image of the second target object to which the first target object
         must be transferred, given as a 3D RGB pixel array.
 
@@ -218,7 +218,7 @@ class GoalCategory(Enum):
     target.id : string
         The objectId of the target object to find and move next to.
 
-    target.image : list of lists of lists of integers
+    target.image : list of numpy arrays
         An image of the target object to find and move next to, given as a 3D
         RGB pixel array.
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -688,12 +688,38 @@ class Test_Controller(unittest.TestCase):
             'target_2': {'image': [2]}
         })
 
+    def test_restrict_goal_output_metadata_img_as_str(self):
+        goal = mcs.GoalMetadata(metadata={
+            'target': {'image': "[0]"},
+            'target_1': {'image': "[1]"},
+            'target_2': {'image': "[2]"}
+        })
+        actual = self.controller.restrict_goal_output_metadata(goal)
+        self.assertEqual(actual.metadata, {
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
+        })
+
     def test_restrict_goal_output_metadata_oracle(self):
         self.controller.set_metadata_tier('oracle')
         goal = mcs.GoalMetadata(metadata={
             'target': {'image': [0]},
             'target_1': {'image': [1]},
             'target_2': {'image': [2]}
+        })
+        actual = self.controller.restrict_goal_output_metadata(goal)
+        self.assertEqual(actual.metadata, {
+            'target': {'image': [0]},
+            'target_1': {'image': [1]},
+            'target_2': {'image': [2]}
+        })
+
+    def test_restrict_goal_output_metadata_oracle_img_as_str(self):
+        goal = mcs.GoalMetadata(metadata={
+            'target': {'image': "[0]"},
+            'target_1': {'image': "[1]"},
+            'target_2': {'image': "[2]"}
         })
         actual = self.controller.restrict_goal_output_metadata(goal)
         self.assertEqual(actual.metadata, {


### PR DESCRIPTION
It looks like we are saving most of our images as PIL.Images, but rereading the original Slack comment and looking at the code, it looked like the issue here was actually that we were saving the image data specifically for target object data as a string -- Falk mentioned that a NumPy array would be acceptable so that's what I went with. 

This change wasn’t hard, but I needed to get the image generator working (or in my case, at least get around current issues well enough to generate a scene with target objects). 

In addition, I realized that this change might be more of a backwards compatibility thing. Our target objects are always going to be the same anyway for Eval 3, and I’m not even sure we’re going to need to save the information for the target objects the same way we used to going forward.

Also wanted to verify the debug output file size -- looks like a .5 MB increase for this change (~~I did notice the depth mask update bumped up my MCS output file for this to about 8-9 MB, so just something to keep in mind~~ Nevermind this was because I was using an old unity app build from before we removed substeps). 
