### PR TITLE
Improve shared argument parsing in integration test scripts

### DIFF
--- a/integration_tests/integration_test_utils.py
+++ b/integration_tests/integration_test_utils.py
@@ -12,10 +12,8 @@ def print_divider():
     print('========================================')
 
 
-def retrieve_test_args(name, handmade_only=False):
-    parser = argparse.ArgumentParser(
-        description=(f'Run {name} Integration Tests')
-    )
+def add_test_args(parser: argparse.ArgumentParser,
+                  handmade_only=False) -> argparse.ArgumentParser:
     parser.add_argument(
         'mcs_unity_build_file_path',
         help='Path to MCS unity build file'
@@ -42,4 +40,4 @@ def retrieve_test_args(name, handmade_only=False):
         action='store_true',
         help='Run in dev mode (useful for adding new test scenes)'
     )
-    return parser.parse_args()
+    return parser

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -1,3 +1,4 @@
+import argparse
 import glob
 import json
 import math
@@ -7,7 +8,7 @@ import time
 import machine_common_sense as mcs
 from additional_integration_tests import FUNCTION_LIST
 from integration_test_utils import METADATA_TIER_LIST, print_divider, \
-    retrieve_test_args
+    add_test_args
 
 
 INTEGRATION_TESTS_FOLDER = os.path.dirname(os.path.abspath(__file__))
@@ -236,8 +237,7 @@ def start_handmade_tests(
     dev
 ):
     # Find all of the test scene JSON files.
-    scene_filename_list = glob.glob(TEST_FOLDER + '*' + SCENE_SUFFIX)
-    scene_filename_list.sort()
+    scene_filename_list = sorted(glob.glob(TEST_FOLDER + '*' + SCENE_SUFFIX))
 
     successful_test_list = []
     failed_test_list = []
@@ -299,7 +299,11 @@ def start_handmade_tests(
 
 
 if __name__ == "__main__":
-    args = retrieve_test_args('Handmade', handmade_only=True)
+    parser = argparse.ArgumentParser(
+        description="Run Handmade Integration Tests"
+    )
+    parser = add_test_args(parser, handmade_only=True)
+    args = parser.parse_args()
     start_handmade_tests(
         args.mcs_unity_build_file_path,
         args.metadata,

--- a/integration_tests/run_prefab_tests.py
+++ b/integration_tests/run_prefab_tests.py
@@ -1,8 +1,6 @@
-# import json
+import argparse
 
-# import machine_common_sense as mcs
-
-from integration_test_utils import retrieve_test_args
+from integration_test_utils import add_test_args
 
 
 OBJECT_REGISTRY_LIST = [
@@ -22,7 +20,11 @@ def start_prefab_tests(mcs_unity_build, branch):
 
 
 if __name__ == "__main__":
-    args = retrieve_test_args('Prefab')
+    parser = argparse.ArgumentParser(
+        description="Run Prefab Integration Tests"
+    )
+    parser = add_test_args(parser)
+    args = parser.parse_args()
     start_prefab_tests(
         args.mcs_unity_build_file_path,
         args.mcs_unity_github_branch_name

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -1,4 +1,6 @@
-from integration_test_utils import retrieve_test_args
+import argparse
+
+from integration_test_utils import add_test_args
 from run_handmade_tests import start_handmade_tests
 # from run_prefab_tests import start_prefab_tests
 
@@ -10,7 +12,11 @@ if __name__ == "__main__":
     #     args.mcs_unity_build_file_path,
     #     args.mcs_unity_github_branch_name
     # )
-    args = retrieve_test_args('All', handmade_only=True)
+    parser = argparse.ArgumentParser(
+        description="Run All Integration Tests"
+    )
+    parser = add_test_args(parser, handmade_only=True)
+    args = parser.parse_args()
     start_handmade_tests(
         args.mcs_unity_build_file_path,
         args.metadata,


### PR DESCRIPTION
I noticed that integration test scripts did not allow for the useful `-h` option even though the script leverage argparse. A better way to handle shared argument parsing is to create the parser in each individual script and pass that parser to the helper function which adds the added arguments and returns the parser. The original script makes the call to parse_args() so you still get the args but the `-h` option still works.

```python
(venv) $ python run_tests.py -h
usage: run_tests.py [-h] [--metadata {level1,level2,oracle}] [--test TEST]
                    [--dev]
                    mcs_unity_build_file_path

Run All Integration Tests

positional arguments:
  mcs_unity_build_file_path
                        Path to MCS unity build file

optional arguments:
  -h, --help            show this help message and exit
  --metadata {level1,level2,oracle}
                        Metadata tier to run (by default, test each metadata
                        tier)
  --test TEST           Specific test filename prefix to run (by default, all
                        files)
  --dev                 Run in dev mode (useful for adding new test scenes)
```
