### PR TITLE
Import sorter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
       - name: Run unit tests
         run: python -m unittest
       - name: Run isort
-        uses: olance/isort-action@v1.0.0
+        uses: jamescurtin/isort-action@master
         with:
-          args: .
+          requirementsFiles: "requirements.txt"
       - name: Flake8
         run: flake8
       - name: Autopep8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,6 @@ jobs:
         run: python -m unittest
       - name: Run isort
         uses: jamescurtin/isort-action@master
-        with:
-          requirementsFiles: "requirements.txt"
       - name: Flake8
         run: flake8
       - name: Autopep8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,10 @@ jobs:
           python -m pip install -r requirements.txt
       - name: Run unit tests
         run: python -m unittest
+      - name: Run isort
+        uses: jamescurtin/isort-action@master
+        with:
+          requirementsFiles: "requirements.txt"
       - name: Flake8
         run: flake8
       - name: Autopep8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
       - name: Run unit tests
         run: python -m unittest
       - name: Run isort
-        uses: jamescurtin/isort-action@master
+        uses: olance/isort-action@v1.0.0
         with:
-          requirementsFiles: "requirements.txt"
+          args: .
       - name: Flake8
         run: flake8
       - name: Autopep8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,6 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-      - id: isort
-        name: isort (cython)
-        types: [cython]
-      - id: isort
-        name: isort (pyi)
-        types: [pyi]    
 -   repo: local
     hooks:
     -   id: sphinx

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,17 @@ repos:
     rev: v1.5.4
     hooks:
     -   id: autopep8
+-   repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        name: isort (python)
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]    
 -   repo: local
     hooks:
     -   id: sphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../../'))
 
 from machine_common_sense import _version

--- a/integration_tests/additional_integration_tests.py
+++ b/integration_tests/additional_integration_tests.py
@@ -1,9 +1,9 @@
 import glob
-import numpy as np
 import os.path
 
-import machine_common_sense as mcs
+import numpy as np
 
