### PR TITLE
NumpyAwareEncoder Class Monkey Patch

### DIFF
--- a/machine_common_sense/API.md
+++ b/machine_common_sense/API.md
@@ -110,6 +110,11 @@ Make a prediction on the previously taken step/action.
 
 
 
+#### retrieve_object_states(object_id)
+Return the state list at the current step for the object with the
+given ID from the scene configuration data, if any.
+
+
 #### start_scene(config_data)
 Starts a new scene using the given scene configuration data dict and
 returns the scene output data object.
@@ -227,7 +232,7 @@ Defines metadata for a goal in the MCS 3D environment.
 ## ObjectMetadata
 
 
-### class machine_common_sense.object_metadata.ObjectMetadata(uuid='', color=None, dimensions=None, direction=None, distance=- 1.0, distance_in_steps=- 1.0, distance_in_world=- 1.0, held=False, mass=0.0, material_list=None, position=None, rotation=None, shape='', texture_color_list=None, visible=False)
+### class machine_common_sense.object_metadata.ObjectMetadata(uuid='', color=None, dimensions=None, direction=None, distance=- 1.0, distance_in_steps=- 1.0, distance_in_world=- 1.0, held=False, mass=0.0, material_list=None, position=None, rotation=None, shape='', state_list=None, texture_color_list=None, visible=False)
 Defines metadata for an object in the MCS 3D environment.
 
 
@@ -283,6 +288,10 @@ Defines metadata for an object in the MCS 3D environment.
 
 
     * **shape** (*string*) – This object’s shape in plain English.
+
+
+    * **state_list** (*list of strings*) – This object’s state(s) from the current step in the scene. Sometimes
+    used by objects with scripted behavior in passive scenes.
 
 
     * **texture_color_list** (*list of strings*) – This object’s colors, derived from its textures, in plain English.

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -43,7 +43,7 @@ from .config_manager import ConfigManager
 
 
 def __image_depth_override(self, image_depth_data, **kwargs):
-    # From https://github.com/NextCenturyCorporation/ai2thor/blob/master/ai2thor/server.py#L232-L240 # noqa: E501
+    # From https://github.com/NextCenturyCorporation/ai2thor/blob/47a9d0802861ba8d7a2a7a6d943a46db28ddbaab/ai2thor/server.py#L232-L240 # noqa: E501
     # The MCS depth shader in Unity is completely different now, so override
     # the original AI2-THOR depth image code. Just return what Unity sends us.
     image_depth = ai2thor.server.read_buffer_image(
@@ -55,7 +55,7 @@ ai2thor.server.Event._image_depth = __image_depth_override
 
 
 class NumpyAwareEncoderOverride(json.JSONEncoder):
-    # From https://github.com/allenai/ai2thor/blob/master/ai2thor/server.py#L17-L24 # noqa: E501
+    # From https://github.com/allenai/ai2thor/blob/bd35d2cb887faee8b87aa04bd9373b027eb39f17/ai2thor/server.py#L17-L24 # noqa: E501
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -41,19 +41,30 @@ from .util import Util
 from .history_writer import HistoryWriter
 from .config_manager import ConfigManager
 
-# From https://github.com/NextCenturyCorporation/ai2thor/blob/master/ai2thor/server.py#L232-L240 # noqa: E501
-
 
 def __image_depth_override(self, image_depth_data, **kwargs):
+    # From https://github.com/NextCenturyCorporation/ai2thor/blob/master/ai2thor/server.py#L232-L240 # noqa: E501
     # The MCS depth shader in Unity is completely different now, so override
-    # the original AI2-THOR depth image code.
-    # Just return what Unity sends us.
+    # the original AI2-THOR depth image code. Just return what Unity sends us.
     image_depth = ai2thor.server.read_buffer_image(
         image_depth_data, self.screen_width, self.screen_height, **kwargs)
     return image_depth
 
 
 ai2thor.server.Event._image_depth = __image_depth_override
+
+
+class NumpyAwareEncoderOverride(json.JSONEncoder):
+    # From https://github.com/allenai/ai2thor/blob/master/ai2thor/server.py#L17-L24 # noqa: E501
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, np.generic):
+            return np.asscalar(obj)
+        return super(NumpyAwareEncoderOverride, self).default(obj)
+
+
+ai2thor.server.NumpyAwareEncoder = NumpyAwareEncoderOverride
 
 
 class Controller():


### PR DESCRIPTION
Added NumpyAwareEncoder override class to fix an issue with passing numpy arrays to Unity.

@bzinberg @fplk Can you please verify that this branch fixes the numpy array issue for you? I'll also add some new tests as part of my current [integration testing](https://github.com/NextCenturyCorporation/MCS/pull/225) ticket.