### PR TITLE
MCS-700 Added debug scene and object properties to the schema classes.

### DIFF
--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -279,14 +279,18 @@ class GoalMetadataSchema(Schema):
 
 class GoalSchema(Schema):
     action_list = fields.List(fields.Raw())
-    habituation_total = fields.Int()
+    answer = fields.Dict()  # UI property
     category = fields.Str()
     description = fields.Str()
+    domainsInfo = fields.Dict()  # UI property
+    habituation_total = fields.Int()
     info_list = fields.List(fields.Str())
-    skip_preview_phase = fields.Bool()
     last_preview_phase_step = fields.Int()
     last_step = fields.Int()
     metadata = fields.Dict()
+    objectsInfo = fields.Dict()  # UI property
+    sceneInfo = fields.Dict()  # UI property
+    skip_preview_phase = fields.Bool()
     task_list = fields.List(fields.Str())
     type_list = fields.List(fields.Str())
 
@@ -352,6 +356,7 @@ class ShowConfigSchema(Schema):
     position = fields.Nested(Vector3dSchema)
     rotation = fields.Nested(Vector3dSchema)
     scale = fields.Nested(Vector3dSchema)
+    boundingBox = fields.List(fields.Dict())  # debug property
 
     @post_load
     def make_show_config(self, data, **kwargs):
@@ -407,7 +412,9 @@ class TransformConfigSchema(Schema):
 class SceneObjectSchema(Schema):
     id = fields.Str()
     type = fields.Str()  # should this be an enum?
+    centerOfMass = fields.Nested(Vector3dSchema)
     changeMaterials = fields.List(fields.Nested(ChangeMaterialSchema))
+    debug = fields.Dict()
     forces = fields.List(fields.Nested(ForceConfigSchema))
     ghosts = fields.List(fields.Nested(StepBeginEndConfigSchema))
     hides = fields.List(fields.Nested(SingleStepConfigSchema))
@@ -426,6 +433,7 @@ class SceneObjectSchema(Schema):
     physicsProperties = fields.Nested(PhysicsConfigSchema)
     pickupable = fields.Bool()
     receptacle = fields.Bool()
+    resetCenterOfMass = fields.Bool()
     resizes = fields.List(fields.Nested(SizeConfigSchema))
     rotates = fields.List(fields.Nested(MoveConfigSchema))
     salientMaterials = fields.List(fields.Str())
@@ -443,23 +451,23 @@ class SceneObjectSchema(Schema):
 
 
 class SceneConfigurationSchema(Schema):
-    name = fields.Str()
-    version = fields.Integer()
     ceilingMaterial = fields.Str()
+    debug = fields.Dict()
     floorMaterial = fields.Str()
-    wallMaterial = fields.Str()
-    performerStart = fields.Nested(PerformerStartSchema)
-    objects = fields.List(fields.Nested(SceneObjectSchema))
+    floorProperties = fields.Nested(PhysicsConfigSchema)
     goal = fields.Nested(GoalSchema)
-    roomDimensions = fields.Nested(Vector3dSchema)
-    roomMaterials = fields.Nested(RoomMaterialsSchema)
     intuitivePhysics = fields.Bool()
     isometric = fields.Bool()
-    answer = fields.Dict()
-    floorProperties = fields.Nested(PhysicsConfigSchema)
+    name = fields.Str()
+    objects = fields.List(fields.Nested(SceneObjectSchema))
+    observation = fields.Bool()  # deprecated; please use intuitivePhysics
+    performerStart = fields.Nested(PerformerStartSchema)
+    roomDimensions = fields.Nested(Vector3dSchema)
+    roomMaterials = fields.Nested(RoomMaterialsSchema)
+    screenshot = fields.Bool()  # developer use only; for the image generator
+    version = fields.Integer()
+    wallMaterial = fields.Str()
     wallProperties = fields.Nested(PhysicsConfigSchema)
-    screenshot = fields.Bool()
-    observation = fields.Bool()
 
     @post_load
     def make_scene_configuration(self, data, **kwargs):
