### PR TITLE
MCS-427 - Add evaluation_name property to config

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -161,6 +161,7 @@ class Controller():
     CONFIG_S3_BUCKET = 's3_bucket'
     CONFIG_S3_FOLDER = 's3_folder'
     CONFIG_TEAM = 'team'
+    CONFIG_EVALUATION_NAME = 'evaluation_name'
 
     def __init__(self, unity_app_file_path, debug=False,
                  enable_noise=False, seed=None, size=None,
@@ -305,12 +306,14 @@ class Controller():
         '''Create video recorders used to capture evaluation scenes for review
         '''
         output_folder = pathlib.Path(self.__output_folder)
+        eval_name = self._config.get(self.CONFIG_EVALUATION_NAME, '')
         team = self._config.get(self.CONFIG_TEAM, '')
         scene = self.__scene_configuration.get(
             'name', '').replace('json', '')
         timestamp = self.generate_time()
-        basename_template = '_'.join(
-            [team, scene, self.PLACEHOLDER, timestamp]) + '.mp4'
+        basename_template = ('_'.join(
+            [eval_name, team, scene,
+             self.PLACEHOLDER, timestamp]) + '.mp4').replace(' ', '')
 
         visual_video_filename = basename_template.replace(
             self.PLACEHOLDER, self.VISUAL)
@@ -389,8 +392,9 @@ class Controller():
                 self.__uploader.upload_history(
                     history_path=self.__history_writer.scene_history_file,
                     s3_filename=(folder_prefix + '/' +
-                                 self._config[self.CONFIG_TEAM] +
-                                 '_' + history_filename)
+                                 self._config[self.CONFIG_EVALUATION_NAME] +
+                                 '_' + self._config[self.CONFIG_TEAM] +
+                                 '_' + history_filename).replace(' ', '')
                 )
 
             self.__topdown_recorder.finish()

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -315,9 +315,9 @@ class Controller():
             scene_name = scene_name.rsplit('/', 1)[1]
 
         timestamp = self.generate_time()
-        basename_template = ('_'.join(
+        basename_template = '_'.join(
             [eval_name, self._metadata_tier, team, scene_name,
-             self.PLACEHOLDER, timestamp]) + '.mp4').replace(' ', '')
+             self.PLACEHOLDER, timestamp]) + '.mp4'
 
         visual_video_filename = basename_template.replace(
             self.PLACEHOLDER, self.VISUAL)
@@ -401,7 +401,7 @@ class Controller():
                                  ) +
                                  '_' + self._metadata_tier +
                                  '_' + self._config.get(self.CONFIG_TEAM, '') +
-                                 '_' + history_filename).replace(' ', '')
+                                 '_' + history_filename)
                 )
 
             self.__topdown_recorder.finish()

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -466,9 +466,21 @@ class Controller():
             # Ensure the previous scene history writer has saved its file.
             if self.__history_writer:
                 self.__history_writer.check_file_written()
+
+            hist_info = {}
+            hist_info[self.CONFIG_EVALUATION_NAME] = self._config.get(
+                self.CONFIG_EVALUATION_NAME, ''
+            )
+            hist_info[self.CONFIG_EVALUATION] = self._config.get(
+                self.CONFIG_EVALUATION, False
+            )
+            hist_info[self.CONFIG_METADATA_TIER] = self._metadata_tier
+            hist_info[self.CONFIG_TEAM] = self._config.get(
+                self.CONFIG_TEAM, ''
+            )
             # Create a new scene history writer with each new scene (config
             # data) so we always create a new, separate scene history file.
