### PR TITLE
MCS-630 Unified action list format to always use tuples and updated human input mode script.

### DIFF
--- a/machine_common_sense/API.md
+++ b/machine_common_sense/API.md
@@ -132,6 +132,11 @@ Make a prediction on the previously taken step/action.
 
 
 
+#### retrieve_action_list_at_step(goal, step_number)
+Return the action list from the given goal at the given step as a
+a list of actions tuples by default.
+
+
 #### retrieve_object_states(object_id)
 Return the state list at the current step for the object with the
 given ID from the scene configuration data, if any.
@@ -203,13 +208,21 @@ Defines metadata for a goal in the MCS 3D environment.
 * **Variables**
 
     
-    * **action_list** (*list of lists of strings**, or **None*) – The list of actions that are available for the scene at each step
-    (outer list index).  Each inner list item is a list of action strings.
-    For example, [‘MoveAhead’,’RotateLook,rotation=180’] restricts the
-    actions to either ‘MoveAhead’ or ‘RotateLook’ with the ‘rotation’
-    parameter set to 180. An action_list of None means that all
-    actions are always available. An empty inner list means that all
-    actions are available for that specific step.
+    * **action_list** (*list of lists of** (**string**, **dict**) **tuples**, or **None*) – The list of all actions that are available for the scene at each step
+    (outer list). Each inner list is the list of all actions that are
+    available for the single step corresponding to the inner list’s index
+    within the outer list. Each action is returned as a tuple containing
+    the action string and the action’s restricted paramters, if any.
+    For example: (“Pass”, {}) forces a Pass action; (“PickupObject”, {})
+    forces a PickupObject action with any parameters; and
+    (“PickupObject”, {“objectId”: “a”}) forces a PickupObject action with
+    the specific parameters objectId=a.
+    An action_list of None means that all actions are always available.
+    An empty inner list means that all actions will be available on that
+    specific step.
+    See StepMetadata.action_list for the available actions of the current
+    step.
+    May be a subset of all possible actions. See [Actions](#Actions).
 
 
     * **category** (*string*) – The category that describes this goal and the properties in its
@@ -346,6 +359,13 @@ Defines output metadata from an action step in the MCS 3D environment.
     * **action_list** (*list of** (**string**, **dict**) **tuples*) – The list of all actions that are available for the next step.
     Each action is returned as a tuple containing the action string and
     the action’s restricted parameters, if any.
+    For example: (“Pass”, {}) forces a Pass action; (“PickupObject”, {})
+    forces a PickupObject action with any parameters; and
+    (“PickupObject”, {“objectId”: “a”}) forces a PickupObject action with
+    the specific parameters objectId=a.
+    An action_list of None or an empty list means that all actions will
+    be available for the next step.
+    Derived from GoalMetadata.action_list.
     May be a subset of all possible actions. See [Actions](#Actions).
 
 

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -747,7 +747,10 @@ class Controller():
         if ',' in action:
             action, kwargs = Util.input_to_action_and_params(action)
 
-        action_list = self.retrieve_action_list(self._goal, self.__step_number)
+        action_list = self.retrieve_action_list_at_step(
+            self._goal,
+            self.__step_number
+        )
         # Only continue with this action step if the given action and
         # parameters are in the restricted action list.
         continue_with_step = False
@@ -766,17 +769,10 @@ class Controller():
                 f"The given action '{action}' with parameters "
                 f"'{kwargs}' isn't in the action_list. Ignoring your action. "
                 f"Please call controller.step() with an action in the "
-                f"action_list."
+                f"action_list. Possible actions at step {self.__step_number}:"
             )
-            action_string_list = self.retrieve_action_list(
-                self._goal,
-                self.__step_number,
-                string_list=True
-            )
-            logger.debug(
-                f"Actions (Step {self.__step_number}): "
-                f"{'; '.join(action_string_list)}"
-            )
+            for action_data in action_list:
+                logger.warning(f'    {action_data}')
             return None
 
         self.__step_number += 1
@@ -959,7 +955,9 @@ class Controller():
 
         return step_output
 
-    def retrieve_action_list(self, goal, step_number, string_list=False):
+    def retrieve_action_list_at_step(self, goal, step_number):
+        """Return the action list from the given goal at the given step as a
+        a list of actions tuples by default."""
         if goal is not None and goal.action_list is not None:
             if step_number < goal.last_preview_phase_step:
                 return ['Pass']
@@ -968,14 +966,9 @@ class Controller():
             adjusted_step = step_number - goal.last_preview_phase_step
             if len(goal.action_list) > adjusted_step:
                 if len(goal.action_list[adjusted_step]) > 0:
-                    return [
-                        Util.input_to_action_and_params(action)
-                        for action in goal.action_list[adjusted_step]
-                    ] if not string_list else goal.action_list[adjusted_step]
+                    return goal.action_list[adjusted_step]
 
-        return self.ACTION_LIST if not string_list else [
-            action[0] for action in self.ACTION_LIST
-        ]
+        return self.ACTION_LIST
 
     def retrieve_goal(self, scene_configuration):
         goal_config = (
@@ -984,12 +977,21 @@ class Controller():
             else {}
         )
 
+        # Transform action list data from strings to tuples.
+        action_list = goal_config.get('action_list', [])
+        for index, action_list_at_step in enumerate(action_list):
+            action_list[index] = [
+                Util.input_to_action_and_params(action)
+                if isinstance(action, str) else action
+                for action in action_list_at_step
+            ]
+
         if 'category' in goal_config:
             # Backwards compatibility
             goal_config['metadata']['category'] = goal_config['category']
 
         return self.update_goal_target_image(GoalMetadata(
-            action_list=goal_config.get('action_list', None),
+            action_list=(action_list if action_list else None),
             category=goal_config.get('category', ''),
             description=goal_config.get('description', ''),
             habituation_total=goal_config.get('habituation_total', 0),
@@ -1281,8 +1283,10 @@ class Controller():
         objects = scene_event.metadata.get('objects', None)
         agent = scene_event.metadata.get('agent', None)
         step_output = StepMetadata(
-            action_list=self.retrieve_action_list(
-                self._goal, self.__step_number),
+            action_list=self.retrieve_action_list_at_step(
+                self._goal,
+                self.__step_number
+            ),
             camera_aspect_ratio=(self.__screen_width, self.__screen_height),
             camera_clipping_planes=(
                 scene_event.metadata.get('clippingPlaneNear', 0.0),

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -8,14 +8,22 @@ class GoalMetadata:
 
     Attributes
     ----------
-    action_list : list of lists of strings, or None
-        The list of actions that are available for the scene at each step
-        (outer list index).  Each inner list item is a list of action strings.
-        For example, ['MoveAhead','RotateLook,rotation=180'] restricts the
-        actions to either 'MoveAhead' or 'RotateLook' with the 'rotation'
-        parameter set to 180. An action_list of None means that all
-        actions are always available. An empty inner list means that all
-        actions are available for that specific step.
+    action_list : list of lists of (string, dict) tuples, or None
+        The list of all actions that are available for the scene at each step
+        (outer list). Each inner list is the list of all actions that are
+        available for the single step corresponding to the inner list's index
+        within the outer list. Each action is returned as a tuple containing
+        the action string and the action's restricted paramters, if any.
+        For example: ("Pass", {}) forces a Pass action; ("PickupObject", {})
+        forces a PickupObject action with any parameters; and
+        ("PickupObject", {"objectId": "a"}) forces a PickupObject action with
+        the specific parameters objectId=a.
+        An action_list of None means that all actions are always available.
+        An empty inner list means that all actions will be available on that
+        specific step.
+        See StepMetadata.action_list for the available actions of the current
+        step.
+        May be a subset of all possible actions. See [Actions](#Actions).
     category : string
         The category that describes this goal and the properties in its
         metadata. See [Goals](#Goals).

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -14,6 +14,13 @@ class StepMetadata:
         The list of all actions that are available for the next step.
         Each action is returned as a tuple containing the action string and
         the action's restricted parameters, if any.
+        For example: ("Pass", {}) forces a Pass action; ("PickupObject", {})
+        forces a PickupObject action with any parameters; and
+        ("PickupObject", {"objectId": "a"}) forces a PickupObject action with
+        the specific parameters objectId=a.
+        An action_list of None or an empty list means that all actions will
+        be available for the next step.
+        Derived from GoalMetadata.action_list.
         May be a subset of all possible actions. See [Actions](#Actions).
     camera_aspect_ratio : (float, float)
         The player camera's aspect ratio. This will remain constant for the

--- a/scripts/run_action_file.py
+++ b/scripts/run_action_file.py
@@ -3,7 +3,7 @@ import machine_common_sense as mcs
 from runner_script import SingleFileRunnerScript
 
 
-action_list = []
+action_list_from_file = []
 
 
 class ActionFileRunnerScript(SingleFileRunnerScript):
@@ -21,16 +21,16 @@ class ActionFileRunnerScript(SingleFileRunnerScript):
 
 
 def action_callback(scene_data, step_metadata, runner_script):
-    if not action_list:
+    if not action_list_from_file:
         with open(runner_script.args.action_filename, 'r') as action_file:
             for line in action_file:
-                action_list.append(line.strip())
+                action_list_from_file.append(line.strip())
 
-    if len(action_list) <= step_metadata.step_number:
+    if len(action_list_from_file) <= step_metadata.step_number:
         return None, None
 
     return mcs.Util.input_to_action_and_params(
-        action_list[step_metadata.step_number]
+        action_list_from_file[step_metadata.step_number]
     )
 
 

--- a/scripts/run_last_action.py
+++ b/scripts/run_last_action.py
@@ -7,9 +7,10 @@ def action_callback(scene_data, step_metadata, runner_script):
         if 'last_step' in scene_data['goal'].keys():
             last_step = scene_data['goal']['last_step']
     if step_metadata.step_number <= last_step:
-        action, params = step_metadata.action_list[
-            len(step_metadata.action_list) - 1
-        ]
+        action, params = (
+            step_metadata.action_list[len(step_metadata.action_list) - 1]
+            if len(step_metadata.action_list) else (None, None)
+        )
         return action, params
     return None, None
 

--- a/scripts/run_passive_scenes.py
+++ b/scripts/run_passive_scenes.py
@@ -1,7 +1,5 @@
 from runner_script import MultipleFileRunnerScript
 
-import machine_common_sense as mcs
-
 
 def action_callback(scene_data, step_metadata, runner_script):
     last_step = 60
@@ -9,13 +7,9 @@ def action_callback(scene_data, step_metadata, runner_script):
         if 'last_step' in scene_data['goal'].keys():
             last_step = scene_data['goal']['last_step']
     if step_metadata.step_number <= last_step:
-        action_list = (
-            step_metadata.action_list[len(step_metadata.action_list) - 1]
-            if len(step_metadata.action_list) else []
-        )
         action, params = (
-            mcs.Util.input_to_action_and_params(action_list[0])
-            if len(action_list) else (None, None)
+            step_metadata.action_list[len(step_metadata.action_list) - 1]
+            if len(step_metadata.action_list) else (None, None)
         )
         return action, params
     return None, None

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -536,15 +536,16 @@ class TestController(unittest.TestCase):
         output = self.controller.step('Foobar')
         self.assertIsNone(output)
 
-        self.controller.set_goal(mcs.GoalMetadata(action_list=[['Pass']]))
+        self.controller.set_goal(mcs.GoalMetadata(action_list=[
+            [('Pass', {})]
+        ]))
         output = self.controller.step('MoveAhead')
         self.assertIsNone(output)
 
-        self.controller.set_goal(
-            mcs.GoalMetadata(
-                action_list=[
-                    ['MoveAhead'],
-                    ['MoveBack']]))
+        self.controller.set_goal(mcs.GoalMetadata(action_list=[
+            [('MoveAhead', {})],
+            [('MoveBack', {})]]
+        ))
         output = self.controller.step('MoveAhead')
         self.assertIsNotNone(output)
         output = self.controller.step('MoveAhead')
@@ -919,15 +920,8 @@ class TestController(unittest.TestCase):
         self.assertEqual(actual.position, None)
         self.assertEqual(actual.rotation, None)
 
-    def test_retrieve_action_list(self):
+    def test_retrieve_action_list_at_step(self):
         test_action_list = [
-            'Pass',
-            'LookUp,amount=10',
-            'MoveAhead,amount=0.1',
-            'PickupObject,objectId=ball',
-            'PickupObject,objectId=duck'
-        ]
-        test_output_list = [
             ('Pass', {}),
             ('LookUp', {'amount': 10}),
             ('MoveAhead', {'amount': 0.1}),
@@ -937,12 +931,15 @@ class TestController(unittest.TestCase):
 
         # With no action list
         self.assertEqual(
-            self.controller.retrieve_action_list(mcs.GoalMetadata(), 0),
+            self.controller.retrieve_action_list_at_step(
+                mcs.GoalMetadata(),
+                0
+            ),
             self.controller.ACTION_LIST
         )
         # With empty action list
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[]),
                 0
             ),
@@ -950,7 +947,7 @@ class TestController(unittest.TestCase):
         )
         # With empty nested action list
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[[]]),
                 0
             ),
@@ -958,15 +955,15 @@ class TestController(unittest.TestCase):
         )
         # With test action list
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[test_action_list]),
                 0
             ),
-            test_output_list
+            test_action_list
         )
         # With index greater than action list length
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[test_action_list]),
                 1
             ),
