### PR TITLE
Added the optional prefix argument to the developer run scripts that appends a prefix to the output filenames

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,7 +39,8 @@ Use the following command line options:
 
 - `--debug` Saves output images of each action/frame/step to file.
 - `--save-videos` Creates a video from all the output images after running each scene.
-- `--rename <prefix>` Renames the output files to use the given file prefix.
+- `--prefix <prefix>` Uses the given prefix with each scene's name as the name for all the output files.
+- `--rename <name>` Ignores each scene's original name and uses the given name with each scene's ID (if available) as the name for all the output files.
 
 Example:
 

--- a/scripts/run_interactive_scenes.py
+++ b/scripts/run_interactive_scenes.py
@@ -8,11 +8,7 @@ def action_callback(scene_data, step_metadata, runner_script):
 
 
 def main():
-    MultipleFileRunnerScript(
-        'Interactive Scenes',
-        action_callback,
-        rename=True
-    )
+    MultipleFileRunnerScript('Interactive Scenes', action_callback)
 
 
 if __name__ == "__main__":

--- a/scripts/run_passive_scenes.py
+++ b/scripts/run_passive_scenes.py
@@ -16,11 +16,7 @@ def action_callback(scene_data, step_metadata, runner_script):
 
 
 def main():
-    MultipleFileRunnerScript(
-        'Passive Scenes',
-        action_callback,
-        rename=True
-    )
+    MultipleFileRunnerScript('Passive Scenes', action_callback)
 
 
 if __name__ == "__main__":

--- a/scripts/run_reorientation_scenes.py
+++ b/scripts/run_reorientation_scenes.py
@@ -220,11 +220,7 @@ def action_callback(scene_data, step_metadata, runner_script):
 
 
 def main():
-    MultipleFileRunnerScript(
-        'Reorientation Scenes',
-        action_callback,
-        rename=True
-    )
+    MultipleFileRunnerScript('Reorientation Scenes', action_callback)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
By default, scripts like `run_last_action.py` save output data named using the input scene's `name` property. For example, a scene with `"name": "thomas_1"` would generate an output folder named `thomas_1/` and, with the `--save-videos` flag, an output video named `thomas_1.mp4`

The `--prefix` flag lets you add a prefix to these output files, so, in the above example, `--prefix foobar` would generate an output folder named `foobar_thomas_1` and an output video named `foobar_thomas_1.mp4`

This is useful in the pipeline to append evaluation names and team names to the output videos uploaded to S3.