-            self.__history_writer = HistoryWriter(config_data)
+            self.__history_writer = HistoryWriter(config_data, hist_info)
 
         skip_preview_phase = (True if 'goal' in config_data and
                               'skip_preview_phase' in config_data['goal']

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -392,9 +392,11 @@ class Controller():
                 self.__uploader.upload_history(
                     history_path=self.__history_writer.scene_history_file,
                     s3_filename=(folder_prefix + '/' +
-                                 self._config[self.CONFIG_EVALUATION_NAME] +
+                                 self._config.get(
+                                     self.CONFIG_EVALUATION_NAME, ''
+                                 ) +
                                  '_' + self._metadata_tier +
-                                 '_' + self._config[self.CONFIG_TEAM] +
+                                 '_' + self._config.get(self.CONFIG_TEAM, '') +
                                  '_' + history_filename).replace(' ', '')
                 )
 

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -312,7 +312,7 @@ class Controller():
             'name', '').replace('json', '')
         timestamp = self.generate_time()
         basename_template = ('_'.join(
-            [eval_name, team, scene,
+            [eval_name, self._metadata_tier, team, scene,
              self.PLACEHOLDER, timestamp]) + '.mp4').replace(' ', '')
 
         visual_video_filename = basename_template.replace(
@@ -393,6 +393,7 @@ class Controller():
                     history_path=self.__history_writer.scene_history_file,
                     s3_filename=(folder_prefix + '/' +
                                  self._config[self.CONFIG_EVALUATION_NAME] +
+                                 '_' + self._metadata_tier +
                                  '_' + self._config[self.CONFIG_TEAM] +
                                  '_' + history_filename).replace(' ', '')
                 )

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -7,8 +7,8 @@ import datetime
 
 
 class HistoryWriter(object):
-    def __init__(self, scene_config_data=None):
-        self.info_obj = {}
+    def __init__(self, scene_config_data=None, hist_info={}):
+        self.info_obj = hist_info
         self.current_steps = []
         self.end_score = {}
         self.scene_history_file = None
@@ -27,14 +27,17 @@ class HistoryWriter(object):
             if not os.path.exists(prefix_directory):
                 os.makedirs(prefix_directory)
 
+        timestamp = self.generate_time()
+
         if ('screenshot' not in scene_config_data or
                 not scene_config_data['screenshot']):
             self.scene_history_file = os.path.join(
                 self.HISTORY_DIRECTORY, scene_config_data['name'].replace(
-                    '.json', '') + "-" + self.generate_time() + ".json")
+                    '.json', '') + "-" + timestamp + ".json")
 
         self.info_obj['name'] = scene_config_data['name'].replace(
             '.json', '')
+        self.info_obj['timestamp'] = timestamp
 
     def generate_time(self):
         return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/tests/test_history_writer.py
+++ b/tests/test_history_writer.py
@@ -10,7 +10,26 @@ class Test_HistoryWriter(unittest.TestCase):
         config_data = {"name": "test_scene_file.json"}
         writer = mcs.HistoryWriter(config_data)
 
+        self.assertEqual(writer.info_obj.keys(), {'name', 'timestamp'})
         self.assertEqual(writer.info_obj['name'], "test_scene_file")
+        self.assertTrue(os.path.exists(writer.HISTORY_DIRECTORY))
+
+    def test_init_with_hist_info(self):
+        config_data = {"name": "test_scene_file.json"}
+        writer = mcs.HistoryWriter(config_data, {
+            'team': 'team1',
+            'metadata': 'level1'
+        })
+
+        self.assertEqual(writer.info_obj.keys(), {
+            'team',
+            'metadata',
+            'name',
+            'timestamp'
+        })
+        self.assertEqual(writer.info_obj['name'], "test_scene_file")
+        self.assertEqual(writer.info_obj['team'], "team1")
+        self.assertEqual(writer.info_obj['metadata'], "level1")
         self.assertTrue(os.path.exists(writer.HISTORY_DIRECTORY))
 
     def test_add_step(self):


### PR DESCRIPTION
Using this property in names for uploaded files. 

I also added metadata_tier to the filenames because I thought that was helpful, but I can take that out.

Evaluation name + metadata are first in the filenames, but I can change the ordering in case we want to keep the team name first.

Example file name: Eval3_level1_ra_playroom_visual_20201104-202325.mp4
