### PR TITLE
MCS-477 Read scripted object states from scene configuration files and return them in step output object metadata

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -994,10 +994,7 @@ class Controller():
             if state_list is not None:
                 if not isinstance(state_list, list):
                     return [state_list]
-                for index, state in enumerate(state_list):
-                    if not isinstance(state, str):
-                        state_list[index] = str(state)
-                return state_list
+                return [str(state) for state in state_list]
         return []
 
     def retrieve_pose(self, scene_event) -> str:

--- a/machine_common_sense/object_metadata.py
+++ b/machine_common_sense/object_metadata.py
@@ -45,6 +45,9 @@ class ObjectMetadata(object):
         in degrees.
     shape : string
         This object's shape in plain English.
+    state_list : list of strings
+        This object's state(s) from the current step in the scene. Sometimes
+        used by objects with scripted behavior in passive scenes.
     texture_color_list : list of strings
         This object's colors, derived from its textures, in plain English.
     visible : boolean
@@ -66,6 +69,7 @@ class ObjectMetadata(object):
         position=None,
         rotation=None,
         shape="",
+        state_list=None,
         texture_color_list=None,
         visible=False
     ):
@@ -82,6 +86,7 @@ class ObjectMetadata(object):
         self.position = {} if position is None else position
         self.rotation = {} if rotation is None else rotation
         self.shape = shape
+        self.state_list = [] if state_list is None else state_list
         self.texture_color_list = (
             [] if texture_color_list is None else texture_color_list
         )
@@ -106,5 +111,6 @@ class ObjectMetadata(object):
         yield 'position', self.position
         yield 'rotation', self.rotation
         yield 'shape', self.shape
+        yield 'state_list', self.state_list
         yield 'texture_color_list', self.texture_color_list
         yield 'visible', self.visible

--- a/machine_common_sense/util.py
+++ b/machine_common_sense/util.py
@@ -73,19 +73,23 @@ class Util:
             "POSITION (WORLD)",
             "DIMENSIONS (WORLD)",
             "DISTANCE (WORLD)",
-            "DIRECTION (WORLD)"]
+            "DIRECTION (WORLD)",
+            "STATE"
+        ]
         rows = [titles] + [
             [
                 metadata.uuid,
                 metadata.shape,
-                ", ".join(
-                    metadata.texture_color_list) if(
-                    metadata.texture_color_list is not None) else metadata.texture_color_list,  # noqa: E501
+                ", ".join(metadata.texture_color_list)
+                if(metadata.texture_color_list is not None)
+                else metadata.texture_color_list,
                 metadata.held,
                 Util.vector_to_string(metadata.position),
                 Util.vector_to_string(metadata.dimensions),
                 metadata.distance_in_world,
-                Util.vector_to_string(metadata.direction)
+                Util.vector_to_string(metadata.direction),
+                ", ".join(metadata.state_list)
+                if(metadata.state_list is not None) else metadata.state_list
             ]
             for metadata in object_list
         ]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1078,6 +1078,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual, -56.78)
 
     def test_retrieve_object_list(self):
+        self.controller.start_scene({'name': 'test name'})
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
         actual = self.controller.retrieve_object_list(
             self.create_mock_scene_event(mock_scene_event_data))
@@ -1104,6 +1105,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual[0].position, {"x": 1, "y": 1, "z": 2})
         self.assertEqual(actual[0].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[0].shape, 'shape1')
+        self.assertEqual(actual[0].state_list, [])
         self.assertEqual(actual[0].texture_color_list, ['c1'])
         self.assertEqual(actual[0].visible, True)
 
@@ -1130,10 +1132,32 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual[1].position, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[1].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[1].shape, 'shape2')
+        self.assertEqual(actual[1].state_list, [])
         self.assertEqual(actual[1].texture_color_list, ['c2', 'c3'])
         self.assertEqual(actual[1].visible, True)
 
