### PR TITLE
MCS-421: Rename depth masks to depth maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Example usage of the MCS library:
 import machine_common_sense as mcs
 
 # We will give you the Unity app file.
-controller = mcs.create_controller(unity_app_file_path, depth_masks=True,
+controller = mcs.create_controller(unity_app_file_path, depth_maps=True,
                                    object_masks=True)
 
 # Either load the config data dict from an MCS config JSON file or create your own.
@@ -109,7 +109,7 @@ Example running multiple scenes sequentially:
 import machine_common_sense as mcs
 
 # Only create the MCS controller ONCE!
-controller = mcs.create_controller(unity_app_file_path, depth_masks=True,
+controller = mcs.create_controller(unity_app_file_path, depth_maps=True,
                                    object_masks=True)
 
 for config_json_file_path in config_json_file_list:
@@ -132,7 +132,7 @@ run_in_human_input_mode <mcs_unity_build_file> <mcs_config_json_file>
 
 Run options:
 - `--debug`
-- `--depth_masks`
+- `--depth_maps`
 - `--noise`
 - `--object_masks`
 - `--seed <python_random_seed>`

--- a/machine_common_sense/API.md
+++ b/machine_common_sense/API.md
@@ -24,7 +24,7 @@
 ## Controller
 
 
-### class machine_common_sense.controller.Controller(unity_app_file_path, debug=False, enable_noise=False, seed=None, size=None, depth_masks=None, object_masks=None, history_enabled=True)
+### class machine_common_sense.controller.Controller(unity_app_file_path, debug=False, enable_noise=False, seed=None, size=None, depth_maps=None, object_masks=None, history_enabled=True)
 MCS Controller class implementation for the MCS wrapper of the AI2-THOR
 library.
 
@@ -306,7 +306,7 @@ Defines metadata for an object in the MCS 3D environment.
 ## StepMetadata
 
 
-### class machine_common_sense.step_metadata.StepMetadata(action_list=None, camera_aspect_ratio=None, camera_clipping_planes=None, camera_field_of_view=0.0, camera_height=0.0, depth_mask_list=None, goal=None, habituation_trial=None, head_tilt=0.0, image_list=None, object_list=None, object_mask_list=None, pose='UNDEFINED', position=None, return_status='UNDEFINED', reward=0, rotation=0.0, step_number=0, structural_object_list=None)
+### class machine_common_sense.step_metadata.StepMetadata(action_list=None, camera_aspect_ratio=None, camera_clipping_planes=None, camera_field_of_view=0.0, camera_height=0.0, depth_map_list=None, goal=None, habituation_trial=None, head_tilt=0.0, image_list=None, object_list=None, object_mask_list=None, pose='UNDEFINED', position=None, return_status='UNDEFINED', reward=0, rotation=0.0, step_number=0, structural_object_list=None)
 Defines output metadata from an action step in the MCS 3D environment.
 
 
@@ -333,7 +333,7 @@ Defines output metadata from an action step in the MCS 3D environment.
     actions like “LieDown”, “Stand”, or “Crawl”.
 
 
-    * **depth_mask_list** (*list of 2D numpy arrays*) – The list of 2-dimensional numpy arrays of depth float data from the
+    * **depth_map_list** (*list of 2D numpy arrays*) – The list of 2-dimensional numpy arrays of depth float data from the
     scene after the last action and physics simulation were run.
     Each depth float in a 2-dimensional numpy array is a value between 0
     and the camera’s far clipping plane (default 15) correspondings to the

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -150,7 +150,7 @@ class Controller():
 
     def __init__(self, unity_app_file_path, debug=False,
                  enable_noise=False, seed=None, size=None,
-                 depth_masks=None, object_masks=None,
+                 depth_maps=None, object_masks=None,
                  history_enabled=True):
 
         self._update_screen_size(size)
@@ -173,7 +173,7 @@ class Controller():
             }
         )
 
