### PR TITLE
Adding msgpack to setup dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
         'boto3>=1.15',
         'opencv-python>=4.0',
         'matplotlib>=3.3',
+        'msgpack>=1.0.0',
         ('ai2thor @ '
          'git+https://github.com/NextCenturyCorporation/ai2thor'
          '@0.3.8#egg=ai2thor')


### PR DESCRIPTION
Although a pinned msgpack dependency was correctly added to the requirements.txt file, we missed the fact that this package dependency also needs to be added to the setup.py 'install_requires'. This is needed for researchers writing with the MCS package who aren't core developers or contributors.