### PR TITLE
Dropped minimum version of marshmallow dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         'msgpack>=1.0.0',
         'ai2thor==2.5.0',
         'dataclasses==0.8; python_version<"3.7"',
-        'marshmallow==3.12.1'
+        'marshmallow>=3.5.0'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         'msgpack>=1.0.0',
         'ai2thor==2.5.0',
         'dataclasses==0.8; python_version<"3.7"',
-        'marshmallow>=3.5.0'
+        'marshmallow>=3.5.2'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Replace pinned marshmallow dependency (3.12.1) in the MCS package setup.py with any version equal to or above 3.5.2 to allow more flexibility with other packages. V3.5.2 was chosen out of the marshmallow changelog for its processing of lists of nested fields and bug fixes. MCS Developers should continue to use 3.12.1 pinned in requirements.txt.

https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst#352-2020-04-30
