### PR TITLE
Adding scene history cleanup after test module is run

### DIFF
--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -6,13 +6,15 @@ import os
 
 
 class HistoryWriter(object):
+
+    HISTORY_DIRECTORY = "SCENE_HISTORY"
+
     def __init__(self, scene_config_data=None, hist_info={}, timestamp=''):
         self.info_obj = hist_info
         self.current_steps = []
         self.end_score = {}
         self.scene_history_file = None
         self.history_obj = {}
-        self.HISTORY_DIRECTORY = "SCENE_HISTORY"
 
         if not os.path.exists(self.HISTORY_DIRECTORY):
             os.makedirs(self.HISTORY_DIRECTORY)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -11,6 +11,7 @@ from .mock_controller import (
 
 import os
 import glob
+import shutil
 
 SCENE_HIST_DIR = "./SCENE_HISTORY/"
 TEST_FILE_NAME = "test controller"
@@ -21,6 +22,10 @@ class Test_Controller(unittest.TestCase):
     def setUp(self):
         self.controller = MockControllerAI2THOR()
         self.controller.set_metadata_tier('')
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(SCENE_HIST_DIR)
 
     def create_mock_scene_event(self, mock_scene_event_data):
         # Wrap the dict in a SimpleNamespace object to permit property access

--- a/tests/test_history_writer.py
+++ b/tests/test_history_writer.py
@@ -1,10 +1,15 @@
 import unittest
 import os
+import shutil
 
 import machine_common_sense as mcs
 
 
 class Test_HistoryWriter(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(mcs.HistoryWriter.HISTORY_DIRECTORY)
 
     def test_init(self):
         config_data = {"name": "test_scene_file.json"}


### PR DESCRIPTION
Scene history and mcs controller left history artifacts after unit tests. tearDownClass was added to both to remove that folder and all of its contents.