@@ -493,15 +501,19 @@ class PerformerStart:
 @dataclass
 class Goal:
     action_list: list = None
+    answer: dict = None  # UI property
     category: str = None
-    habituation_total: int = None
     description: str = None
+    domainsInfo: dict = None  # UI property
+    habituation_total: int = None
     info_list: list = None
-    skip_preview_phase: bool = False
     last_preview_phase_step: int = None
     last_step: int = None
     # TODO metadata objects
     metadata: dict = None
+    objectsInfo: dict = None  # UI property
+    sceneInfo: dict = None  # UI property
+    skip_preview_phase: bool = False
     task_list: List[str] = None
     type_list: List[str] = None
 
@@ -549,6 +561,7 @@ class ShowConfig:
     position: Vector3d = Vector3d(0, 0, 0)
     rotation: Vector3d = Vector3d(0, 0, 0)
     scale: Vector3d = Vector3d(1, 1, 1)
+    boundingBox: List[dict] = field(default_factory=list)  # debug property
 
 
 @dataclass
@@ -586,7 +599,9 @@ class TransformConfig:
 class SceneObject:
     id: str
     type: str  # should this be an enum?
+    centerOfMass: Vector3d = None
     changeMaterials: List[ChangeMaterial] = field(default_factory=list)
+    debug: dict = None
     forces: List[ForceConfig] = field(default_factory=list)
     ghosts: List[StepBeginEndConfig] = field(default_factory=list)
     hides: List[SingleStepConfig] = field(default_factory=list)
@@ -607,6 +622,7 @@ class SceneObject:
     physicsProperties: PhysicsConfig = None
     pickupable: bool = None
     receptacle: bool = False
+    resetCenterOfMass: bool = False
     resizes: List[SizeConfig] = field(default_factory=list)
     rotates: List[MoveConfig] = field(default_factory=list)
     salientMaterials: List[str] = field(default_factory=list)
@@ -622,22 +638,22 @@ class SceneObject:
 @dataclass
 class SceneConfiguration:
     '''Class for keeping track of scene configuration'''
-    name: str = None
-    version: int = None
     ceilingMaterial: str = None
+    debug: dict = None
     floorMaterial: str = None
-    wallMaterial: str = None
+    floorProperties: PhysicsConfig = None
+    goal: Goal = None  # TODO change to concrete class
+    intuitivePhysics: bool = False
+    isometric: bool = False
+    name: str = None
+    objects: List[SceneObject] = field(default_factory=list)
+    observation: bool = False  # deprecated; please use intuitivePhysics
     performerStart: PerformerStart = None
     roomDimensions: Vector3d = None
     roomMaterials: RoomMaterials = None
-    goal: Goal = None  # TODO change to concrete class
-    objects: List[SceneObject] = field(default_factory=list)
-    intuitivePhysics: bool = False
-    answer = None  # TODO later
-    floorProperties: PhysicsConfig = None
-    screenshot: bool = False
-    observation: bool = False  # deprecated; please use intuitivePhysics
-    isometric: bool = False
+    screenshot: bool = False  # developer use only; for the image generator
+    version: int = None
+    wallMaterial: str = None
     wallProperties: PhysicsConfig = None
 
     def retrieve_object_states(self,


### PR DESCRIPTION
- Added debug and UI properties to the schema classes
- Marked debug and UI properties with comments

Note that this change is NOT backwards compatible, but since the issue only affects debug scene files, hopefully that limitation won't matter very much.

You can generate example scenes on your own, but here's a set that I used for my testing: https://ta2-examples.s3.amazonaws.com/mcs700_scenes.zip

Run example (from the MCS repo's root folder):
```
python scripts/run_passive_scenes.py --mcs_unity_build_file <path_to_unity_app> <path>/mcs700_0001_
```

Corresponding python PR: https://github.com/NextCenturyCorporation/mcs-private/pull/32
Corresponding ingest PR: TODO (probably when I return from vacation)