### PR TITLE
MCS-641 natural plot sizes

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -513,8 +513,7 @@ class Controller():
             team = self._config.get_team()
             scene = self.__scene_configuration.get(
                 'name', '').replace('json', '')
-            self.__plotter = TopDownPlotter(
-                team, scene, self.__screen_width, self.__screen_height)
+            self.__plotter = TopDownPlotter(team, scene)
             self._create_video_recorders(timestamp)
 
         pre_restrict_output = self.wrap_output(self._controller.step(

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -317,24 +317,18 @@ class Controller():
             self.PLACEHOLDER, self.VISUAL)
         self.__image_recorder = VideoRecorder(
             vid_path=output_folder / visual_video_filename,
-            width=self.__screen_width,
-            height=self.__screen_height,
             fps=self.FPS_FRAME_RATE)
 
         topdown_video_filename = basename_template.replace(
             self.PLACEHOLDER, self.TOPDOWN)
         self.__topdown_recorder = VideoRecorder(
             vid_path=output_folder / topdown_video_filename,
-            width=self.__screen_width,
-            height=self.__screen_height,
             fps=self.FPS_FRAME_RATE)
 
         heatmap_video_filename = basename_template.replace(
             self.PLACEHOLDER, self.HEATMAP)
         self.__heatmap_recorder = VideoRecorder(
             vid_path=output_folder / heatmap_video_filename,
-            width=self.__screen_width,
-            height=self.__screen_height,
             fps=self.FPS_FRAME_RATE)
 
         if self.__depth_maps:
@@ -342,8 +336,6 @@ class Controller():
                 self.PLACEHOLDER, self.DEPTH)
             self.__depth_recorder = VideoRecorder(
                 vid_path=output_folder / depth_video_filename,
-                width=self.__screen_width,
-                height=self.__screen_height,
                 fps=self.FPS_FRAME_RATE)
 
         if self.__object_masks:
@@ -351,8 +343,6 @@ class Controller():
                 self.PLACEHOLDER, self.SEGMENTATION)
             self.__segmentation_recorder = VideoRecorder(
                 vid_path=output_folder / segmentation_video_filename,
-                width=self.__screen_width,
-                height=self.__screen_height,
                 fps=self.FPS_FRAME_RATE)
 
     def end_scene(self, choice, confidence=1.0):

--- a/machine_common_sense/plotter.py
+++ b/machine_common_sense/plotter.py
@@ -41,14 +41,11 @@ class TopDownPlotter():
     MAXIMUM_ROOM_DIMENSION = 5
     BORDER = 0.05
 
-    def __init__(self, team: str, scene_name: str,
-                 plot_width: int, plot_height: int):
+    def __init__(self, team: str, scene_name: str):
         self._team = team
         if '/' in scene_name:
             scene_name = scene_name.rsplit('/', 1)[1]
         self._scene_name = scene_name
-        self._plot_width = plot_width
-        self._plot_height = plot_height
 
     def plot(self, scene_event: ai2thor.server.Event,
              step_number: int,
@@ -96,9 +93,7 @@ class TopDownPlotter():
         fig.savefig(buf)
         buf.seek(0)
         img = PIL.Image.open(buf)
-        # resize image to match screen dimensions
-        # current video recorders require it for now
-        return img.resize((self._plot_width, self._plot_height))
+        return img
 
     def _draw_robot(self, robot_metadata: Dict) -> None:
         '''Plot the robot position and heading'''

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -7,15 +7,10 @@ from machine_common_sense.plotter import TopDownPlotter, XZHeading
 
 class TestTopDownPlotter(unittest.TestCase):
 
-    PLOT_WIDTH = 600
-    PLOT_HEIGHT = 400
-
     def setUp(self):
         self.plotter = TopDownPlotter(
             team="test",
-            scene_name="scene",
-            plot_width=self.PLOT_WIDTH,
-            plot_height=self.PLOT_HEIGHT
+            scene_name="scene"
         )
 
     def test_convert_color_empty(self):
@@ -59,8 +54,6 @@ class TestTopDownPlotter(unittest.TestCase):
         scene_event = ai2thor.server.Event(metadata=metadata)
         img = self.plotter.plot(scene_event=scene_event, step_number=1)
         self.assertIsInstance(img, PIL.Image.Image)
-        self.assertEqual(img.width, self.PLOT_WIDTH)
-        self.assertEqual(img.height, self.PLOT_HEIGHT)
 
     def test_plot_twice(self):
         metadata = {
@@ -337,9 +330,7 @@ class TestTopDownPlotter(unittest.TestCase):
     def test_scene_name_prefix(self):
         plotter = TopDownPlotter(
             team="test",
-            scene_name="prefix/scene",
-            plot_width=self.PLOT_WIDTH,
-            plot_height=self.PLOT_HEIGHT
+            scene_name="prefix/scene"
         )
 
         self.assertEqual(plotter._scene_name, "scene")

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,78 @@
+import unittest
+import pathlib
+import PIL
+import cv2
+
+from machine_common_sense.recorder import VideoRecorder
+
+
+class TestVideoRecorder(unittest.TestCase):
+
+    test_video_file = pathlib.Path('test.mp4')
+    fps = 30
+
+    def setUp(self):
+        self.recorder = VideoRecorder(
+            vid_path=self.test_video_file,
+            fps=self.fps
+        )
+
+    def tearDown(self):
+        if self.test_video_file.exists():
+            self.test_video_file.unlink()
+
+    def test_active(self):
+        '''Recorder automatically starts (i.e. becomes active)'''
+        self.assertTrue(self.recorder.active)
+
+    def test_thread(self):
+        '''Thread should start automatically'''
+        self.assertTrue(self.recorder.thread.is_alive())
+
+    def test_video_path(self):
+        self.assertEqual(self.recorder.path, self.test_video_file)
+
+    def test_fps(self):
+        self.assertEqual(self.recorder.fps, self.fps)
+
+    def test_default_fourcc(self):
+        self.assertEqual(self.recorder.fourcc, 'mp4v')
+
+    def test_queue_empty(self):
+        '''No frames sitting in the queue'''
+        self.assertTrue(self.recorder.frame_queue.empty())
+
+    def test_frames_written(self):
+        '''No frames have been written yet'''
+        self.assertEqual(self.recorder._frames_written, 0)
+
+    def test_video_writer_none(self):
+        '''The actual writer is None until the first frame'''
+        self.assertIsNone(self.recorder.writer)
+
+    def test_flush(self):
+        '''Flushing an empty recorder queue should not be a problem'''
+        self.recorder.flush()
+        self.assertTrue(self.recorder.frame_queue.empty())
+
+    def test_add(self):
+        size = (50, 100)
+        img = PIL.Image.new("RGB", size)
+        self.recorder.add(img)
+        self.assertFalse(self.recorder.frame_queue.empty())
+        self.assertIsNotNone(self.recorder.writer)
+        self.assertEqual(
+            int(self.recorder.writer.get(
+                cv2.CAP_PROP_FRAME_WIDTH)), 50)
+        self.assertEqual(
+            self.recorder.writer.get(
+                cv2.CAP_PROP_FRAME_HEIGHT), 100)
+
+    def test_finish(self):
+        self.recorder.finish()
+        self.assertFalse(self.recorder.active)
+        self.assertTrue(self.recorder.frame_queue.empty())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The video recorder now establishes a size (width, height) from the first provided frame. All future video frames are compared against that established size and a ValueError is raises if the size varies in any dimension. The plotter naturally produces images sizes of 640x480 for the default DPI setting which is different from our rendered frames of 600x400.