### PR TITLE
Mcs 551

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -781,7 +781,7 @@ class Controller():
             args=kwargs,
             params=params,
             output=history_copy,
-            deltaTimeMillis=0)
+            delta_time_millis=0)
 
         output = self.restrict_step_output_metadata(pre_restrict_output)
 

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -689,7 +689,8 @@ class Controller():
             physics simulation were run. Returns None if you have passed the
             "last_step" of this scene.
         """
-
+        if self.__history_enabled and self.__step_number == 0:
+            self.__history_writer.init_timer()
         if self.__history_enabled and self.__step_number > 0:
             self.__history_writer.add_step(self.__history_item)
 
@@ -779,7 +780,8 @@ class Controller():
             action=action,
             args=kwargs,
             params=params,
-            output=history_copy)
+            output=history_copy,
+            deltaTimeMillis=0)
 
         output = self.restrict_step_output_metadata(pre_restrict_output)
 

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -3,6 +3,7 @@ from .scene_history import SceneHistory
 from typing import Dict
 import json
 import os
+from time import perf_counter
 
 
 class HistoryWriter(object):
@@ -15,6 +16,7 @@ class HistoryWriter(object):
         self.end_score = {}
         self.scene_history_file = None
         self.history_obj = {}
+        self.lastStepTimeMillis = perf_counter() * 1000
 
         if not os.path.exists(self.HISTORY_DIRECTORY):
             os.makedirs(self.HISTORY_DIRECTORY)
@@ -60,9 +62,17 @@ class HistoryWriter(object):
                         del history.output.goal.metadata[target]['image']
         return history
 
+    def init_timer(self):
+        """Initialize the step timer.  Should be called when first command is
+            sent to controller"""
+        self.lastStepTimeMillis = perf_counter() * 1000
+
     def add_step(self, step_obj: Dict):
         """ Add a new step to the array of history steps"""
+        currentTime = perf_counter() * 1000
         if step_obj is not None:
+            step_obj.deltaTimeMillis = currentTime - self.lastStepTimeMillis
+            self.lastStepTimeMillis = currentTime
             self.current_steps.append(
                 dict(self.filter_history_output(step_obj)))
 

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -16,7 +16,7 @@ class HistoryWriter(object):
         self.end_score = {}
         self.scene_history_file = None
         self.history_obj = {}
-        self.lastStepTimeMillis = perf_counter() * 1000
+        self.last_step_time_millis = perf_counter() * 1000
 
         if not os.path.exists(self.HISTORY_DIRECTORY):
             os.makedirs(self.HISTORY_DIRECTORY)
@@ -65,14 +65,15 @@ class HistoryWriter(object):
     def init_timer(self):
         """Initialize the step timer.  Should be called when first command is
             sent to controller"""
-        self.lastStepTimeMillis = perf_counter() * 1000
+        self.last_step_time_millis = perf_counter() * 1000
 
     def add_step(self, step_obj: Dict):
         """Add a new step to the array of history steps"""
-        currentTime = perf_counter() * 1000
+        current_time = perf_counter() * 1000
         if step_obj is not None:
-            step_obj.deltaTimeMillis = currentTime - self.lastStepTimeMillis
-            self.lastStepTimeMillis = currentTime
+            step_obj.delta_time_millis = current_time - \
+                self.last_step_time_millis
+            self.last_step_time_millis = current_time
             self.current_steps.append(
                 dict(self.filter_history_output(step_obj)))
 

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -68,7 +68,7 @@ class HistoryWriter(object):
         self.lastStepTimeMillis = perf_counter() * 1000
 
     def add_step(self, step_obj: Dict):
-        """ Add a new step to the array of history steps"""
+        """Add a new step to the array of history steps"""
         currentTime = perf_counter() * 1000
         if step_obj is not None:
             step_obj.deltaTimeMillis = currentTime - self.lastStepTimeMillis

--- a/machine_common_sense/scene_history.py
+++ b/machine_common_sense/scene_history.py
@@ -13,7 +13,7 @@ class SceneHistory(object):
         confidence: float = None,
         violations_xy_list: List[Dict[str, float]] = None,
         internal_state: object = None,
-        deltaTimeMillis=0,
+        delta_time_millis=0,
         output=None
 
     ):
@@ -25,7 +25,7 @@ class SceneHistory(object):
         self.confidence = confidence
         self.violations_xy_list = violations_xy_list
         self.internal_state = internal_state
-        self.deltaTimeMillis = deltaTimeMillis
+        self.delta_time_millis = delta_time_millis
         self.output = output
 
     def __str__(self):
@@ -44,4 +44,4 @@ class SceneHistory(object):
         yield 'internal_state', self.internal_state
         yield 'output', dict(self.output) if(
             self.output) is not None else self.output
-        yield 'deltaTimeMillis', self.deltaTimeMillis
+        yield 'delta_time_millis', self.delta_time_millis

--- a/machine_common_sense/scene_history.py
+++ b/machine_common_sense/scene_history.py
@@ -13,7 +13,9 @@ class SceneHistory(object):
         confidence: float = None,
         violations_xy_list: List[Dict[str, float]] = None,
         internal_state: object = None,
+        deltaTimeMillis=0,
         output=None
+
     ):
         self.step = step
         self.action = action
@@ -23,6 +25,7 @@ class SceneHistory(object):
         self.confidence = confidence
         self.violations_xy_list = violations_xy_list
         self.internal_state = internal_state
+        self.deltaTimeMillis = deltaTimeMillis
         self.output = output
 
     def __str__(self):
@@ -41,3 +44,4 @@ class SceneHistory(object):
         yield 'internal_state', self.internal_state
         yield 'output', dict(self.output) if(
             self.output) is not None else self.output
+        yield 'deltaTimeMillis', self.deltaTimeMillis

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -515,6 +515,7 @@ class TestController(unittest.TestCase):
         self.assertIsNone(output)
 
     def test_step_validate_action(self):
+        _ = self.controller.start_scene({'name': TEST_FILE_NAME})
         output = self.controller.step('Foobar')
         self.assertIsNone(output)
 
@@ -522,7 +523,6 @@ class TestController(unittest.TestCase):
         output = self.controller.step('MoveAhead')
         self.assertIsNone(output)
 
-        output = self.controller.start_scene({'name': TEST_FILE_NAME})
         self.controller.set_goal(
             mcs.GoalMetadata(
                 action_list=[

--- a/tests/test_history_writer.py
+++ b/tests/test_history_writer.py
@@ -91,6 +91,43 @@ class TestHistoryWriter(unittest.TestCase):
         self.assertEqual(len(writer.current_steps), 2)
         self.assertEqual(writer.current_steps[1]["action"], "MoveLeft")
 
+    def test_add_step_timer(self):
+        writer = mcs.HistoryWriter(self.config_data)
+        writer.init_timer()
+        # set start time back 500ms as if the run took 500ms.
+        writer.last_step_time_millis -= 500
+        # Save the time so we can check that it changes
+        priorToStep1 = writer.last_step_time_millis
+        history_item = mcs.SceneHistory(
+            step=1,
+            action="MoveAhead")
+        writer.add_step(history_item)
+
+        self.assertEqual(len(writer.current_steps), 1)
+        # we give some delta here because commands do take some time to run
+        self.assertAlmostEqual(
+            writer.current_steps[0]["delta_time_millis"], 500, delta=.1)
+        self.assertNotEqual(priorToStep1, writer.last_step_time_millis)
+
+        writer.last_step_time_millis -= 300
+        history_item = mcs.SceneHistory(
+            step=2,
+            action="MoveLeft")
+        writer.add_step(history_item)
+
+        self.assertEqual(len(writer.current_steps), 2)
+        self.assertAlmostEqual(
+            writer.current_steps[1]["delta_time_millis"], 300, delta=.1)
+
+        history_item = mcs.SceneHistory(
+            step=3,
+            action="MoveLeft")
+        writer.add_step(history_item)
+
+        self.assertEqual(len(writer.current_steps), 3)
+        self.assertAlmostEqual(
+            writer.current_steps[2]["delta_time_millis"], 0, delta=.1)
+
     def test_write_history_file(self):
         writer = mcs.HistoryWriter(self.config_data)
 


### PR DESCRIPTION
This pull request adds a new field deltaTimeMillis to each step in the history output. 

Questions:

- JSON output already has mixed CamelCase and Underscores.  I made the field CamelCase, should it stay that way?
- I outputted the time value in milliseconds.  Should it stay milliseconds?  Should it be whole unit milliseconds?  Currently it looks like this: "deltaTimeMillis": 2591.8941180109978.  I didn't find any other durations to keep consistency.