### PR TITLE
Add metadata accessor, update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ The `metadata` property describes what metadata will be returned by the MCS Pyth
 - `level1`: Only returns the images (with depth maps but NOT object masks), camera info, and properties corresponding to the player themself (like head tilt or pose). No information about specific objects will be included.
 - `none`: Only returns the images (but no depth maps or object masks), camera info, and properties corresponding to the player themself (like head tilt or pose). No information about specific objects will be included.
 
-Otherwise, return the metadata for the visible and held objects.
+If no metadata level is set:
+- `default`: Fallback if no metadata level is specified. Only meant for use during development (evaluations will never be run this way). Includes metadata for visible and held objects in the scene, as well as camera info and properties corresponding to the player. Does not include depth maps or object masks.
 
 #### noise_enabled
 

--- a/machine_common_sense/API.md
+++ b/machine_common_sense/API.md
@@ -71,7 +71,7 @@ numerical action parameters noise_enabled is True.
 
 #### get_metadata_level()
 Returns the current metadata level set in the config. If none
-specified, returns an empty string.
+specified, returns ‘default’.
 
 
 * **Returns**

--- a/machine_common_sense/API.md
+++ b/machine_common_sense/API.md
@@ -69,6 +69,23 @@ numerical action parameters noise_enabled is True.
 :rtype: float
 
 
+#### get_metadata_level()
+Returns the current metadata level set in the config. If none
+specified, returns an empty string.
+
+
+* **Returns**
+
+    A string containing the current metadata level.
+
+
+
+* **Return type**
+
+    string
+
+
+
 #### make_step_prediction(choice: str = None, confidence: float = None, violations_xy_list: List[Dict[str, float]] = None, heatmap_img: PIL.Image.Image = None, internal_state: object = None)
 Make a prediction on the previously taken step/action.
 

--- a/machine_common_sense/API.md
+++ b/machine_common_sense/API.md
@@ -368,10 +368,12 @@ Defines output metadata from an action step in the MCS 3D environment.
     * **depth_map_list** (*list of 2D numpy arrays*) – The list of 2-dimensional numpy arrays of depth float data from the
     scene after the last action and physics simulation were run. This is
     usually a list with 1 array, except for the output from start_scene
-    for a scene with a scripted Preview Phase.
+    for a scene with a scripted Preview Phase (Preview Phase case details
+    TBD).
     Each depth float in a 2-dimensional numpy array is a value between 0
     and the camera’s far clipping plane (default 15) correspondings to the
     depth in simulation units at that pixel in the image.
+    Note that this list will be empty if the metadata level is ‘none’.
 
 
     * **goal** (*GoalMetadata** or **None*) – The goal for the whole scene. Will be None in “Exploration” scenes.
@@ -389,19 +391,23 @@ Defines output metadata from an action step in the MCS 3D environment.
     * **image_list** (*list of Pillow.Image objects*) – The list of images from the scene after the last action and physics
     simulation were run. This is usually a list with 1 image, except for
     the output from start_scene for a scene with a scripted Preview Phase.
+    (Preview Phase case details TBD).
 
 
     * **object_list** (*list of ObjectMetadata objects*) – The list of metadata for all the visible interactive objects in the
-    scene. For metadata on structural objects like walls, please see
-    structural_object_list
+    scene. This list will be empty if using a metadata level below
+    the ‘oracle’ level. For metadata on structural objects like walls,
+    please see structural_object_list
 
 
     * **object_mask_list** (*list of Pillow.Image objects*) – The list of object mask (instance segmentation) images from the scene
     after the last action and physics simulation were run. This is usually
     a list with 1 image, except for the output from start_scene for a
-    scene with a scripted Previous Phase.
+    scene with a scripted Preview Phase (Preview Phase case details TBD).
     The color of each object in the mask corresponds to the “color”
     property in its ObjectMetadata object.
+    Note that this list will be empty if the metadata level is ‘none’
+    or ‘level1’.
 
 
     * **performer_radius** (*float*) – The radius of the performer.
@@ -414,6 +420,8 @@ Defines output metadata from an action step in the MCS 3D environment.
 
 
     * **position** (*dict*) – The “x”, “y”, and “z” coordinates for your global position.
