### PR TITLE
Update for setting config path + metadata properties

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -234,11 +234,18 @@ class Controller():
         self.__history_item = None
 
         self._config = self.read_config_file()
-        self._metadata_tier = (
-            self._config[self.CONFIG_METADATA_TIER]
-            if self.CONFIG_METADATA_TIER in self._config
-            else ''
-        )
+
+        # Environment variable override for metadata property
+        metadata_env_var = os.getenv('MCS_METADATA_LEVEL', None)
+
+        if(metadata_env_var is None):
+            self._metadata_tier = (
+                self._config[self.CONFIG_METADATA_TIER]
+                if self.CONFIG_METADATA_TIER in self._config
+                else ''
+            )
+        else:
+            self._metadata_tier = metadata_env_var
 
         # Order of preference for depth/object mask settings:
         # look for user specified depth_masks/object_masks properties,

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -208,8 +208,8 @@ class Controller():
                  depth_masks=None, object_masks=None,
                  history_enabled=True):
 
-        self.config_file = os.getenv('MCS_CONFIG_FILE_PATH',
-                                     './mcs_config.yaml')
+        self._config_file = os.getenv('MCS_CONFIG_FILE_PATH',
+                                      './mcs_config.yaml')
 
         self.__debug_to_file = True if (
             debug is True or debug == 'file') else False
@@ -710,8 +710,8 @@ class Controller():
         return action
 
     def read_config_file(self):
-        if os.path.exists(self.config_file):
-            with open(self.config_file, 'r') as config_file:
+        if os.path.exists(self._config_file):
+            with open(self._config_file, 'r') as config_file:
                 config = yaml.load(config_file)
                 if self.__debug_to_terminal:
                     print('Read MCS Config File:')

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -124,8 +124,6 @@ class Controller():
     OBJECT_MOVE_ACTIONS = ["CloseObject", "OpenObject"]
     MOVE_ACTIONS = ["MoveAhead", "MoveLeft", "MoveRight", "MoveBack"]
 
-    CONFIG_FILE = os.getenv('MCS_CONFIG_FILE_PATH', './mcs_config.yaml')
-
     AWS_CREDENTIALS_FOLDER = os.path.expanduser('~') + '/.aws/'
     AWS_CREDENTIALS_FILE = os.path.expanduser('~') + '/.aws/credentials'
     AWS_ACCESS_KEY_ID = 'aws_access_key_id'
@@ -209,6 +207,9 @@ class Controller():
     def _on_init(self, debug=False, enable_noise=False, seed=None,
                  depth_masks=None, object_masks=None,
                  history_enabled=True):
+
+        self.config_file = os.getenv('MCS_CONFIG_FILE_PATH',
+                                     './mcs_config.yaml')
 
         self.__debug_to_file = True if (
             debug is True or debug == 'file') else False
@@ -702,8 +703,8 @@ class Controller():
         return action
 
     def read_config_file(self):
-        if os.path.exists(self.CONFIG_FILE):
-            with open(self.CONFIG_FILE, 'r') as config_file:
+        if os.path.exists(self.config_file):
+            with open(self.config_file, 'r') as config_file:
                 config = yaml.load(config_file)
                 if self.__debug_to_terminal:
                     print('Read MCS Config File:')

--- a/tests/mock_controller.py
+++ b/tests/mock_controller.py
@@ -80,6 +80,12 @@ class MockControllerAI2THOR(Controller):
     def get_last_step_data(self):
         return self._controller.get_last_step_data()
 
+    def read_config_file(self):
+        if(self._config_file == 'test-metadata-lvl1.yaml'):
+            return {'metadata': 'level1'}
+        else:
+            return {}
+
     def render_mask_images(self):
         self._update_internal_config(depth_masks=True, object_masks=True)
 

--- a/tests/test_env_variables.py
+++ b/tests/test_env_variables.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import patch
+import os
+
+from .mock_controller import (
+    MockControllerAI2THOR
+)
+
+
+class Test_Env_Variables(unittest.TestCase):
+
+    def mock_env(**env_vars):
+        return patch.dict(os.environ, env_vars, clear=True)
+
+    @mock_env()
+    def test_no_env_variables_set(self):
+        controller = MockControllerAI2THOR()
+        self.assertEqual(
+            controller._config_file,
+            './mcs_config.yaml')
+        self.assertEqual(
+            controller._config,
+            {})
+        self.assertEqual(
+            controller._metadata_tier,
+            '')
+
+    @mock_env(MCS_CONFIG_FILE_PATH='test-metadata-lvl1.yaml')
+    def test_config_file_env_set(self):
+        controller = MockControllerAI2THOR()
+        self.assertEqual(
+            controller._config_file,
+            'test-metadata-lvl1.yaml')
+        self.assertEqual(
+            controller._config,
+            {'metadata': 'level1'})
+        self.assertEqual(
+            controller._metadata_tier,
+            'level1')
+
+    @mock_env(MCS_METADATA_LEVEL='level2')
+    def test_metadata_env_set(self):
+        controller = MockControllerAI2THOR()
+        self.assertEqual(
+            controller._config_file,
+            './mcs_config.yaml')
+        self.assertEqual(
+            controller._config,
+            {})
+        self.assertEqual(
+            controller._metadata_tier,
+            'level2')
+
+    @mock_env(
+        MCS_CONFIG_FILE_PATH='test-metadata-lvl1.yaml',
+        MCS_METADATA_LEVEL='level2'
+    )
+    def test_both_config_and_metadata_env_set(self):
+        controller = MockControllerAI2THOR()
+        self.assertEqual(
+            controller._config_file,
+            'test-metadata-lvl1.yaml')
+        self.assertEqual(
+            controller._config,
+            {'metadata': 'level1'})
+        self.assertEqual(
+            controller._metadata_tier,
+            'level2')


### PR DESCRIPTION
Can't tackle all the config changes for MCS-410, but this should address what we need for Eval 3:

- Moving config path environment variable check to controller initialization to help ensure it is set the way we want per run
- Also adding a MCS_METADATA_LEVEL override to initialization. This will be prioritized over whatever level is in the configuration file. 

I'm hoping this is good enough, but again, may need to be tweaked a bit later since we haven't fully nailed down what the automation pipeline will look like. 