### PR TITLE
MCS-666 moved subscriber initialization outside of the controller

### DIFF
--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -274,6 +274,7 @@ def start_handmade_tests(
     dev,
     autofix
 ):
+    mcs.init_logging()
     # Find all of the test scene JSON files.
     scene_filename_list = sorted(glob.glob(TEST_FOLDER + '*' + SCENE_SUFFIX))
 

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -274,7 +274,6 @@ def start_handmade_tests(
     dev,
     autofix
 ):
-    mcs.init_logging()
     # Find all of the test scene JSON files.
     scene_filename_list = sorted(glob.glob(TEST_FOLDER + '*' + SCENE_SUFFIX))
 

--- a/machine_common_sense/__init__.py
+++ b/machine_common_sense/__init__.py
@@ -8,6 +8,7 @@ import signal
 from contextlib import contextmanager
 
 from .action import Action
+from .config_manager import ConfigManager
 from .controller import Controller
 from .controller_logger import ControllerAi2thorFileGenerator
 from .controller_logger import ControllerDebugFileGenerator
@@ -68,19 +69,19 @@ def create_controller(unity_app_file_path,
         The MCS Controller object.
     """
     try:
+        config = ConfigManager(config_file_path)
         with time_limit(TIME_LIMIT_SECONDS):
             controller = Controller(unity_app_file_path,
-                                    config_file_path)
-        _add_subscribers(controller)
+                                    config)
+        _add_subscribers(controller, config)
         return controller
     except Exception as Msg:
         logger.error("Exception in create_controller()", exc_info=Msg)
         return None
 
 
-def _add_subscribers(controller):
+def _add_subscribers(controller: Controller, config: ConfigManager):
     if controller:
-        config = controller._config
         if config.is_save_debug_json():
             controller.subscribe(ControllerDebugFileGenerator())
             controller.subscribe(ControllerAi2thorFileGenerator())

--- a/machine_common_sense/__init__.py
+++ b/machine_common_sense/__init__.py
@@ -9,6 +9,10 @@ from contextlib import contextmanager
 
 from .action import Action
 from .controller import Controller
+from .controller_logger import ControllerAi2thorFileGenerator
+from .controller_logger import ControllerDebugFileGenerator
+from .controller_logger import ControllerLogger
+from .controller_video_manager import ControllerVideoManager
 from .goal_metadata import GoalMetadata, GoalCategory
 from .material import Material
 from .object_metadata import ObjectMetadata
@@ -16,7 +20,7 @@ from .pose import Pose
 from .return_status import ReturnStatus
 from .reward import Reward
 from .scene_history import SceneHistory
-from .history_writer import HistoryWriter
+from .history_writer import HistoryEventHandler, HistoryWriter
 from .step_metadata import StepMetadata
 from .util import Util
 from .serializer import SerializerMsgPack, SerializerJson
@@ -65,11 +69,28 @@ def create_controller(unity_app_file_path,
     """
     try:
         with time_limit(TIME_LIMIT_SECONDS):
-            return Controller(unity_app_file_path,
-                              config_file_path)
+            controller = Controller(unity_app_file_path,
+                                    config_file_path)
+        _add_subscribers(controller)
+        return controller
     except Exception as Msg:
         logger.error("Exception in create_controller()", exc_info=Msg)
         return None
+
+
+def _add_subscribers(controller):
+    if controller:
+        config = controller._config
+        if config.is_save_debug_json():
+            controller.subscribe(ControllerDebugFileGenerator())
+            controller.subscribe(ControllerAi2thorFileGenerator())
+        # TODO MCS-664 Once separated, use config to only subscribe when,
+        # # necessary
+        controller.subscribe(ControllerVideoManager())
+        controller.subscribe(ControllerLogger())
+        # TODO once we remove evaulation code, we can better handle when,
+        # this handler subscribes
+        controller.subscribe(HistoryEventHandler())
 
 
 def load_scene_json_file(scene_json_file_path):

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -149,13 +149,13 @@ class Controller():
     AWS_ACCESS_KEY_ID = 'aws_access_key_id'
     AWS_SECRET_ACCESS_KEY = 'aws_secret_access_key'
 
-    def __init__(self, unity_app_file_path, config_file_path=None):
+    def __init__(self, unity_app_file_path, config):
 
         self._subscribers = []
 
         self._end_scene_not_registered = True
 
-        self._config = ConfigManager(config_file_path)
+        self._config = config
 
         self._output_handler = ControllerOutputHandler(self._config)
 
@@ -177,7 +177,7 @@ class Controller():
             }
         )
 
-        self._on_init(config_file_path)
+        self._on_init()
 
     def subscribe(self, subscriber):
         if subscriber not in self._subscribers:
@@ -216,7 +216,7 @@ class Controller():
         else:
             return y_coord
 
-    def _on_init(self, config_file_path=None):
+    def _on_init(self):
 
         self.__noise_enabled = self._config.is_noise_enabled()
         self.__seed = self._config.get_seed()

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -31,12 +31,8 @@ from .uploader import S3Uploader
 from .util import Util
 from .config_manager import ConfigManager, SceneConfiguration
 from .controller_output_handler import ControllerOutputHandler
-from .controller_logger import ControllerLogger, ControllerDebugFileGenerator
-from .controller_logger import ControllerAi2thorFileGenerator
 from .controller_events import ControllerEventPayload, EventType
 from .controller_events import PredictionPayload
-from .controller_video_manager import ControllerVideoManager
-from .history_writer import HistoryEventHandler
 
 
 def __reset_override(self, scene):
@@ -160,14 +156,6 @@ class Controller():
         self._end_scene_not_registered = True
 
         self._config = ConfigManager(config_file_path)
-
-        # Can we rearrange to use dependency injection?
-        if self._config.is_save_debug_json():
-            self.subscribe(ControllerDebugFileGenerator())
-            self.subscribe(ControllerAi2thorFileGenerator())
-        self.subscribe(ControllerVideoManager())
-        self.subscribe(ControllerLogger())
-        self.subscribe(HistoryEventHandler())
 
         self._output_handler = ControllerOutputHandler(self._config)
 


### PR DESCRIPTION
Blame @ThomasSchellenbergNextCentury for this being a smaller, easy PR.

Thanks @ThomasSchellenbergNextCentury for pointing out to me that the controller is constructed in __init__

This change mostly just sets a precedent for later for using dependency injection.