### PR TITLE
Mcs 622 restrict goal

### DIFF
--- a/integration_tests/data/073.trophy_reward.actions.txt
+++ b/integration_tests/data/073.trophy_reward.actions.txt
@@ -1,0 +1,2 @@
+﻿LookDown
+PickupObject,objectId=trophy

--- a/integration_tests/data/073.trophy_reward.level1.outputs.json
+++ b/integration_tests/data/073.trophy_reward.level1.outputs.json
@@ -1,0 +1,35 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.999,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/073.trophy_reward.level2.outputs.json
+++ b/integration_tests/data/073.trophy_reward.level2.outputs.json
@@ -1,0 +1,35 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.999,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/073.trophy_reward.oracle.outputs.json
+++ b/integration_tests/data/073.trophy_reward.oracle.outputs.json
@@ -1,0 +1,41 @@
+﻿[
+    {
+        "camera_height": 0.762,
+        "head_tilt": 20,
+        "objects": [],
+        "objects_count": 1,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": 0.0,
+        "step_number": 0,
+        "structural_objects_count": 6
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 1,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": 0.0,
+        "step_number": 1,
+        "structural_objects_count": 6
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 1,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.999,
+        "rotation_y": 0.0,
+        "step_number": 2,
+        "structural_objects_count": 6
+    }
+]

--- a/integration_tests/data/073.trophy_reward.scene.json
+++ b/integration_tests/data/073.trophy_reward.scene.json
@@ -1,0 +1,40 @@
+﻿{
+    "name": "retrieval_goal_example_with_trophy",
+    "version": 2,
+    "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
+    "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",
+    "wallMaterial": "AI2-THOR/Materials/Walls/DrywallBeige",
+    "performerStart": {
+        "position": {
+            "x": 0,
+            "z": 0
+        },
+        "rotation": {
+            "x": 20,
+            "y": 0
+        }
+    },
+    "objects": [{
+        "id": "trophy",
+        "type": "trophy",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": 0,
+                "y": 0,
+                "z": 0.5
+            }
+        }]
+    }],
+    "goal": {
+        "category": "retrieval",
+        "description": "Find and pick up the trophy.",
+        "last_step": 3000,
+        "metadata": {
+            "target": {
+                "id": "trophy",
+                "image": null
+            }
+        }
+    }
+}

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -532,7 +532,8 @@ class Controller():
         pre_restrict_output = self.wrap_output(self._controller.step(
             self.wrap_step(action='Initialize', sceneConfig=config_data)))
 
-        output = self.restrict_step_output_metadata(pre_restrict_output)
+        output = self.restrict_step_output_metadata(
+            copy.deepcopy(pre_restrict_output))
 
         self.write_debug_output(output)
 
@@ -825,7 +826,8 @@ class Controller():
             output=history_copy,
             delta_time_millis=0)
 
-        output = self.restrict_step_output_metadata(pre_restrict_output)
+        output = self.restrict_step_output_metadata(
+            copy.deepcopy(pre_restrict_output))
 
         self.write_debug_output(output)
 
@@ -951,8 +953,8 @@ class Controller():
                     if 'image' in step_output.goal.metadata[target_name]:
                         step_output.goal.metadata[target_name]['image'] = None
                     # Disabling goal id restriction for now
-                    # if 'id' in step_output.goal.metadata[target_name]:
-                    #     step_output.goal.metadata[target_name]['id'] = None
+                    if 'id' in step_output.goal.metadata[target_name]:
+                        step_output.goal.metadata[target_name]['id'] = None
                     if 'image_name' in step_output.goal.metadata[target_name]:
                         step_output.goal.metadata[
                             target_name]['image_name'] = None

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1822,9 +1822,9 @@ class TestController(unittest.TestCase):
         actual = self.controller.restrict_step_output_metadata(pre_restrict)
 
         self.assertEqual(pre_restrict.goal.metadata, {
-            'target': {'image': None, 'id': '1', 'image_name': None},
-            'target_1': {'image': None, 'id': '2', 'image_name': None},
-            'target_2': {'image': None, 'id': '3', 'image_name': None}
+            'target': {'image': None, 'id': None, 'image_name': None},
+            'target_1': {'image': None, 'id': None, 'image_name': None},
+            'target_2': {'image': None, 'id': None, 'image_name': None}
         })
 
         self.assertEqual(actual.action_list, self.controller.ACTION_LIST)


### PR DESCRIPTION
Added restrict goal code back in.  
Verified reward is correctly calculated (and added test for this).
Verified overhead video still shows star over goal even on metadata level 1 and level 2.