### PR TITLE
Fixed bug with reward at restricted metadata levels.

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -1168,7 +1168,7 @@ class Controller():
             camera_height=scene_event.metadata.get(
                 'cameraPosition', {}).get('y', 0.0),
             depth_map_list=depth_map_list,
-            goal=self._goal,
+            goal=copy.deepcopy(self._goal),
             habituation_trial=(
                 self.__habituation_trial
                 if self._goal.habituation_total >= self.__habituation_trial


### PR DESCRIPTION
Fixed a bug in which the positive reward wasn't being properly added at restricted metadata levels (like level 1 and level 2). (Apparently we need better test coverage for these metadata levels...)

See https://machinecommonsense.slack.com/archives/CTR31V12M/p1607126814291400