### PR TITLE
Removing ffmpeg video conversion from recorder

### DIFF
--- a/machine_common_sense/recorder.py
+++ b/machine_common_sense/recorder.py
@@ -1,7 +1,5 @@
-import os
 import time
 import pathlib
-import shutil
 import threading
 import queue
 
@@ -100,18 +98,6 @@ class VideoRecorder():
         self.thread.join()
         self.flush()
         self.writer.release()
-
-        if self._frames_written > 0:
-            # convert video to use h264 codec for browser playing
-            # which is not usable directly from opencv
-            shutil.move(self._path, 'temp.mp4')
-            os.system(
-                f'ffmpeg -loglevel quiet -i temp.mp4'
-                f' -vcodec libx264 -vf format=yuv420p {self._path}')
-            os.remove('temp.mp4')
-        else:
-            # Remove the unused video file without any frames.
-            os.remove(self._path)
 
     @property
     def path(self) -> pathlib.Path:


### PR DESCRIPTION
Closes #279 by removing the ffmpeg requirement entirely. We'll do the encoding during ingest instead.