+    def test_retrieve_object_list_with_states(self):
+        self.controller.start_scene({
+            'name': 'test name',
+            'objects': [{
+                'id': 'testId1',
+                'states': [['a', 'b'], ['c', 'd']]
+            }]
+        })
+        mock_scene_event_data = self.create_retrieve_object_list_scene_event()
+        actual = self.controller.retrieve_object_list(
+            self.create_mock_scene_event(mock_scene_event_data)
+        )
+        self.assertEqual(len(actual), 2)
+
+        self.assertEqual(actual[0].uuid, "testId1")
+        self.assertEqual(actual[0].state_list, ['a', 'b'])
+
+        self.assertEqual(actual[1].uuid, "testId2")
+        self.assertEqual(actual[1].state_list, [])
+
     def test_retrieve_object_list_with_config_metadata_oracle(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.set_metadata_tier('oracle')
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
         actual = self.controller.retrieve_object_list(
@@ -1161,6 +1185,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual[0].position, {"x": 1, "y": 1, "z": 2})
         self.assertEqual(actual[0].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[0].shape, 'shape1')
+        self.assertEqual(actual[0].state_list, [])
         self.assertEqual(actual[0].texture_color_list, ['c1'])
         self.assertEqual(actual[0].visible, True)
 
@@ -1187,6 +1212,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual[1].position, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[1].rotation, {"x": 1, "y": 2, "z": 3})
         self.assertEqual(actual[1].shape, 'shape2')
+        self.assertEqual(actual[1].state_list, [])
         self.assertEqual(actual[1].texture_color_list, ['c2', 'c3'])
         self.assertEqual(actual[1].visible, True)
 
@@ -1213,10 +1239,12 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(actual[2].position, {"x": -3, "y": -2, "z": -1})
         self.assertEqual(actual[2].rotation, {"x": 11, "y": 12, "z": 13})
         self.assertEqual(actual[2].shape, 'shape3')
