### PR TITLE
MCS-426 Handling scene name prefix for history, video writing and uploading

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -306,11 +306,15 @@ class Controller():
         '''
         output_folder = pathlib.Path(self.__output_folder)
         team = self._config.get(self.CONFIG_TEAM, '')
-        scene = self.__scene_configuration.get(
+        scene_name = self.__scene_configuration.get(
             'name', '').replace('json', '')
+        # strip prefix in scene_name
+        if '/' in scene_name:
+            scene_name = scene_name.rsplit('/', 1)[1]
+
         timestamp = self.generate_time()
         basename_template = '_'.join(
-            [team, scene, self.PLACEHOLDER, timestamp]) + '.mp4'
+            [team, scene_name, self.PLACEHOLDER, timestamp]) + '.mp4'
 
         visual_video_filename = basename_template.replace(
             self.PLACEHOLDER, self.VISUAL)

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -18,6 +18,15 @@ class HistoryWriter(object):
         if not os.path.exists(self.HISTORY_DIRECTORY):
             os.makedirs(self.HISTORY_DIRECTORY)
 
+        scene_name = scene_config_data['name']
+        prefix_directory = None
+        if '/' in scene_name:
+            prefix, scene_basename = scene_name.rsplit('/', 1)
+            print(f"{prefix} {scene_basename}")
+            prefix_directory = os.path.join(self.HISTORY_DIRECTORY, prefix)
+            if not os.path.exists(prefix_directory):
+                os.makedirs(prefix_directory)
+
         if ('screenshot' not in scene_config_data or
                 not scene_config_data['screenshot']):
             self.scene_history_file = os.path.join(

--- a/tests/test_history_writer.py
+++ b/tests/test_history_writer.py
@@ -59,3 +59,32 @@ class Test_HistoryWriter(unittest.TestCase):
         self.assertEqual(writer.history_obj["score"]["confidence"], "0.75")
 
         self.assertTrue(os.path.exists(writer.scene_history_file))
+
+    def test_write_history_file_with_slash(self):
+        config_data = {"name": "prefix/test_scene_file.json"}
+        writer = mcs.HistoryWriter(config_data)
+
+        history_item = mcs.SceneHistory(
+            step=1,
+            action="MoveAhead")
+        writer.add_step(history_item)
+
+        history_item = mcs.SceneHistory(
+            step=2,
+            action="MoveLeft")
+        writer.add_step(history_item)
+
+        writer.write_history_file("Plausible", 0.75)
+
+        self.assertEqual(writer.end_score["classification"], "Plausible")
+        self.assertEqual(writer.end_score["confidence"], "0.75")
+
+        self.assertEqual(
+            writer.history_obj["info"]["name"],
+            "prefix/test_scene_file")
+        self.assertEqual(len(writer.history_obj["steps"]), 2)
+        self.assertEqual(
+            writer.history_obj["score"]["classification"], "Plausible")
+        self.assertEqual(writer.history_obj["score"]["confidence"], "0.75")
+
+        self.assertTrue(os.path.exists(writer.scene_history_file))


### PR DESCRIPTION
Scene history now creates a subfolder with the prefix name and puts the scene history files in that folder collection. Video output for evaluation purposes are written in the same folder as the debug image and upload properly to S3.

![image](https://user-images.githubusercontent.com/26032066/98163267-95215880-1eb0-11eb-8aad-69131ab9f14d.png)

![image](https://user-images.githubusercontent.com/26032066/98163960-8a1af800-1eb1-11eb-8d4f-c8b00cb55a69.png)
