### PR TITLE
MCS-640 moved ai2thor json writing to recorder

### DIFF
--- a/machine_common_sense/controller_logger.py
+++ b/machine_common_sense/controller_logger.py
@@ -1,7 +1,8 @@
-import json
 import logging
+from pathlib import Path
 
 from .controller_events import AbstractControllerSubscriber
+from .recorder import JsonRecorder
 from .stringifier import Stringifier
 
 logger = logging.getLogger(__name__)
@@ -82,6 +83,11 @@ class ControllerAi2thorFileGenerator(AbstractControllerSubscriber):
     '''
 
     def on_start_scene(self, payload):
+        if payload.output_folder and payload.config.is_save_debug_json():
+            path = Path(payload.output_folder) / 'ai2thor_input_{}.json'
+            self._in_recorder = JsonRecorder(json_template=path)
+            path = Path(payload.output_folder) / 'ai2thor_output_{}.json'
+            self._out_recorder = JsonRecorder(json_template=path)
         self._write_debug_input_file(payload)
         self._write_debug_output_file(payload)
 
@@ -91,18 +97,12 @@ class ControllerAi2thorFileGenerator(AbstractControllerSubscriber):
 
     def _write_debug_input_file(self, payload):
         data = payload.wrapped_step
-        name = 'ai2thor_input_'
-        self._write_ai2thor_file(payload, data, name)
+        if self._in_recorder:
+            self._in_recorder.add(data)
 
     def _write_debug_output_file(self, payload):
         data = {
             "metadata": payload.step_metadata.metadata
         }
-        name = 'ai2thor_output_'
-        self._write_ai2thor_file(payload, data, name)
-
-    def _write_ai2thor_file(self, payload, data, name):
-        if payload.output_folder and payload.config.is_save_debug_json():
-            with open(payload.output_folder + name +
-                      str(payload.step_number) + '.json', 'w') as json_file:
-                json.dump(data, json_file, sort_keys=True, indent=4)
+        if self._out_recorder:
+            self._out_recorder.add(data)

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -111,7 +111,7 @@ class SceneEvent():
     def position(self) -> dict:
         return self._raw_output.metadata['agent']['position']
 
-    def _get_objects(self, key):
+    def _get_objects(self, key: str):
         # Return object list for all tier levels, the restrict output function
         # will then strip out the necessary metadata
         metadata_tier = self._config.get_metadata_tier()

--- a/machine_common_sense/recorder.py
+++ b/machine_common_sense/recorder.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pathlib
 import queue
@@ -93,6 +94,45 @@ class BaseRecorder(ABC):
     def _write(self):
         '''Subclasses to provide writing specifics'''
         pass
+
+
+class JsonRecorder(BaseRecorder):
+    '''Threaded json recorder'''
+
+    def __init__(self, json_template: pathlib.Path,
+                 timeout: float = 1.0, sort_keys=True, indent=4):
+        '''Create the json recorder.
+
+        Args:
+            json_template(pathlib.Path): Filename template
+            timeout (float): How often in seconds to check the queue
+
+        Returns:
+            None
+        '''
+        self.path = json_template
+        self.sort_keys = sort_keys
+        self.indent = indent
+        super().__init__(timeout)
+        super().start()
+
+    def _write(self, data: dict) -> None:
+        '''Save the json to disk
+
+        Args:
+            data (dict): The data to record
+
+        Returns:
+            None
+        '''
+        json_file = str(self.path).format(self.num_recorded)
+        logger.debug(f"Writing {json_file}")
+        with open(json_file, 'w') as json_file:
+            json.dump(
+                data,
+                json_file,
+                sort_keys=self.sort_keys,
+                indent=self.indent)
 
 
 class ImageRecorder(BaseRecorder):


### PR DESCRIPTION
This is a small update to make some of the json writing threaded.

It be nice to thread the debug log file writer, but it creates a json string in a custom way.  We could create yet another record to just write text?  