-        self._on_init(debug, enable_noise, seed, depth_masks,
+        self._on_init(debug, enable_noise, seed, depth_maps,
                       object_masks, history_enabled)
 
     # Pixel coordinates are expected to start at the top left, but
@@ -192,22 +192,22 @@ class Controller():
             self.__screen_height = int(size / 3 * 2)
 
     def _update_internal_config(self, enable_noise=None, seed=None,
-                                depth_masks=None, object_masks=None,
+                                depth_maps=None, object_masks=None,
                                 history_enabled=None):
 
         if enable_noise is not None:
             self.__enable_noise = enable_noise
         if seed is not None:
             self.__seed = seed
-        if depth_masks is not None:
-            self.__depth_masks = depth_masks
+        if depth_maps is not None:
+            self.__depth_maps = depth_maps
         if object_masks is not None:
             self.__object_masks = object_masks
         if history_enabled is not None:
             self.__history_enabled = history_enabled
 
     def _on_init(self, debug=False, enable_noise=False, seed=None,
-                 depth_masks=None, object_masks=None,
+                 depth_maps=None, object_masks=None,
                  history_enabled=True):
 
         self.__debug_to_file = True if (
@@ -240,22 +240,22 @@ class Controller():
         )
 
         # Order of preference for depth/object mask settings:
-        # look for user specified depth_masks/object_masks properties,
+        # look for user specified depth_maps/object_masks properties,
         # then check config settings, else default to False
         if(self._metadata_tier == self.CONFIG_METADATA_TIER_LEVEL_1):
-            self.__depth_masks = (
-                depth_masks if depth_masks is not None else True)
+            self.__depth_maps = (
+                depth_maps if depth_maps is not None else True)
             self.__object_masks = (
                 object_masks if object_masks is not None else False)
         elif(self._metadata_tier == self.CONFIG_METADATA_TIER_LEVEL_2 or
              self._metadata_tier == self.CONFIG_METADATA_TIER_ORACLE):
-            self.__depth_masks = (
-                depth_masks if depth_masks is not None else True)
+            self.__depth_maps = (
+                depth_maps if depth_maps is not None else True)
             self.__object_masks = (
                 object_masks if object_masks is not None else True)
         else:
-            self.__depth_masks = (
-                depth_masks if depth_masks is not None else False)
+            self.__depth_maps = (
+                depth_maps if depth_maps is not None else False)
             self.__object_masks = (
                 object_masks if object_masks is not None else False)
 
@@ -362,7 +362,7 @@ class Controller():
             if (self._goal is not None and
                     self._goal.last_preview_phase_step > 0):
                 image_list = output.image_list
-                depth_mask_list = output.depth_mask_list
+                depth_map_list = output.depth_map_list
                 object_mask_list = output.object_mask_list
 
                 if self.__debug_to_terminal:
@@ -371,7 +371,7 @@ class Controller():
                 for i in range(0, self._goal.last_preview_phase_step):
                     output = self.step('Pass')
                     image_list = image_list + output.image_list
-                    depth_mask_list = depth_mask_list + output.depth_mask_list
+                    depth_map_list = depth_map_list + output.depth_map_list
                     object_mask_list = (object_mask_list +
                                         output.object_mask_list)
 
@@ -379,7 +379,7 @@ class Controller():
                     print('ENDING PREVIEW PHASE')
 
                 output.image_list = image_list
-                output.depth_mask_list = depth_mask_list
+                output.depth_map_list = depth_map_list
                 output.object_mask_list = object_mask_list
             elif self.__debug_to_terminal:
                 print('NO PREVIEW PHASE')
@@ -583,7 +583,7 @@ class Controller():
             self.wrap_step(action=action, **params)))
 
         output_copy = copy.deepcopy(output)
-        del output_copy.depth_mask_list
+        del output_copy.depth_map_list
         del output_copy.image_list
         del output_copy.object_mask_list
         self.__history_item = SceneHistory(
@@ -955,14 +955,14 @@ class Controller():
 
     def save_images(self, scene_event, max_depth):
         image_list = []
-        depth_mask_list = []
+        depth_map_list = []
         object_mask_list = []
 
         for index, event in enumerate(scene_event.events):
             scene_image = PIL.Image.fromarray(event.frame)
             image_list.append(scene_image)
 
-            if self.__depth_masks:
+            if self.__depth_maps:
                 # The Unity depth array (returned by Depth.shader) contains
                 # a third of the total max depth in each RGB element.
                 unity_depth_array = event.depth_frame.astype(numpy.float32)
@@ -974,10 +974,10 @@ class Controller():
                 )
                 # Convert to pixel values for saving debug image.
                 depth_pixel_array = depth_float_array * 255 / max_depth