+    Will be set to ‘None’ if using a metadata level below the
+    ‘oracle’ level.
 
 
     * **return_status** (*string*) – The return status from your last action. See [Actions](#Actions).
@@ -422,7 +430,8 @@ Defines output metadata from an action step in the MCS 3D environment.
     * **reward** (*integer*) – Reward is 1 on successful completion of a task, 0 otherwise.
 
 
-    * **rotation** (*float*) – Your current rotation angle in degrees.
+    * **rotation** (*float*) – Your current rotation angle in degrees. Will be set to ‘None’
+    if using a metadata level below the ‘oracle’ level.
 
 
     * **step_number** (*integer*) – The step number of your last action, recorded since you started the
@@ -430,11 +439,13 @@ Defines output metadata from an action step in the MCS 3D environment.
 
 
     * **structural_object_list** (*list of ObjectMetadata objects*) – The list of metadata for all the visible structural objects (like
-    walls, occluders, and ramps) in the scene. Please note that occluders
-    are composed of two separate objects, the “wall” and the “pole”, with
-    corresponding object IDs (occluder_wall_<uuid> and
-    occluder_pole_<uuid>), and ramps are composed of between one and three
-    objects (depending on the type of ramp), with corresponding object IDs.
+    walls, occluders, and ramps) in the scene. This list will be empty
+    if using a metadata level below the ‘oracle’ level.
+    Please note that occluders are composed of two separate objects,
+    the “wall” and the “pole”, with corresponding object IDs
+    (occluder_wall_<uuid> and occluder_pole_<uuid>), and ramps are
+    composed of between one and three objects (depending on the type
+    of ramp), with corresponding object IDs.
 
 
 ## Actions

--- a/machine_common_sense/DEV.md
+++ b/machine_common_sense/DEV.md
@@ -144,7 +144,8 @@ The `metadata` property describes what metadata will be returned by the MCS Pyth
 - `level1`: Only returns the images (with depth masks but NOT object masks), camera info, and properties corresponding to the player themself (like head tilt or pose). No information about specific objects will be included.
 - `none`: Only returns the images (but not the masks), camera info, and properties corresponding to the player themself (like head tilt or pose). No information about specific objects will be included.
 
-Otherwise, return the metadata for the visible and held objects.
+If no metadata level is set:
+- `default`: Fallback if no metadata level is specified. Only meant for use during development (evaluations will never be run this way). Includes metadata for visible and held objects in the scene, as well as camera info and properties corresponding to the player. Does not include depth maps or object masks.
 
 #### noise_enabled
 

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -92,7 +92,7 @@ class ConfigManager(object):
             return self._config.get(
                 self.CONFIG_DEFAULT_SECTION,
                 self.CONFIG_METADATA_TIER,
-                fallback=''
+                fallback='default'
             )
 
         return metadata_env_var

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -1373,3 +1373,15 @@ class Controller():
         """
 
         return random.uniform(-0.5, 0.5)
+
+    def get_metadata_level(self):
+        """
+        Returns the current metadata level set in the config. If none
+        specified, returns an empty string.
+
+        Returns
+        -------
+        string
+            A string containing the current metadata level.
+        """
+        return self._metadata_tier

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -1381,7 +1381,7 @@ class Controller():
     def get_metadata_level(self):
         """
         Returns the current metadata level set in the config. If none
-        specified, returns an empty string.
+        specified, returns 'default'.
 
         Returns
         -------

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -177,6 +177,10 @@ class Controller():
     # feedback
     CONFIG_METADATA_TIER_NONE = 'none'
 
+    # Default metadata level if none specified, meant for use during
+    # development
+    CONFIG_METADATA_TIER_DEFAULT = 'default'
+
     AWS_CREDENTIALS_FOLDER = os.path.expanduser('~') + '/.aws/'
     AWS_CREDENTIALS_FILE = os.path.expanduser('~') + '/.aws/credentials'
 
@@ -1008,7 +1012,7 @@ class Controller():
     def retrieve_object_list(self, scene_event):
         # Return object list for all tier levels, the restrict output function
         # will then strip out the necessary metadata
