### PR TITLE
MCS-685 removed error when ending scene without starting a scene

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -245,7 +245,7 @@ class Controller():
 
     def end_scene(self, choice, confidence=1.0):
         """
-        Ends the current scene.  Calling end_scene() before calling 
+        Ends the current scene.  Calling end_scene() before calling
         start_scene() will do nothing.
 
         Parameters

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -245,7 +245,8 @@ class Controller():
 
     def end_scene(self, choice, confidence=1.0):
         """
-        Ends the current scene.  Calling end_scene() before calling start_scene() will do nothing.
+        Ends the current scene.  Calling end_scene() before calling 
+        start_scene() will do nothing.
 
         Parameters
         ----------

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -245,7 +245,7 @@ class Controller():
 
     def end_scene(self, choice, confidence=1.0):
         """
-        Ends the current scene.
+        Ends the current scene.  Calling end_scene() before calling start_scene() will do nothing.
 
         Parameters
         ----------

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -73,25 +73,26 @@ class HistoryEventHandler(AbstractControllerSubscriber):
             self.__history_item.internal_state = payload.internal_state
 
     def on_end_scene(self, payload):
-        if payload.config.is_history_enabled():
-            self.__history_writer.add_step(self.__history_item)
-            self.__history_writer.write_history_file(
-                payload.choice, payload.confidence)
-
-        if payload.config.is_evaluation():
-            uploader = payload.uploader
-            folder_prefix = payload.uploader_folder_prefix
+        if self.__history_writer is not None:
             if payload.config.is_history_enabled():
-                history_filename = self._get_filename_without_timestamp(
-                    pathlib.Path(self.__history_writer.scene_history_file))
-                uploader.upload_history(
-                    history_path=self.__history_writer.scene_history_file,
-                    s3_filename=(folder_prefix + '/' +
-                                 payload.config.get_evaluation_name() +
-                                 '_' + payload.config.get_metadata_tier() +
-                                 '_' + payload.config.get_team() +
-                                 '_' + history_filename)
-                )
+                self.__history_writer.add_step(self.__history_item)
+                self.__history_writer.write_history_file(
+                    payload.choice, payload.confidence)
+
+            if payload.config.is_evaluation():
+                uploader = payload.uploader
+                folder_prefix = payload.uploader_folder_prefix
+                if payload.config.is_history_enabled():
+                    history_filename = self._get_filename_without_timestamp(
+                        pathlib.Path(self.__history_writer.scene_history_file))
+                    uploader.upload_history(
+                        history_path=self.__history_writer.scene_history_file,
+                        s3_filename=(folder_prefix + '/' +
+                                     payload.config.get_evaluation_name() +
+                                     '_' + payload.config.get_metadata_tier() +
+                                     '_' + payload.config.get_team() +
+                                     '_' + history_filename)
+                    )
 
     def _get_filename_without_timestamp(self, filepath: pathlib.Path):
         return filepath.stem[:-16] + filepath.suffix


### PR DESCRIPTION
Fixed error in history writer where if the writer isn't initiated (because the scene was never started) it would throw an error and crash.

The further question is should we alert the user if they do this?  Trying to end a scene when one has never started is a user error, should we detect it and alert them?  currently, there is no output and nothing happens when end_scene() is called.  stop_simulation() closes the unity window.