### PR TITLE
Using gitignore file for empty logs folder

### DIFF
--- a/logs/.dir
+++ b/logs/.dir
@@ -1,1 +1,0 @@
-just created to force the logs directory into git

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything
+*
+# except the .gitignore file
+!.gitignore


### PR DESCRIPTION
Empty folders can't be committed to git repositories without containing at least a single file. While the `.dir` file suffices for that purpose, it does not ensure that additional log files aren't committed to the repo. However, by replacing the `.dir` file with a `.gitignore` file, we can avoid accidental committal of log files while also serving as a single file inside a folder.