### PR TITLE
Increase timeout to 3 minutes

### DIFF
--- a/machine_common_sense/mcs.py
+++ b/machine_common_sense/mcs.py
@@ -4,7 +4,8 @@ import signal
 from contextlib import contextmanager
 from .controller import Controller
 
-TIME_LIMIT_SECONDS = 60
+# Timeout at 3 minutes (180 seconds).  It was 60 seconds but this can cause timeouts on EC2 instances
+TIME_LIMIT_SECONDS = 180
 
 
 @contextmanager


### PR DESCRIPTION
In mcs.py, there is code that times out after 60 seconds when starting up the controller.  On Amazon EC2, the machines can be quite slow at the beginning which results in time out of the Unity code, producing an error that looks like:

      Output: Exception in create_controller() Time out!

Based on experiments using the MESS code and p2.xlarge machines, 3 minutes is about the right amount of time.  