-                depth_mask = PIL.Image.fromarray(
+                depth_map = PIL.Image.fromarray(
                     depth_pixel_array.astype(numpy.uint8)
                 )
-                depth_mask_list.append(numpy.array(depth_float_array))
+                depth_map_list.append(numpy.array(depth_float_array))
 
             if self.__object_masks:
                 object_mask = PIL.Image.fromarray(
@@ -992,9 +992,9 @@ class Controller():
                 suffix = '_' + str(step_plus_substep_index) + '.png'
                 scene_image.save(fp=self.__output_folder +
                                  'frame_image' + suffix)
-                if self.__depth_masks:
-                    depth_mask.save(fp=self.__output_folder +
-                                    'depth_mask' + suffix)
+                if self.__depth_maps:
+                    depth_map.save(fp=self.__output_folder +
+                                   'depth_map' + suffix)
                 if self.__object_masks:
                     object_mask.save(fp=self.__output_folder +
                                      'object_mask' + suffix)
@@ -1007,7 +1007,7 @@ class Controller():
             self.upload_image_to_s3(scene_image, team_prefix,
                                     step_num_affix)
 
-        return image_list, depth_mask_list, object_mask_list
+        return image_list, depth_map_list, object_mask_list
 
     def wrap_output(self, scene_event):
         if self.__debug_to_file and self.__output_folder is not None:
@@ -1017,7 +1017,7 @@ class Controller():
                     "metadata": scene_event.metadata
                 }, json_file, sort_keys=True, indent=4)
 
