### PR TITLE
MCS-416: Fix target image check, but not updating goal id check

### DIFF
--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -40,13 +40,13 @@ class HistoryWriter(object):
             self,
             history: SceneHistory) -> SceneHistory:
         """ filter out images from the step history data"""
+        targets = ['target', 'target_1', 'target2']
         if history.output:
-            if 'target' in history.output.goal.metadata.keys():
-                del history.output.goal.metadata['target']['image']
-            if 'target_1' in history.output.goal.metadata.keys():
-                del history.output.goal.metadata['target_1']['image']
-            if 'target_2' in history.output.goal.metadata.keys():
-                del history.output.goal.metadata['target_2']['image']
+            for target in targets:
+                if target in history.output.goal.metadata.keys():
+                    if history.output.goal.metadata[target].get(
+                            'image', None) is not None:
+                        del history.output.goal.metadata[target]['image']
         return history
 
     def add_step(self, step_obj: Dict):


### PR DESCRIPTION
After team discussions.  We will not change the code for the reward calculation, the id will still come from the goal id, but updated the target image code check to make sure we cover the cases Thomas noted in the ticket.