### PR TITLE
MCS-682 add wheel file

### DIFF
--- a/.github/master-merge.yaml
+++ b/.github/master-merge.yaml
@@ -1,0 +1,47 @@
+name: Pre-release to latest
+
+on:
+  push:
+    branches:
+      master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        # we are building a pure python wheel so it should work on any platform
+        os: [ubuntu-latest]
+        python-versions: [3.6]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-versions }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements.txt
+      - name: Run unit tests
+        run: python -m unittest
+      - name: Flake8
+        run: flake8
+      - name: Autopep8
+        run: autopep8 --in-place --aggressive --recursive machine_common_sense
+      - name: create wheel file
+        run: python setup.py bdist_wheel sdist clean --all
+      - name: download unity packages
+        run: echo download ${GITHUB_REF##*/} and save in dist
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          #Can set an automatic release tag or let it use the initial tag.  If latter, need to conform to semantic versioning.
+          # Note, so far, we don't conform to semantic versioning.
+          #alternatively, we could always tag as latest   
+          automatic_release_tag: latest
+          prerelease: true
+          title: "Latest Pre-Release"
+          files: |
+            dist/*


### PR DESCRIPTION
This PR will add a master-merge.yaml workflow.  This workflow will kick off only when code is merged into master.  It will perform one last run of tests, but those tests are only on ubuntu, python version 3.6.  This choice is rather arbitrary, but I wanted only 1 instance and all the code should have already been tested when moved to development.  After the tests, a wheel file is created and a new pre-release is created.  The pre release includes the wheel file and a source tar.gz file and is tagged as latest.  

We still need to manually add the unity build, edit the version, and change the tag if necessary.  

There is an alternative method to do this where we trigger on a new tag that is semantically versioned.  I mistakenly told standup that we were not semantically versioned, but I believe we are.