+        self.assertEqual(actual[2].state_list, [])
         self.assertEqual(actual[2].texture_color_list, [])
         self.assertEqual(actual[2].visible, False)
 
     def test_retrieve_object_list_with_config_metadata_level2(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.set_metadata_tier('level2')
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
         actual = self.controller.retrieve_object_list(
@@ -1224,6 +1252,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(len(actual), 3)
 
     def test_retrieve_object_list_with_config_metadata_level1(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.set_metadata_tier('level1')
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
         actual = self.controller.retrieve_object_list(
@@ -1231,6 +1260,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(len(actual), 3)
 
     def test_retrieve_object_list_with_config_metadata_none(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.set_metadata_tier('none')
         mock_scene_event_data = self.create_retrieve_object_list_scene_event()
         actual = self.controller.retrieve_object_list(
@@ -1446,6 +1476,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(numpy.array(object_mask_list[1]), object_mask_data_2)
 
     def test_wrap_output(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.render_mask_images()
         (
             mock_scene_event_data,
@@ -1500,6 +1531,7 @@ class Test_Controller(unittest.TestCase):
             actual.object_list[0].rotation, {
                 "x": 1, "y": 2, "z": 3})
         self.assertEqual(actual.object_list[0].shape, 'shape')
+        self.assertEqual(actual.object_list[0].state_list, [])
         self.assertEqual(actual.object_list[0].texture_color_list, ['c1'])
         self.assertEqual(actual.object_list[0].visible, True)
 
@@ -1536,6 +1568,7 @@ class Test_Controller(unittest.TestCase):
             actual.structural_object_list[0].rotation, {
                 "x": 4, "y": 5, "z": 6})
         self.assertEqual(actual.structural_object_list[0].shape, 'structure')
+        self.assertEqual(actual.structural_object_list[0].state_list, [])
         self.assertEqual(
             actual.structural_object_list[0].texture_color_list,
             ['c2'])
@@ -1556,6 +1589,7 @@ class Test_Controller(unittest.TestCase):
             object_mask_data)
 
     def test_wrap_output_with_config_metadata_oracle(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.render_mask_images()
         self.controller.set_metadata_tier('oracle')
         (
@@ -1622,6 +1656,7 @@ class Test_Controller(unittest.TestCase):
             object_mask_data)
 
     def test_wrap_output_with_config_metadata_level2(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.set_metadata_tier('level2')
         (
             mock_scene_event_data,
@@ -1686,6 +1721,7 @@ class Test_Controller(unittest.TestCase):
         #     object_mask_data)
 
     def test_wrap_output_with_config_metadata_level1(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.set_metadata_tier('level1')
         (
             mock_scene_event_data,
@@ -1722,6 +1758,7 @@ class Test_Controller(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 0)
 
     def test_wrap_output_with_config_metadata_none(self):
+        self.controller.start_scene({'name': 'test name'})
         self.controller.set_metadata_tier('none')
         (
             mock_scene_event_data,

--- a/tests/test_object_metadata.py
+++ b/tests/test_object_metadata.py
@@ -20,6 +20,7 @@ class Test_ObjectMetadata(unittest.TestCase):
         "position": {},
         "rotation": {},
         "shape": "",
+        "state_list": [],
         "texture_color_list": [],
         "visible": false
     }'''
@@ -84,6 +85,10 @@ class Test_ObjectMetadata(unittest.TestCase):
     def test_shape(self):
         self.assertEqual(self.object_metadata.shape, "")
         self.assertIsInstance(self.object_metadata.shape, str)
+
+    def test_state_list(self):
+        self.assertFalse(self.object_metadata.state_list)
+        self.assertIsInstance(self.object_metadata.state_list, list)
 
     def test_texture_color_list(self):
         self.assertFalse(self.object_metadata.texture_color_list)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -69,6 +69,7 @@ class Test_Util(unittest.TestCase):
             mcs.ObjectMetadata(
                 uuid='id1',
                 shape='',
+                state_list=[],
                 texture_color_list=[],
                 held=True,
                 position=None,
@@ -79,6 +80,7 @@ class Test_Util(unittest.TestCase):
             mcs.ObjectMetadata(
                 uuid='really_long_id2',
                 shape='sofa',
+                state_list=['state1', 'state2'],
                 texture_color_list=['black', 'white'],
                 held=False,
                 position={
@@ -100,9 +102,9 @@ class Test_Util(unittest.TestCase):
             )
         ]
         self.assertEqual(mcs.Util.generate_pretty_object_output(object_list), [
-            'OBJECT ID        SHAPE  COLORS        HELD   POSITION (WORLD)  DIMENSIONS (WORLD)  DISTANCE (WORLD)     DIRECTION (WORLD)  ',  # noqa: E501
-            'id1                                   True   None              None                0                    None               ',  # noqa: E501
-            'really_long_id2  sofa   black, white  False  (1,2,3)           (4,5,6)             1234567890987654321  (10000,20000,30000)'  # noqa: E501
+            'OBJECT ID        SHAPE  COLORS        HELD   POSITION (WORLD)  DIMENSIONS (WORLD)  DISTANCE (WORLD)     DIRECTION (WORLD)    STATE         ',  # noqa: E501
+            'id1                                   True   None              None                0                    None                               ',  # noqa: E501
+            'really_long_id2  sofa   black, white  False  (1,2,3)           (4,5,6)             1234567890987654321  (10000,20000,30000)  state1, state2'  # noqa: E501
         ])
 
     def test_input_to_action_and_params(self):


### PR DESCRIPTION
This is from @ThomasSchellenbergNextCentury's PR https://github.com/NextCenturyCorporation/MCS/pull/219 (cherry picked the commit + made another branch because of wonky commit history due to recent merges -- I'll copy/paste his comments): 

"Read scripted object-specific states from the scene configuration files at each step and return a state_list in the ObjectMetadata.

Lets us show when a gravity support pole is "active" or "inactive", and is flexible in case we need to give new states to objects in future tasks."
