### PR TITLE
sample logging config initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ scripts/**/*.mp4
 scripts/**/*.png
 scripts/**/*.zip
 
+# Logging output and user config
 logs/*.log
+scripts/log.config.user.py

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ scripts/**/*.json
 scripts/**/*.mp4
 scripts/**/*.png
 scripts/**/*.zip
+
+logs/*.log

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - [Download](#download)
 - [Training Datasets](#training-datasets)
 - [Usage](#usage)
+- [Logging](#logging)
 - [Run with Human Input](#run-with-human-input)
 - [Run with Scene Timer](#run-with-scene-timer)
 - [Config File](#config-file)
@@ -212,28 +213,39 @@ for scene_json_file_path in scene_json_file_list:
     controller.end_scene()
 ```
 
-Example with terminal logging:
+### Logging
+#### Initialize development logging config settings
+In startup script make sure you include:
 ```python
-import logging
 import machine_common_sense as mcs
 
-logger = logging.getLogger('machine_common_sense')
-logger.setLevel(logging.DEBUG)
-stream_handler = logging.StreamHandler()
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
+#This code initializes logging using config files
+mcs.init_logging()
+```
+#### Logging configuration files
+This logging configuration system uses a file at [scripts/log.config.py](./scripts/log.config.py) as a default configuration file.  See that file for links to documentation and some descriptions.
 
-controller = mcs.create_controller(unity_app_file_path, config_file_path='./some-path/config.ini')
-scene_data, status = mcs.load_scene_json_file(scene_json_file_path)
-output = controller.start_scene(scene_data)
+Users can copy that file to scripts/log.config.user.py to create their own configuration.  This file is gitignored so it will not be shared.
 
-action, params = select_action(output)
-while action != '':
-    logger.debug(f"Taking {action} with {params{")
-    controller.step(action, params)
-    action, params = select_action(output)
+#### Why use logging and configuration files
 
-controller.end_scene()
+We use logging configuration files so users have a reasonable default configuration but also have the ability to override when circumstances demand.  This eliminates the need to alter code when changing what logging is necessary.  In the future, additional features to the initialization function to support difficult overrides if necessary (i.e. different logging override files for dev, test, eval, etc).
+
+#### Example with logging config file:
+
+Sample of how to log in all files:
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+def any_function(self):
+    #basic log functions in order of level.  If logger or handler is set to a level, that level and above will be logged.
+    logger.critical("This message is see as long as the logger is enabled")
+    logger.error("This message reports an error")
+    logger.info("This message is general info")
+    logger.debug("This message is mainly for debugging and shouldn't cause usage problems if missing")
+    # Unlike many common loggers in other languages, python logging doesn't seem to have TRACE
 ```
 
 ## Run with Human Input

--- a/logs/.dir
+++ b/logs/.dir
@@ -1,0 +1,1 @@
+just created to force the logs directory into git

--- a/machine_common_sense/util.py
+++ b/machine_common_sense/util.py
@@ -1,8 +1,5 @@
 import numpy
 import logging
-import logging.config
-import ast
-from os.path import exists
 
 from .action import Action
 from .material import Material
@@ -317,28 +314,3 @@ class Util:
             return True
         except KeyError:
             return False
-
-    @staticmethod
-    def init_logging():
-        """
-        Initializes logging system.  Attempts to read user file first,
-        which should not be checked in and each user can have their own.
-        If user file doesn't exist, then there is a base config file that
-        should be read.
-        """
-        log_config_base = "scripts/log.config.py"
-        log_config_user = "scripts/log.config.user.py"
-        log_config_file = None
-        if (exists(log_config_user)):
-            log_config_file = log_config_user
-        if (exists(log_config_base)):
-            log_config_file = log_config_base
-        if (log_config_file is not None):
-            with open(log_config_file, "r") as data:
-                logConfig = ast.literal_eval(data.read())
-            logging.config.dictConfig(logConfig)
-            logger.info("Loaded logging config from " + log_config_file)
-        else:
-            print(
-                "Error initializing logging.  No file found at " +
-                log_config_base + " or " + log_config_user)

--- a/machine_common_sense/util.py
+++ b/machine_common_sense/util.py
@@ -1,5 +1,8 @@
 import numpy
 import logging
+import logging.config
+import ast
+from os.path import exists
 
 from .action import Action
 from .material import Material
@@ -314,3 +317,28 @@ class Util:
             return True
         except KeyError:
             return False
+
+    @staticmethod
+    def init_logging():
+        """
+        Initializes logging system.  Attempts to read user file first,
+        which should not be checked in and each user can have their own.
+        If user file doesn't exist, then there is a base config file that
+        should be read.
+        """
+        log_config_base = "scripts/log.config.py"
+        log_config_user = "scripts/log.config.user.py"
+        log_config_file = None
+        if (exists(log_config_user)):
+            log_config_file = log_config_user
+        if (exists(log_config_base)):
+            log_config_file = log_config_base
+        if (log_config_file is not None):
+            with open(log_config_file, "r") as data:
+                logConfig = ast.literal_eval(data.read())
+            logging.config.dictConfig(logConfig)
+            logger.info("Loaded logging config from " + log_config_file)
+        else:
+            print(
+                "Error initializing logging.  No file found at " +
+                log_config_base + " or " + log_config_user)

--- a/scripts/log.config.py
+++ b/scripts/log.config.py
@@ -5,6 +5,18 @@
 # The goal here is to create a logging file that will work for most while
 # providing additional options to make changing the configuration relatively
 # easy.
+#
+# Basic structure of logging.
+#   Code should get and use a logger determined by the class name:
+#     logger = logging.getLogger(__name__)
+#   Loggers are configured here to pass log data zero or more handlers
+#     Loggers have a level which filters out any logs below that level
+#   Handlers determine where to send the data (console, files, sockets)
+#     Handlers have a level which filters out any logs below that level
+#     Handlers can reference a formatter
+#   Formatters determine the format of the log message
+#   Note: For a message to be logged, its level must be equal to or above
+#     both the logger's level and the handler's level
 {
     "version": 1,
     # Essentially the default.  Anything that isn't defined elsewhere, will

--- a/scripts/log.config.py
+++ b/scripts/log.config.py
@@ -1,0 +1,79 @@
+# This file is loaded as a python dictionary.  Documentation on the format
+# can be found here:
+# https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+#
+# The goal here is to create a logging file that will work for most while
+# providing additional options to make changing the configuration relatively
+# easy.
+{
+    "version": 1,
+    # Essentially the default.  Anything that isn't defined elsewhere, will
+    # take these settings
+    "root": {
+        "level": "WARN",
+        "handlers": ["console", "debug-file"],
+        "propagate": False
+    },
+    "loggers": {
+        # Sets all machine_common_sense loggers to these settings and
+        # logs them into the listed handlers
+        "machine_common_sense": {
+            "level": "DEBUG",
+            "handlers": ["console", "debug-file"],
+            "propagate": False
+        }
+        # Sample of how to change the level at a more detailed level:
+        # ,
+        # "machine_common_sense.controller": {
+        #    "level": "TRACE",
+        #    "handlers": ["console", "debug-file"],
+        #    "propagate": False
+        # }
+    },
+    # Handlers take log messages and put them somewhere (console, files,
+    # sockets, syslog, smtp, http)
+    # See https://docs.python.org/3/library/logging.handlers.html for
+    # all the different built in handlers
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "brief",
+            "level": "DEBUG",
+            "stream": "ext://sys.stdout"
+        },
+        # The file handlers have a nice feature to rotate log files so you
+        # don't use up all your disk space (maxBytes and backupCount).
+        "debug-file": {
+            "level": "DEBUG",
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "precise",
+            "filename": "logs/mcs.debug.log",
+            "maxBytes": 10240000,
+            "backupCount": 3
+        },
+        # This is mostly here for a sample.  We don't seem to have enough
+        # differentiation between debug and info yet to make this useful
+        "info-file": {
+            "level": "INFO",
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "precise",
+            "filename": "logs/mcs.info.log",
+            "maxBytes": 10240000,
+            "backupCount": 3
+        }
+    },
+    # Formatters just specify the format of the log message.  Sometimes its
+    # useful to have a lot of detail.  Sometimes it more annoying than useful.
+    # Simply change which formatter you want in the handlers section.False
+    "formatters": {
+        "brief": {
+            "format": "%(message)s"
+        },
+        "precise": {
+            "format": "%(asctime)s <%(levelname)s>: %(message)s"
+        },
+        "full": {
+            "format": "[%(name)s] %(asctime)s <%(levelname)s>: %(message)s"
+        }
+    }
+}

--- a/scripts/run_human_input.py
+++ b/scripts/run_human_input.py
@@ -209,6 +209,7 @@ def run_scene(controller, scene_data):
 
 
 def main():
+    mcs.Util.init_logging()
     args = parse_args()
     scene_data, status = mcs.load_scene_json_file(args.mcs_scene_json_file)
 

--- a/scripts/run_human_input.py
+++ b/scripts/run_human_input.py
@@ -209,7 +209,7 @@ def run_scene(controller, scene_data):
 
 
 def main():
-    mcs.Util.init_logging()
+    mcs.init_logging()
     args = parse_args()
     scene_data, status = mcs.load_scene_json_file(args.mcs_scene_json_file)
 


### PR DESCRIPTION
This is a possible method for us to initialize logging for local scripts.  Comments and suggests are strongly encouraged.

My goals were:

- Minimal, easy changes to any script to add logging that could be consistent
- Allow for developer to make custom changes that wouldn't be checked into git without code changes
- A reasonable default for anyone who doesn't want to mess with logging configuration

One issue: it will errors without an obvious message if the ./logs folder doesn't exist.  We could use ./ but I'd rather not let it throw a couple log files into the root directory.