### PR TITLE
Mcs 663 payload classes

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -191,7 +191,6 @@ class Controller():
             # change later
             subscriber.on_event(event_type, payload)
 
-    # TODO this is a huge data dumpster and needs to be thought about
     def _create_event_payload_kwargs(self):
         return {"step_number": self.__step_number,
                 "config": self._config,

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -191,14 +191,14 @@ class Controller():
             # change later
             subscriber.on_event(event_type, payload)
 
-    def _create_event_payload_kwargs(self):
+    def _create_event_payload_kwargs(self) -> dict:
         return {"step_number": self.__step_number,
                 "config": self._config,
                 "scene_config": self._scene_config}
 
     def _create_post_step_event_payload_kwargs(
             self, wrapped_step, step_metadata, step_output: StepMetadata,
-            restricted_step_output: StepMetadata):
+            restricted_step_output: StepMetadata) -> dict:
         args = self._create_event_payload_kwargs()
         args['output_folder'] = self.__output_folder
         args['timestamp'] = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -1,11 +1,11 @@
-
 import atexit
+import datetime
 import glob
 import json
 import logging
 import os
 import random
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import ai2thor.controller
 import ai2thor.server
@@ -27,8 +27,9 @@ DEFAULT_MOVE = 0.1
 from .action import Action
 from .config_manager import (ConfigManager, SceneConfiguration,
                              SceneConfigurationSchema)
-from .controller_events import (ControllerEventPayload, EventType,
-                                PredictionPayload)
+from .controller_events import (AfterStepPayload, BeforeStepPayload,
+                                EndScenePayload, EventType, PredictionPayload,
+                                StartScenePayload)
 from .controller_output_handler import ControllerOutputHandler
 from .goal_metadata import GoalMetadata
 from .step_metadata import StepMetadata
@@ -178,7 +179,9 @@ class Controller():
             self._subscribers.append(subscriber)
 
     def _publish_event(self, event_type: EventType,
-                       payload: ControllerEventPayload):
+                       payload: Union[StartScenePayload, BeforeStepPayload,
+                                      AfterStepPayload, PredictionPayload,
+                                      EndScenePayload]):
         for subscriber in self._subscribers:
             # TODO should we make a deep copy of the payload so subscribers
             # cannot change source data?
@@ -189,15 +192,23 @@ class Controller():
             subscriber.on_event(event_type, payload)
 
     # TODO this is a huge data dumpster and needs to be thought about
-    def _create_event_payload(self):
-        payload = ControllerEventPayload(
-            self.__output_folder,
-            self._config,
-            self.__step_number,
-            self._scene_config,
-            self.__habituation_trial,
-            self._goal)
-        return payload
+    def _create_event_payload_kwargs(self):
+        return {"step_number": self.__step_number,
+                "config": self._config,
+                "scene_config": self._scene_config}
+
+    def _create_post_step_event_payload_kwargs(
+            self, wrapped_step, step_metadata, step_output: StepMetadata,
+            restricted_step_output: StepMetadata):
+        args = self._create_event_payload_kwargs()
+        args['output_folder'] = self.__output_folder
+        args['timestamp'] = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        args['wrapped_step'] = wrapped_step
+        args['step_metadata'] = step_metadata
+        args['step_output'] = step_output
+        args['restricted_step_output'] = restricted_step_output
+        args['goal'] = self._goal
+        return args
 
     # Pixel coordinates are expected to start at the top left, but
     # in Unity, (0,0) is the bottom left.
@@ -273,12 +284,15 @@ class Controller():
 
         # TODO uploader be passed to classes that need
         # it on early on via dependency injection?
-        payload = self._create_event_payload()
-        payload.choice = choice
-        payload.confidence = confidence
-        payload.uploader = uploader
-        payload.uploader_folder_prefix = self._config.get_s3_folder()
-        self._publish_event(EventType.ON_END_SCENE, payload)
+        payloadArgs = self._create_event_payload_kwargs()
+        payloadArgs['choice'] = choice
+        payloadArgs['confidence'] = confidence
+        payloadArgs['uploader'] = uploader
+        payloadArgs['uploader_folder_prefix'] = self._config.get_s3_folder()
+        self._publish_event(
+            EventType.ON_END_SCENE,
+            EndScenePayload(
+                **payloadArgs))
 
         if (not self._end_scene_not_registered):
             atexit.unregister(self.end_scene)