-        image_list, depth_mask_list, object_mask_list = self.save_images(
+        image_list, depth_map_list, object_mask_list = self.save_images(
             scene_event,
             scene_event.metadata.get(
                 'clippingPlaneFar',
@@ -1038,7 +1038,7 @@ class Controller():
             camera_field_of_view=scene_event.metadata.get('fov', 0.0),
             camera_height=scene_event.metadata.get(
                 'cameraPosition', {}).get('y', 0.0),
-            depth_mask_list=depth_mask_list,
+            depth_map_list=depth_map_list,
             goal=self._goal,
             habituation_trial=(
                 self.__habituation_trial
@@ -1095,7 +1095,7 @@ class Controller():
             continuous=True,
             gridSize=self.GRID_SIZE,
             logs=True,
-            renderDepthImage=self.__depth_masks,
+            renderDepthImage=self.__depth_maps,
             renderObjectImage=self.__object_masks,
             snapToGrid=False,
             # Yes, in AI2-THOR, the player's reach appears to be

--- a/machine_common_sense/mcs.py
+++ b/machine_common_sense/mcs.py
@@ -20,7 +20,7 @@ def time_limit(seconds):
 
 
 def create_controller(unity_app_file_path, debug=False, enable_noise=False,
-                      seed=None, size=None, depth_masks=None,
+                      seed=None, size=None, depth_maps=None,
                       history_enabled=True, object_masks=None):
     """
     Creates and returns a new MCS Controller object.
@@ -42,7 +42,7 @@ def create_controller(unity_app_file_path, debug=False, enable_noise=False,
     size : int, optional
         Desired screen width
         (default None)
-    depth_masks : boolean, optional
+    depth_maps : boolean, optional
         Whether or not to generate depth mask images
         (default None)
     object_masks : boolean, optional
@@ -62,7 +62,7 @@ def create_controller(unity_app_file_path, debug=False, enable_noise=False,
         with time_limit(TIME_LIMIT_SECONDS):
             return Controller(unity_app_file_path, debug,
                               enable_noise, seed, size,
-                              depth_masks, object_masks)
+                              depth_maps, object_masks)
     except Exception as Msg:
         print("Exception in create_controller()", Msg)
         return None

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -25,7 +25,7 @@ class StepMetadata:
     camera_height : float
         The player camera's height. This will change if the player uses
         actions like "LieDown", "Stand", or "Crawl".
-    depth_mask_list : list of 2D numpy arrays
+    depth_map_list : list of 2D numpy arrays
         The list of 2-dimensional numpy arrays of depth float data from the
         scene after the last action and physics simulation were run.
         Each depth float in a 2-dimensional numpy array is a value between 0
@@ -93,7 +93,7 @@ class StepMetadata:
         camera_clipping_planes=None,
         camera_field_of_view=0.0,
         camera_height=0.0,
-        depth_mask_list=None,
+        depth_map_list=None,
         goal=None,
         habituation_trial=None,
         head_tilt=0.0,
@@ -118,8 +118,8 @@ class StepMetadata:
         )
         self.camera_field_of_view = camera_field_of_view
         self.camera_height = camera_height
-        self.depth_mask_list = (
-            [] if depth_mask_list is None else depth_mask_list
+        self.depth_map_list = (
+            [] if depth_map_list is None else depth_map_list
         )
         self.goal = GoalMetadata() if goal is None else goal
         self.habituation_trial = habituation_trial

--- a/scripts/run_human_input.py
+++ b/scripts/run_human_input.py
@@ -36,7 +36,7 @@ def parse_args():
         default=None,
         help='Screen width of 450+ (height = width * 2/3) [default=600]')
     parser.add_argument(
-        '--depth_masks',
+        '--depth_maps',
         default=False,
         action='store_true',
         help='Render and return depth masks of each scene ' +
@@ -252,7 +252,7 @@ def main():
                                        enable_noise=args.noise,
                                        seed=args.seed,
                                        size=args.size,
-                                       depth_masks=args.depth_masks,
+                                       depth_maps=args.depth_maps,
                                        object_masks=args.object_masks,
                                        history_enabled=args.history_enabled)
 

--- a/scripts/run_init_scenes.py
+++ b/scripts/run_init_scenes.py
@@ -27,7 +27,7 @@ def main():
     controller = mcs.create_controller(
         args.mcs_unity_build_file,
         debug=False,
-        depth_masks=True,
+        depth_maps=True,
         object_masks=True)
 
     for json_file_name in json_file_list:

--- a/scripts/run_interactive_samples.py
+++ b/scripts/run_interactive_samples.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     controller = mcs.create_controller(
         args.mcs_unity_build_file,
         debug=True,
-        depth_masks=True,
+        depth_maps=True,
         object_masks=True)
 
     run_scene('../scenes/eval_sample_1.json', [

--- a/scripts/run_just_pass.py
+++ b/scripts/run_just_pass.py
@@ -24,7 +24,7 @@ def main():
         exit()
 
     controller = mcs.create_controller(args.mcs_unity_build_file, debug=True,
-                                       depth_masks=True, object_masks=True)
+                                       depth_maps=True, object_masks=True)
     config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():

--- a/scripts/run_just_rotate.py
+++ b/scripts/run_just_rotate.py
@@ -24,7 +24,7 @@ def main():
         exit()
 
     controller = mcs.create_controller(args.mcs_unity_build_file, debug=True,
-                                       depth_masks=True, object_masks=True)
+                                       depth_maps=True, object_masks=True)
     config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():

--- a/scripts/run_last_action.py
+++ b/scripts/run_last_action.py
@@ -24,7 +24,7 @@ def main():
         exit()
 
     controller = mcs.create_controller(args.mcs_unity_build_file, debug=True,
-                                       depth_masks=True, object_masks=True)
+                                       depth_maps=True, object_masks=True)
     config_file_name = config_file_path[config_file_path.rfind('/') + 1:]
 
     if 'name' not in config_data.keys():

--- a/tests/mock_controller.py
+++ b/tests/mock_controller.py
@@ -81,7 +81,7 @@ class MockControllerAI2THOR(Controller):
         return self._controller.get_last_step_data()
 
     def render_mask_images(self):
-        self._update_internal_config(depth_masks=True, object_masks=True)
+        self._update_internal_config(depth_maps=True, object_masks=True)
 
     def set_config(self, config):
         self._config = config

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -374,7 +374,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(output.step_number, 0)
         self.assertEqual(str(output.goal), str(mcs.GoalMetadata()))
         self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.depth_mask_list),
+        self.assertEqual(len(output.depth_map_list),
                          MOCK_VARIABLES['event_count'])
         self.assertEqual(len(output.object_mask_list),
                          MOCK_VARIABLES['event_count'])
@@ -394,7 +394,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(output.step_number, 0)
         self.assertEqual(str(output.goal), str(mcs.GoalMetadata()))
         self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.depth_mask_list),
+        self.assertEqual(len(output.depth_map_list),
                          MOCK_VARIABLES['event_count'])
         self.assertEqual(len(output.object_mask_list),
                          MOCK_VARIABLES['event_count'])
@@ -424,7 +424,7 @@ class Test_Controller(unittest.TestCase):
             MOCK_VARIABLES['event_count'] * (last_preview_phase_step + 1),
         )
         self.assertEqual(
-            len(output.depth_mask_list),
+            len(output.depth_map_list),
             MOCK_VARIABLES['event_count'] * (last_preview_phase_step + 1),
         )
         self.assertEqual(
@@ -450,7 +450,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(output.step_number, 1)
         self.assertEqual(str(output.goal), str(mcs.GoalMetadata()))
         self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.depth_mask_list),
+        self.assertEqual(len(output.depth_map_list),
                          MOCK_VARIABLES['event_count'])
         self.assertEqual(len(output.object_mask_list),
                          MOCK_VARIABLES['event_count'])
@@ -470,7 +470,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(output.step_number, 2)
         self.assertEqual(str(output.goal), str(mcs.GoalMetadata()))
         self.assertEqual(len(output.image_list), MOCK_VARIABLES['event_count'])
-        self.assertEqual(len(output.depth_mask_list),
+        self.assertEqual(len(output.depth_map_list),
                          MOCK_VARIABLES['event_count'])
         self.assertEqual(len(output.object_mask_list),
                          MOCK_VARIABLES['event_count'])
@@ -736,7 +736,7 @@ class Test_Controller(unittest.TestCase):
             camera_clipping_planes=(3, 4),
             camera_field_of_view=5,
             camera_height=6,
-            depth_mask_list=[7],
+            depth_map_list=[7],
             object_mask_list=[8],
             position={'x': 4, 'y': 5, 'z': 6},
             rotation={'x': 7, 'y': 8, 'z': 9}
@@ -746,7 +746,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual.camera_clipping_planes, (3, 4))
         self.assertEqual(actual.camera_field_of_view, 5)
         self.assertEqual(actual.camera_height, 6)
-        self.assertEqual(actual.depth_mask_list, [7])
+        self.assertEqual(actual.depth_map_list, [7])
         self.assertEqual(actual.object_mask_list, [8])
         self.assertEqual(actual.position, {'x': 4, 'y': 5, 'z': 6})
         self.assertEqual(actual.rotation, {'x': 7, 'y': 8, 'z': 9})
@@ -758,7 +758,7 @@ class Test_Controller(unittest.TestCase):
             camera_clipping_planes=(3, 4),
             camera_field_of_view=5,
             camera_height=6,
-            depth_mask_list=[7],
+            depth_map_list=[7],
             object_mask_list=[8],
             position={'x': 4, 'y': 5, 'z': 6},
             rotation={'x': 7, 'y': 8, 'z': 9}
@@ -768,7 +768,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual.camera_clipping_planes, (3, 4))
         self.assertEqual(actual.camera_field_of_view, 5)
         self.assertEqual(actual.camera_height, 6)
-        self.assertEqual(actual.depth_mask_list, [7])
+        self.assertEqual(actual.depth_map_list, [7])
         self.assertEqual(actual.object_mask_list, [8])
         self.assertEqual(actual.position, {'x': 4, 'y': 5, 'z': 6})
         self.assertEqual(actual.rotation, {'x': 7, 'y': 8, 'z': 9})
@@ -780,7 +780,7 @@ class Test_Controller(unittest.TestCase):
             camera_clipping_planes=(3, 4),
             camera_field_of_view=5,
             camera_height=6,
-            depth_mask_list=[7],
+            depth_map_list=[7],
             object_mask_list=[8],
             position={'x': 4, 'y': 5, 'z': 6},
             rotation={'x': 7, 'y': 8, 'z': 9}
@@ -790,7 +790,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual.camera_clipping_planes, (3, 4))
         self.assertEqual(actual.camera_field_of_view, 5)
         self.assertEqual(actual.camera_height, 6)
-        self.assertEqual(actual.depth_mask_list, [7])
+        self.assertEqual(actual.depth_map_list, [7])
         self.assertEqual(actual.object_mask_list, [8])
         self.assertEqual(actual.position, None)
         self.assertEqual(actual.rotation, None)
@@ -802,7 +802,7 @@ class Test_Controller(unittest.TestCase):
             camera_clipping_planes=(3, 4),
             camera_field_of_view=5,
             camera_height=6,
-            depth_mask_list=[7],
+            depth_map_list=[7],
             object_mask_list=[8],
             position={'x': 4, 'y': 5, 'z': 6},
             rotation={'x': 7, 'y': 8, 'z': 9}
@@ -812,7 +812,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual.camera_clipping_planes, (3, 4))
         self.assertEqual(actual.camera_field_of_view, 5)
         self.assertEqual(actual.camera_height, 6)
-        self.assertEqual(actual.depth_mask_list, [7])
+        self.assertEqual(actual.depth_map_list, [7])
         self.assertEqual(actual.object_mask_list, [])
         self.assertEqual(actual.position, None)
         self.assertEqual(actual.rotation, None)
@@ -1292,7 +1292,7 @@ class Test_Controller(unittest.TestCase):
 
         (
             image_list,
-            depth_mask_list,
+            depth_map_list,
             object_mask_list,
         ) = self.controller.save_images(
             self.create_mock_scene_event(mock_scene_event_data),
@@ -1300,12 +1300,12 @@ class Test_Controller(unittest.TestCase):
         )
 
         self.assertEqual(len(image_list), 1)
-        self.assertEqual(len(depth_mask_list), 1)
+        self.assertEqual(len(depth_map_list), 1)
         self.assertEqual(len(object_mask_list), 1)
 
         self.assertEqual(numpy.array(image_list[0]), image_data)
         numpy.testing.assert_almost_equal(
-            numpy.array(depth_mask_list[0]),
+            numpy.array(depth_map_list[0]),
             numpy.array([[0.0]], dtype=numpy.float32),
             3
         )
@@ -1335,19 +1335,19 @@ class Test_Controller(unittest.TestCase):
 
         (
             image_list,
-            depth_mask_list,
+            depth_map_list,
             object_mask_list
         ) = self.controller.save_images(
             self.create_mock_scene_event(mock_scene_event_data),
             15.0
         )
         self.assertEqual(len(image_list), 2)
-        self.assertEqual(len(depth_mask_list), 2)
+        self.assertEqual(len(depth_map_list), 2)
         self.assertEqual(len(object_mask_list), 2)
 
         self.assertEqual(numpy.array(image_list[0]), image_data_1)
         numpy.testing.assert_almost_equal(
-            numpy.array(depth_mask_list[0]),
+            numpy.array(depth_map_list[0]),
             numpy.array([[4.392]], dtype=numpy.float32),
             3
         )
@@ -1355,7 +1355,7 @@ class Test_Controller(unittest.TestCase):
 
         self.assertEqual(numpy.array(image_list[1]), image_data_2)
         numpy.testing.assert_almost_equal(
-            numpy.array(depth_mask_list[1]),
+            numpy.array(depth_map_list[1]),
             numpy.array([[1.882]], dtype=numpy.float32),
             3
         )
@@ -1457,11 +1457,11 @@ class Test_Controller(unittest.TestCase):
             ['c2'])
         self.assertEqual(actual.structural_object_list[0].visible, True)
 
-        self.assertEqual(len(actual.depth_mask_list), 1)
+        self.assertEqual(len(actual.depth_map_list), 1)
         self.assertEqual(len(actual.image_list), 1)
         self.assertEqual(len(actual.object_mask_list), 1)
         numpy.testing.assert_almost_equal(
-            numpy.array(actual.depth_mask_list[0]),
+            numpy.array(actual.depth_map_list[0]),
             numpy.array([[2.51]], dtype=numpy.float32),
             3
         )
@@ -1503,11 +1503,11 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(len(actual.object_list), 2)
         self.assertEqual(len(actual.structural_object_list), 2)
 
-        self.assertEqual(len(actual.depth_mask_list), 1)
+        self.assertEqual(len(actual.depth_map_list), 1)
         self.assertEqual(len(actual.image_list), 1)
         self.assertEqual(len(actual.object_mask_list), 1)
         numpy.testing.assert_almost_equal(
-            numpy.array(actual.depth_mask_list[0]),
+            numpy.array(actual.depth_map_list[0]),
             numpy.array([[2.51]], dtype=numpy.float32),
             3
         )
@@ -1548,17 +1548,17 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(len(actual.object_list), 0)
         self.assertEqual(len(actual.structural_object_list), 0)
 
-        self.assertEqual(len(actual.depth_mask_list), 0)
+        self.assertEqual(len(actual.depth_map_list), 0)
         self.assertEqual(len(actual.image_list), 1)
         self.assertEqual(len(actual.object_mask_list), 0)
         # self.assertEqual(
         #     numpy.array(
-        #         actual.depth_mask_list[0]),
+        #         actual.depth_map_list[0]),
         #     depth_data)
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
         # self.assertEqual(
         #     numpy.array(
-        #         actual.object_mask_list[0]),
+        #         actual.depth_map_list[0]),
         #     object_mask_data)
 
     def test_wrap_output_with_config_metadata_no_vision(self):
@@ -1592,7 +1592,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(len(actual.object_list), 1)
         self.assertEqual(len(actual.structural_object_list), 1)
 
-        self.assertEqual(len(actual.depth_mask_list), 0)
+        self.assertEqual(len(actual.depth_map_list), 0)
         self.assertEqual(len(actual.image_list), 1)
         self.assertEqual(len(actual.object_mask_list), 0)
 
@@ -1627,7 +1627,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(len(actual.object_list), 0)
         self.assertEqual(len(actual.structural_object_list), 0)
 
-        self.assertEqual(len(actual.depth_mask_list), 0)
+        self.assertEqual(len(actual.depth_map_list), 0)
         self.assertEqual(len(actual.image_list), 1)
         self.assertEqual(len(actual.object_mask_list), 0)
 

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -12,7 +12,7 @@ class Test_StepMetadata(unittest.TestCase):
         "camera_clipping_planes": [0.0,0.0],
         "camera_field_of_view": 0.0,
         "camera_height": 0.0,
-        "depth_mask_list": [],
+        "depth_map_list": [],
         "goal": {
             "action_list": null,
             "category": "",
@@ -62,9 +62,9 @@ class Test_StepMetadata(unittest.TestCase):
     def test_camera_height(self):
         self.assertIsInstance(self.step_metadata.camera_height, float)
 
-    def test_depth_mask_list(self):
-        self.assertFalse(self.step_metadata.depth_mask_list)
-        self.assertIsInstance(self.step_metadata.depth_mask_list, list)
+    def test_depth_map_list(self):
+        self.assertFalse(self.step_metadata.depth_map_list)
+        self.assertIsInstance(self.step_metadata.depth_map_list, list)
 
     def test_goal(self):
         self.assertIsInstance(self.step_metadata.goal, mcs.GoalMetadata)


### PR DESCRIPTION
Updated anywhere in confluence I could find us referencing depth_masks or depth masks as well.