### PR TITLE
Use config dict getter with default

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -812,7 +812,7 @@ class Controller():
 
         if(heatmap_img is not None and
            isinstance(heatmap_img, PIL.Image.Image) and
-           self._config[self.CONFIG_EVALUATION]):
+           self._config.get(self.CONFIG_EVALUATION, False)):
             self.__heatmap_recorder.add(heatmap_img)
 
     def generate_time(self):


### PR DESCRIPTION
When 'evaluation' is missing from the config (likely a non-existent config file), the key is missing from the dictionary and causes a key error. Although we use the dictionary getter everywhere else, this one slipped by.