@@ -375,11 +389,9 @@ class Controller():
                 atexit.register(self.end_scene, choice="", confidence=-1)
                 self._end_scene_not_registered = False
 
-        payload = self._create_event_payload()
-        payload.wrapped_step = wrapped_step
-        payload.step_metadata = step_output
-        payload.step_output = pre_restrict_output
-        payload.restricted_step_output = output
+        payloadArgs = self._create_post_step_event_payload_kwargs(
+            wrapped_step, step_output, pre_restrict_output, output)
+        payload = StartScenePayload(**payloadArgs)
         self._publish_event(
             EventType.ON_START_SCENE, payload)
 
@@ -590,12 +602,13 @@ class Controller():
 
         self.__step_number += 1
 
-        payload = self._create_event_payload()
-        payload.action = action
-        payload.action_args = kwargs
+        payloadArgs = self._create_event_payload_kwargs()
+        payloadArgs['action'] = action
+        payloadArgs['habituation_trial'] = self.__habituation_trial
+        payloadArgs['goal'] = self._goal
         self._publish_event(
             EventType.ON_BEFORE_STEP,
-            payload)
+            BeforeStepPayload(**payloadArgs))
 
         params = self.validate_and_convert_params(action, **kwargs)
 
@@ -620,18 +633,14 @@ class Controller():
             step_output, self._goal, self.__step_number,
             self.__habituation_trial)
 
-        payload = self._create_event_payload()
-        # do we need both outputs?
-        payload.ai2thor_action = action
-        payload.step_params = params
-        payload.kwargs = kwargs
-        payload.wrapped_step = step_action
-        payload.step_metadata = step_output
-        payload.step_output = pre_restrict_output
-        payload.restricted_step_output = output
+        payloadArgs = self._create_post_step_event_payload_kwargs(
+            step_action, step_output, pre_restrict_output, output)
+        payloadArgs['ai2thor_action'] = action
+        payloadArgs['step_params'] = params
+        payloadArgs['action_kwargs'] = kwargs
         self._publish_event(
             EventType.ON_AFTER_STEP,
-            payload)
+            AfterStepPayload(**payloadArgs))
 
         return output
 

--- a/machine_common_sense/controller_events.py
+++ b/machine_common_sense/controller_events.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 import PIL
 from ai2thor.server import Event
-from marshmallow import Schema, fields  # , post_load
+from marshmallow import Schema, fields
 
 from .config_manager import ConfigManager, SceneConfiguration
 from .goal_metadata import GoalMetadata
@@ -72,23 +72,6 @@ class EndScenePayload(BaseEventPayload):
     confidence: float
     uploader: S3Uploader  # allow none
     uploader_folder_prefix: str  # allow none
-
-
-'''class StartScenePayloadSchema(Schema):
-    scene_config = fields.Nested(SceneConfigurationSchema)
-    # config =
-    # action =
-    # goal =
-    habitation_trial = fields.Int()
-    restricted_step_output
-    wrapped_step = wrapped_step
-    step_metadata = step_output
-    step_output = pre_restrict_output
-    restricted_step_output = output
-
-    @post_load
-    def make_scene_configuration(self, data, **kwargs):
-        return SceneConfiguration(**data)'''
 
 
 class ControllerEventPayload(BaseEventPayload):

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -58,7 +58,7 @@ class HistoryEventHandler(AbstractControllerSubscriber):
         self.__history_item = SceneHistory(
             step=payload.step_number,
             action=payload.ai2thor_action,
-            args=payload.kwargs,
+            args=payload.action_kwargs,
             params=payload.step_params,
             output=output,
             delta_time_millis=0)


### PR DESCRIPTION
All controller events have their own specific data payload class.

I'm not sure this is a huge improvement, but at least subscribers should know what data is available.  