### PR TITLE
updated integration test because material was not in MCSConfig

### DIFF
--- a/integration_tests/data/065.platform.scene.json
+++ b/integration_tests/data/065.platform.scene.json
@@ -1,7 +1,7 @@
 ﻿{
     "name": "platform",
     "version": 1,
-    "ceilingMaterial": "AI2-THOR/Materials/Walls/WallDrywallWhite",
+    "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
     "floorMaterial": "AI2-THOR/Materials/Fabrics/RUG4",
     "wallMaterial": "AI2-THOR/Materials/Walls/YellowDrywall",
     "roomDimensions": {


### PR DESCRIPTION
Updated Integration test.  The material that was changed was not in MCSConfig and thus didn't always return a color.  I'm not sure how this may have worked previously.

See Corresponding pull request: https://github.com/NextCenturyCorporation/ai2thor/pull/129