-        if (self._metadata_tier != ''):
+        if (self._metadata_tier != self.CONFIG_METADATA_TIER_DEFAULT):
             return sorted(
                 [
                     self.retrieve_object_output(
@@ -1150,7 +1154,7 @@ class Controller():
     def retrieve_structural_object_list(self, scene_event):
         # Return structural object list for all tier levels, the restrict
         # output function will then strip out the necessary metadata
-        if (self._metadata_tier != ''):
+        if (self._metadata_tier != self.CONFIG_METADATA_TIER_DEFAULT):
             return sorted(
                 [
                     self.retrieve_object_output(

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -31,10 +31,12 @@ class StepMetadata:
         The list of 2-dimensional numpy arrays of depth float data from the
         scene after the last action and physics simulation were run. This is
         usually a list with 1 array, except for the output from start_scene
-        for a scene with a scripted Preview Phase.
+        for a scene with a scripted Preview Phase (Preview Phase case details
+        TBD).
         Each depth float in a 2-dimensional numpy array is a value between 0
         and the camera's far clipping plane (default 15) correspondings to the
         depth in simulation units at that pixel in the image.
+        Note that this list will be empty if the metadata level is 'none'.
     goal : GoalMetadata or None
         The goal for the whole scene. Will be None in "Exploration" scenes.
     habituation_trial : int or None
@@ -48,17 +50,21 @@ class StepMetadata:
         The list of images from the scene after the last action and physics
         simulation were run. This is usually a list with 1 image, except for
         the output from start_scene for a scene with a scripted Preview Phase.
+        (Preview Phase case details TBD).
     object_list : list of ObjectMetadata objects
         The list of metadata for all the visible interactive objects in the
-        scene. For metadata on structural objects like walls, please see
-        structural_object_list
+        scene. This list will be empty if using a metadata level below
+        the 'oracle' level. For metadata on structural objects like walls,
+        please see structural_object_list
     object_mask_list : list of Pillow.Image objects
         The list of object mask (instance segmentation) images from the scene
         after the last action and physics simulation were run. This is usually
         a list with 1 image, except for the output from start_scene for a
-        scene with a scripted Previous Phase.
+        scene with a scripted Preview Phase (Preview Phase case details TBD).
         The color of each object in the mask corresponds to the "color"
         property in its ObjectMetadata object.
+        Note that this list will be empty if the metadata level is 'none'
+        or 'level1'.
     performer_radius: float
         The radius of the performer.
     performer_reach: float
@@ -67,22 +73,27 @@ class StepMetadata:
         Your current pose. Either "STANDING", "CRAWLING", or "LYING".
     position : dict
         The "x", "y", and "z" coordinates for your global position.
+        Will be set to 'None' if using a metadata level below the
+        'oracle' level.
     return_status : string
         The return status from your last action. See [Actions](#Actions).
     reward : integer
         Reward is 1 on successful completion of a task, 0 otherwise.
     rotation : float
-        Your current rotation angle in degrees.
+        Your current rotation angle in degrees. Will be set to 'None'
+        if using a metadata level below the 'oracle' level.
     step_number : integer
         The step number of your last action, recorded since you started the
         current scene.
     structural_object_list : list of ObjectMetadata objects
         The list of metadata for all the visible structural objects (like
-        walls, occluders, and ramps) in the scene. Please note that occluders
-        are composed of two separate objects, the "wall" and the "pole", with
-        corresponding object IDs (occluder_wall_<uuid> and
-        occluder_pole_<uuid>), and ramps are composed of between one and three
-        objects (depending on the type of ramp), with corresponding object IDs.
+        walls, occluders, and ramps) in the scene. This list will be empty
+        if using a metadata level below the 'oracle' level.
+        Please note that occluders are composed of two separate objects,
+        the "wall" and the "pole", with corresponding object IDs
+        (occluder_wall_<uuid> and occluder_pole_<uuid>), and ramps are
+        composed of between one and three objects (depending on the type
+        of ramp), with corresponding object IDs.
     """
 
     def __init__(

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -103,7 +103,7 @@ class TestConfigManager(unittest.TestCase):
 
     @mock_env()
     def test_get_metadata_tier(self):
-        self.assertEqual(self.config_mngr.get_metadata_tier(), '')
+        self.assertEqual(self.config_mngr.get_metadata_tier(), 'default')
 
         self.config_mngr._config[
             self.config_mngr.CONFIG_DEFAULT_SECTION

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -21,7 +21,7 @@ class TestController(unittest.TestCase):
 
     def setUp(self):
         self.controller = MockControllerAI2THOR()
-        self.controller.set_metadata_tier('')
+        self.controller.set_metadata_tier('default')
         self.maxDiff = None
 
     @classmethod
@@ -1986,7 +1986,7 @@ class TestController(unittest.TestCase):
         self.assertTrue(minValue <= currentNoise <= maxValue)
 
     def test_get_metadata_level(self):
-        self.assertEqual('', self.controller.get_metadata_level())
+        self.assertEqual('default', self.controller.get_metadata_level())
 
         self.controller.set_metadata_tier('oracle')
         self.assertEqual('oracle', self.controller.get_metadata_level())

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1985,6 +1985,15 @@ class TestController(unittest.TestCase):
         currentNoise = self.controller.generate_noise()
         self.assertTrue(minValue <= currentNoise <= maxValue)
 
+    def test_get_metadata_level(self):
+        self.assertEqual('', self.controller.get_metadata_level())
+
+        self.controller.set_metadata_tier('oracle')
+        self.assertEqual('oracle', self.controller.get_metadata_level())
+
+        self.controller.set_metadata_tier('none')
+        self.assertEqual('none', self.controller.get_metadata_level())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Adding a way to access the current metadata level from the controller
- Updated the empty string/not specified metadata level to 'default'
- Updated documentation to indicate that 'default' is meant as a developer convenience feature only, and to be clearer about what's returned for what metadata level in StepMetadata. 

Should address https://github.com/NextCenturyCorporation/MCS/issues/233 and https://github.com/NextCenturyCorporation/MCS/issues/234