@@ -974,7 +971,7 @@ class TestController(unittest.TestCase):
         )
         # With incorrect index
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[test_action_list, []]),
                 1
             ),
@@ -982,7 +979,7 @@ class TestController(unittest.TestCase):
         )
         # With incorrect index
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[[], test_action_list]),
                 0
             ),
@@ -990,93 +987,27 @@ class TestController(unittest.TestCase):
         )
         # With correct index
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[[], test_action_list]),
                 1
             ),
-            test_output_list
+            test_action_list
         )
         # Before last step
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[test_action_list], last_step=1),
                 0
             ),
-            test_output_list
+            test_action_list
         )
         # On last step
         self.assertEqual(
-            self.controller.retrieve_action_list(
+            self.controller.retrieve_action_list_at_step(
                 mcs.GoalMetadata(action_list=[test_action_list], last_step=0),
                 0
             ),
             []
-        )
-
-        # Same, but with string_list=True
-        self.assertEqual(
-            self.controller.retrieve_action_list(
-                mcs.GoalMetadata(),
-                0,
-                string_list=True
-            ),
-            [action[0] for action in self.controller.ACTION_LIST]
-        )
-        self.assertEqual(
-            self.controller.retrieve_action_list(
-                mcs.GoalMetadata(action_list=[]),
-                0,
-                string_list=True
-            ),
-            [action[0] for action in self.controller.ACTION_LIST]
-        )
-        self.assertEqual(
-            self.controller.retrieve_action_list(
-                mcs.GoalMetadata(action_list=[[]]),
-                0,
-                string_list=True
-            ),
-            [action[0] for action in self.controller.ACTION_LIST]
-        )
-        self.assertEqual(
-            self.controller.retrieve_action_list(
-                mcs.GoalMetadata(action_list=[test_action_list]),
-                0,
-                string_list=True
-            ),
-            test_action_list
-        )
-        self.assertEqual(
-            self.controller.retrieve_action_list(
-                mcs.GoalMetadata(action_list=[test_action_list]),
-                1,
-                string_list=True
-            ),
-            [action[0] for action in self.controller.ACTION_LIST]
-        )
-        self.assertEqual(
-            self.controller.retrieve_action_list(
-                mcs.GoalMetadata(action_list=[test_action_list, []]),
-                1,
-                string_list=True
-            ),
-            [action[0] for action in self.controller.ACTION_LIST]
-        )
-        self.assertEqual(
-            self.controller.retrieve_action_list(
-                mcs.GoalMetadata(action_list=[[], test_action_list]),
-                0,
-                string_list=True
-            ),
-            [action[0] for action in self.controller.ACTION_LIST]
-        )
-        self.assertEqual(
-            self.controller.retrieve_action_list(
-                mcs.GoalMetadata(action_list=[[], test_action_list]),
-                1,
-                string_list=True
-            ),
-            test_action_list
         )
 
     def test_retrieve_goal(self):
@@ -1102,9 +1033,9 @@ class TestController(unittest.TestCase):
         goal_3 = self.controller.retrieve_goal({
             "goal": {
                 "action_list": [
-                    ["action1"],
+                    [("MoveAhead", {"amount": 0.1})],
                     [],
-                    ["action2", "action3", "action4"]
+                    [("Pass", {}), ("RotateLeft", {}), ("RotateRight", {})]
                 ],
                 "category": "test category",
                 "description": "test description",
@@ -1115,10 +1046,11 @@ class TestController(unittest.TestCase):
                 }
             }
         })
-        self.assertEqual(
-            goal_3.action_list, [
-                ["action1"], [], [
-                    "action2", "action3", "action4"]])
+        self.assertEqual(goal_3.action_list, [
+            [("MoveAhead", {"amount": 0.1})],
+            [],
+            [("Pass", {}), ("RotateLeft", {}), ("RotateRight", {})]
+        ])
         self.assertEqual(goal_3.category, "test category")
         self.assertEqual(goal_3.description, "test description")
         self.assertEqual(goal_3.habituation_total, 5)


### PR DESCRIPTION
Fixes https://github.com/NextCenturyCorporation/MCS/issues/307

Changes:
- Both GoalMetadata.action_list and StepMetadata.action_list now save actions and parameters as tuples rather than strings.
- Added "auto" mode to human input run script that automatically runs the next step if only one action is available.
- Reordered terminal output in human input run script to be more useful.
- Updated python run scripts and documentation.

TBD:
- Consider releasing a new python version.
- Post on Confluence about these changes.