+import machine_common_sense as mcs
 
 INTEGRATION_TESTS_FOLDER = os.path.dirname(os.path.abspath(__file__))
 DEPTH_AND_SEGMENTATION_SCENE = (

--- a/integration_tests/integration_test_utils.py
+++ b/integration_tests/integration_test_utils.py
@@ -1,6 +1,5 @@
 import argparse
 
-
 METADATA_TIER_LIST = [
     ('level1', './config_level1.ini'),
     ('level2', './config_level2.ini'),

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -1,16 +1,16 @@
 import argparse
 import glob
 import json
-from machine_common_sense.logging_config import LoggingConfig
 import math
 import os.path
 import time
 
-import machine_common_sense as mcs
 from additional_integration_tests import FUNCTION_LIST
-from integration_test_utils import METADATA_TIER_LIST, print_divider, \
-    add_test_args
+from integration_test_utils import (METADATA_TIER_LIST, add_test_args,
+                                    print_divider)
 
+import machine_common_sense as mcs
+from machine_common_sense.logging_config import LoggingConfig
 
 INTEGRATION_TESTS_FOLDER = os.path.dirname(os.path.abspath(__file__))
 TEST_FOLDER = INTEGRATION_TESTS_FOLDER + '/data/'

--- a/integration_tests/run_prefab_tests.py
+++ b/integration_tests/run_prefab_tests.py
@@ -2,7 +2,6 @@ import argparse
 
 from integration_test_utils import add_test_args
 
-
 OBJECT_REGISTRY_LIST = [
     'ai2thor_object_registry.json',
     'mcs_object_registry.json',

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -2,6 +2,7 @@ import argparse
 
 from integration_test_utils import add_test_args
 from run_handmade_tests import start_handmade_tests
+
 # from run_prefab_tests import start_prefab_tests
 
 

--- a/machine_common_sense/__init__.py
+++ b/machine_common_sense/__init__.py
@@ -1,30 +1,28 @@
+import json
 import logging
 import logging.config
-from os.path import exists
-import json
 import signal
-
 from contextlib import contextmanager
+from os.path import exists
 
+from ._version import __version__
 from .action import Action
 from .config_manager import ConfigManager
 from .controller import Controller
-from .goal_metadata import GoalMetadata, GoalCategory
+from .goal_metadata import GoalCategory, GoalMetadata
+from .history_writer import HistoryWriter
 from .logging_config import LoggingConfig
 from .material import Material
-from .validation import Validation
 from .object_metadata import ObjectMetadata
 from .pose import Pose
 from .return_status import ReturnStatus
 from .reward import Reward
 from .scene_history import SceneHistory
-from .history_writer import HistoryWriter
-from .step_metadata import StepMetadata
-from .serializer import SerializerMsgPack, SerializerJson
+from .serializer import SerializerJson, SerializerMsgPack
 from .setup import add_subscribers
+from .step_metadata import StepMetadata
 from .stringifier import Stringifier
-from ._version import __version__
-
+from .validation import Validation
 
 logger = logging.getLogger(__name__)
 # Set default logging handler to avoid "No handler found" warnings

--- a/machine_common_sense/action.py
+++ b/machine_common_sense/action.py
@@ -1,4 +1,5 @@
 from enum import Enum, unique
+
 from .validation import Validation
 
 

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -1,6 +1,7 @@
-import os
-import logging
 import configparser  # noqa: F401
+import logging
+import os
+
 import yaml  # noqa: F401
 
 from .action import Action

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -1,17 +1,16 @@
+import ast
+import atexit
 import glob
 import json
 import logging
-import numpy as np
 import os
 import random
-import PIL
-import ast
 from typing import Dict, List
-import atexit
 
 import ai2thor.controller
 import ai2thor.server
-
+import numpy as np
+import PIL
 
 logger = logging.getLogger(__name__)
 
@@ -25,14 +24,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_MOVE = 0.1
 
 from .action import Action
+from .config_manager import ConfigManager, SceneConfiguration
+from .controller_events import (ControllerEventPayload, EventType,
+                                PredictionPayload)
+from .controller_output_handler import ControllerOutputHandler
 from .goal_metadata import GoalMetadata
-from .validation import Validation
 from .step_metadata import StepMetadata
 from .uploader import S3Uploader
-from .config_manager import ConfigManager, SceneConfiguration
-from .controller_output_handler import ControllerOutputHandler
-from .controller_events import ControllerEventPayload, EventType
-from .controller_events import PredictionPayload
+from .validation import Validation
 
 
 def __reset_override(self, scene):

--- a/machine_common_sense/controller_events.py
+++ b/machine_common_sense/controller_events.py
@@ -1,9 +1,10 @@
-from abc import ABC
-
-import enum
 import datetime
-import PIL
+import enum
+from abc import ABC
 from typing import Dict, List
+
+import PIL
+
 from .config_manager import ConfigManager, SceneConfiguration
 from .goal_metadata import GoalMetadata
 

--- a/machine_common_sense/controller_logger.py
+++ b/machine_common_sense/controller_logger.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 
 from .controller_events import AbstractControllerSubscriber
 from .stringifier import Stringifier

--- a/machine_common_sense/controller_media.py
+++ b/machine_common_sense/controller_media.py
@@ -1,15 +1,15 @@
-import pathlib
 import logging
-import PIL
-import numpy as np
+import pathlib
 from abc import abstractmethod
 
-from .controller_events import AbstractControllerSubscriber
-from .controller_events import ControllerEventPayload
+import numpy as np
+import PIL
+
+from .config_manager import ConfigManager
+from .controller_events import (AbstractControllerSubscriber,
+                                ControllerEventPayload)
 from .plotter import TopDownPlotter
 from .recorder import VideoRecorder
-from .config_manager import ConfigManager
-
 
 logger = logging.getLogger(__name__)
 

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -1,17 +1,17 @@
-import logging
 import copy
-import PIL
+import logging
+
 import numpy as np
+import PIL
 
 from .config_manager import ConfigManager, SceneConfiguration
 from .controller import DEFAULT_MOVE
 from .material import Material
 from .object_metadata import ObjectMetadata
 from .pose import Pose
+from .return_status import ReturnStatus
 from .reward import Reward
 from .step_metadata import StepMetadata
-from .return_status import ReturnStatus
-
 
 logger = logging.getLogger(__name__)
 

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -1,6 +1,7 @@
 from enum import Enum, unique
-from .stringifier import Stringifier
+
 from .config_manager import ConfigManager
+from .stringifier import Stringifier
 
 
 class GoalMetadata:

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -1,12 +1,13 @@
-from .stringifier import Stringifier
-from .scene_history import SceneHistory
-from typing import Dict
-import logging
 import json
+import logging
 import os
 import pathlib
 from time import perf_counter
+from typing import Dict
+
 from .controller_events import AbstractControllerSubscriber
+from .scene_history import SceneHistory
+from .stringifier import Stringifier
 
 logger = logging.getLogger(__name__)
 

--- a/machine_common_sense/logging_config.py
+++ b/machine_common_sense/logging_config.py
@@ -38,9 +38,8 @@
 # section.
 
 import ast
-from os.path import exists
-
 import logging
+from os.path import exists
 
 logger = logging.getLogger(__name__)
 

--- a/machine_common_sense/plotter.py
+++ b/machine_common_sense/plotter.py
@@ -1,12 +1,14 @@
 import io
 import math
-import PIL
+
 import ai2thor
 import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
+import PIL
 
-from typing import Dict, NamedTuple, List
+matplotlib.use('Agg')
+from typing import Dict, List, NamedTuple
+
+import matplotlib.pyplot as plt
 from shapely import geometry
 
 

--- a/machine_common_sense/recorder.py
+++ b/machine_common_sense/recorder.py
@@ -1,16 +1,14 @@
-import time
 import logging
 import pathlib
-import threading
 import queue
-
-from typing import Any
+import threading
+import time
 from abc import ABC, abstractmethod
+from typing import Any
 
 import cv2
-import PIL
 import numpy as np
-
+import PIL
 
 logger = logging.getLogger(__name__)
 

--- a/machine_common_sense/reward.py
+++ b/machine_common_sense/reward.py
@@ -1,9 +1,9 @@
-from typing import List, Dict
+from typing import Dict, List
 
 from shapely import geometry
 
-from .goal_metadata import GoalMetadata, GoalCategory
 from .controller import DEFAULT_MOVE
+from .goal_metadata import GoalCategory, GoalMetadata
 
 GOAL_ACHIEVED = 1
 GOAL_NOT_ACHIEVED = 0

--- a/machine_common_sense/scene_history.py
+++ b/machine_common_sense/scene_history.py
@@ -1,5 +1,6 @@
-from .stringifier import Stringifier
 from typing import Dict, List
+
+from .stringifier import Stringifier
 
 
 class SceneHistory(object):

--- a/machine_common_sense/serializer.py
+++ b/machine_common_sense/serializer.py
@@ -7,8 +7,6 @@ import msgpack
 import numpy as np
 import PIL.Image as Image
 
-import machine_common_sense as mcs
-
 from .goal_metadata import GoalMetadata
 from .object_metadata import ObjectMetadata
 from .step_metadata import StepMetadata
@@ -173,7 +171,7 @@ class SerializerMsgPack(ISerializer):
         return msgpack.ExtType(code, data)
 
     @staticmethod
-    def serialize(step_metadata: mcs.StepMetadata):
+    def serialize(step_metadata: StepMetadata):
         """
         Serializes step metadata into MsgPack.
 
@@ -295,7 +293,7 @@ class SerializerJson(ISerializer):
         return object_list
 
     @staticmethod
-    def serialize(step_metadata: mcs.StepMetadata, indent: int = 4):
+    def serialize(step_metadata: StepMetadata, indent: int = 4):
         json_dump = json.dumps(step_metadata,
                                cls=SerializerJson.McsStepMetadataEncoder,
                                indent=indent)

--- a/machine_common_sense/serializer.py
+++ b/machine_common_sense/serializer.py
@@ -1,11 +1,11 @@
 import io
 import json
+from abc import ABCMeta, abstractmethod
+from typing import Dict, Union
+
 import msgpack
 import numpy as np
 import PIL.Image as Image
-
-from abc import ABCMeta, abstractmethod
-from typing import Dict, Union
 
 import machine_common_sense as mcs
 

--- a/machine_common_sense/setup.py
+++ b/machine_common_sense/setup.py
@@ -1,17 +1,14 @@
 from .config_manager import ConfigManager
 from .controller import Controller
-from .controller_logger import ControllerAi2thorFileGenerator
-from .controller_logger import ControllerDebugFileGenerator
-from .controller_logger import ControllerLogger
-from .controller_media import (
-    DepthVideoEventHandler,
-    DepthImageEventHandler,
-    HeatmapVideoEventHandler,
-    ImageVideoEventHandler,
-    ObjectMaskImageEventHandler,
-    SceneImageEventHandler,
-    TopdownVideoEventHandler,
-    SegmentationVideoEventHandler)
+from .controller_logger import (ControllerAi2thorFileGenerator,
+                                ControllerDebugFileGenerator, ControllerLogger)
+from .controller_media import (DepthImageEventHandler, DepthVideoEventHandler,
+                               HeatmapVideoEventHandler,
+                               ImageVideoEventHandler,
+                               ObjectMaskImageEventHandler,
+                               SceneImageEventHandler,
+                               SegmentationVideoEventHandler,
+                               TopdownVideoEventHandler)
 from .history_writer import HistoryEventHandler
 
 

--- a/machine_common_sense/stringifier.py
+++ b/machine_common_sense/stringifier.py
@@ -1,5 +1,6 @@
-import numpy
 import logging
+
+import numpy
 
 logger = logging.getLogger(__name__)
 

--- a/machine_common_sense/uploader.py
+++ b/machine_common_sense/uploader.py
@@ -5,7 +5,6 @@ import pathlib
 import boto3
 import PIL
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ msgpack==1.0.0
 numpy==1.19.4
 opencv-python==4.4.0.44
 packaging==20.4
-pre-commit==2.7.1
+pre-commit==2.12.1
 purepng==0.2.0
 Pygments==2.7.4
 pyparsing==2.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ flake8==3.8.3
 Flask==1.1.2
 idna==2.10
 imagesize==1.2.0
+isort==5.8.0
 itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1

--- a/scripts/create_intuitive_physics_frames.py
+++ b/scripts/create_intuitive_physics_frames.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import sys
 
-
 if len(sys.argv) < 3:
     print('Usage: python create_intuitive_physics_frames.py <folder_prefix> '
           '<eval_number> <move_across>')

--- a/scripts/generate_passive_quartet_videos.py
+++ b/scripts/generate_passive_quartet_videos.py
@@ -1,9 +1,8 @@
 import argparse
-import subprocess
 import os
 import pathlib
 import shutil
-
+import subprocess
 from typing import List
 
 import machine_common_sense as mcs

--- a/scripts/getch_helper.py
+++ b/scripts/getch_helper.py
@@ -20,13 +20,13 @@ screen."""
 
 class _GetchUnix:
     def __init__(self):
-        import tty  # noqa: F401
         import sys  # noqa: F401
+        import tty  # noqa: F401
 
     def __call__(self):
         import sys
-        import tty
         import termios
+        import tty
         fd = sys.stdin.fileno()
         old_settings = termios.tcgetattr(fd)
         try:
@@ -56,6 +56,7 @@ class _GetchMacCarbon:
 
     def __init__(self):
         import Carbon  # pylint: disable=import-error
+
         # pylint: disable= W0104
         Carbon.Evt  # see if it has this (in Unix, it doesn't)
 

--- a/scripts/run_action_file.py
+++ b/scripts/run_action_file.py
@@ -1,7 +1,6 @@
-import machine_common_sense as mcs
-
 from runner_script import SingleFileRunnerScript
 
+import machine_common_sense as mcs
 
 action_list_from_file = []
 

--- a/scripts/run_human_input.py
+++ b/scripts/run_human_input.py
@@ -1,11 +1,11 @@
 import argparse
 import cmd
 
+from getch_helper import getch
+
 import machine_common_sense as mcs
 from machine_common_sense.config_manager import ConfigManager
 from machine_common_sense.logging_config import LoggingConfig
-
-from getch_helper import getch
 
 commandList = []
 

--- a/scripts/run_init_scenes.py
+++ b/scripts/run_init_scenes.py
@@ -1,8 +1,8 @@
-import glob
 import argparse
+import glob
+import os
 
 import machine_common_sense as mcs
-import os
 
 
 def parse_args():

--- a/scripts/run_scene_timer.py
+++ b/scripts/run_scene_timer.py
@@ -1,10 +1,9 @@
+import argparse
 import os
 import statistics
 import time
-import argparse
 
 import machine_common_sense as mcs
-
 
 DEFAULT_STEP_COUNT = 20
 

--- a/scripts/run_scene_with_command_file.py
+++ b/scripts/run_scene_with_command_file.py
@@ -1,4 +1,5 @@
 import argparse
+
 import machine_common_sense as mcs
 
 commandList = []

--- a/tests/mock_controller.py
+++ b/tests/mock_controller.py
@@ -1,13 +1,14 @@
-import ai2thor.server
-import numpy
 import os
 
-from machine_common_sense.controller import Controller
-from machine_common_sense.pose import Pose
+import ai2thor.server
+import numpy
+
 from machine_common_sense.action import Action
 from machine_common_sense.config_manager import ConfigManager
+from machine_common_sense.controller import Controller
 from machine_common_sense.controller_output_handler import \
     ControllerOutputHandler
+from machine_common_sense.pose import Pose
 
 MOCK_VARIABLES = {
     'event_count': 5,

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,8 +1,8 @@
+import os
 import unittest
+from unittest.mock import patch
 
 from machine_common_sense.config_manager import ConfigManager
-from unittest.mock import patch
-import os
 
 
 class TestConfigManager(unittest.TestCase):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,18 +1,15 @@
-import numpy
-from types import SimpleNamespace
+import glob
+import os
+import shutil
 import unittest
+from types import SimpleNamespace
+
+import numpy
 
 import machine_common_sense as mcs
 from machine_common_sense.config_manager import ConfigManager
 
-from .mock_controller import (
-    MockControllerAI2THOR,
-    MOCK_VARIABLES
-)
-
-import os
-import glob
-import shutil
+from .mock_controller import MOCK_VARIABLES, MockControllerAI2THOR
 
 SCENE_HIST_DIR = "./SCENE_HISTORY/"
 TEST_FILE_NAME = "test controller"

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -1,11 +1,12 @@
-import numpy
-from types import SimpleNamespace
 import unittest
+from types import SimpleNamespace
+
+import numpy
 
 import machine_common_sense as mcs
+from machine_common_sense.config_manager import ConfigManager
 from machine_common_sense.controller_output_handler import StepOutput
 from machine_common_sense.goal_metadata import GoalMetadata
-from machine_common_sense.config_manager import ConfigManager
 
 
 class TestControllerOutputHandler(unittest.TestCase):

--- a/tests/test_goal_metadata.py
+++ b/tests/test_goal_metadata.py
@@ -1,5 +1,5 @@
-import unittest
 import textwrap
+import unittest
 
 import machine_common_sense as mcs
 

--- a/tests/test_history_writer.py
+++ b/tests/test_history_writer.py
@@ -1,10 +1,9 @@
-import unittest
-import os
 import glob
+import os
 import shutil
+import unittest
 
 import machine_common_sense as mcs
-
 
 TEST_FILE_NAME = "test_scene_file.json"
 PREFIX = 'prefix'

--- a/tests/test_mcs.py
+++ b/tests/test_mcs.py
@@ -1,22 +1,17 @@
-from machine_common_sense.config_manager import ConfigManager
-
 import unittest
 
 import machine_common_sense as mcs
-from .mock_controller import MockController
-
+from machine_common_sense.config_manager import ConfigManager
 from machine_common_sense.controller_logger import ControllerLogger
 from machine_common_sense.controller_media import (
-    DepthVideoEventHandler,
-    DepthImageEventHandler,
-    HeatmapVideoEventHandler,
-    ImageVideoEventHandler,
-    ObjectMaskImageEventHandler,
-    SceneImageEventHandler,
-    TopdownVideoEventHandler,
-    SegmentationVideoEventHandler)
+    DepthImageEventHandler, DepthVideoEventHandler, HeatmapVideoEventHandler,
+    ImageVideoEventHandler, ObjectMaskImageEventHandler,
+    SceneImageEventHandler, SegmentationVideoEventHandler,
+    TopdownVideoEventHandler)
 from machine_common_sense.history_writer import HistoryEventHandler
 from machine_common_sense.setup import add_subscribers
+
+from .mock_controller import MockController
 
 
 class TestMCS(unittest.TestCase):

--- a/tests/test_object_metadata.py
+++ b/tests/test_object_metadata.py
@@ -1,5 +1,5 @@
-import unittest
 import textwrap
+import unittest
 
 import machine_common_sense as mcs
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,4 +1,5 @@
 import unittest
+
 import ai2thor
 import PIL
 

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,13 +1,12 @@
-import unittest
 import pathlib
-import PIL
 import random
-
+import unittest
 from typing import Tuple
 
-from machine_common_sense.recorder import BaseRecorder
-from machine_common_sense.recorder import VideoRecorder
-from machine_common_sense.recorder import ImageRecorder
+import PIL
+
+from machine_common_sense.recorder import (BaseRecorder, ImageRecorder,
+                                           VideoRecorder)
 
 
 class ConcreteBaseRecorder(BaseRecorder):

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -1,6 +1,6 @@
 import unittest
-
 from typing import Tuple
+
 from shapely import geometry
 
 import machine_common_sense as mcs

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -1,5 +1,5 @@
-import unittest
 import textwrap
+import unittest
 
 import machine_common_sense as mcs
 


### PR DESCRIPTION
Developers will need to install the isort package and upgrade pre-commit for the hooks to work.

```python
(venv) $ python -m pip install --upgrade isort pre-commit
```