### PR TITLE
Mcs 699 prune reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,44 +1,19 @@
 ai2thor==2.5.0
-# alabaster==0.7.12
 autopep8==1.5.4
-# Babel==2.8.0
 boto3==1.15.2
-# certifi==2020.6.20
-# chardet==3.0.4
-# click==7.1.2
 commonmark==0.9.1
 dataclasses==0.8; python_version<"3.7"
-# docutils==0.16
 flake8==3.8.3
-# Flask==1.1.2
-# idna==2.10
-# imagesize==1.2.0
 isort==5.8.0
-# itsdangerous==1.1.0
-# Jinja2==2.11.3
-# MarkupSafe==1.1.1
 marshmallow==3.12.1
 matplotlib==3.3.2
 msgpack==1.0.0
 numpy==1.19.4
 opencv-python==4.4.0.44
-# packaging==20.4
 pre-commit==2.12.1
-# purepng==0.2.0
-# Pygments==2.7.4
-# pyparsing==2.4.7
-# pytz==2020.1
 recommonmark==0.6.0
 requests==2.24.0
-# rinoh-typeface-dejavuserif==0.1.1
-# rinoh-typeface-texgyrecursor==0.1.1
-# rinoh-typeface-texgyreheros==0.1.1
-# rinoh-typeface-texgyrepagella==0.1.1
-# rinohtype==0.4.2
 Shapely==1.7.1
-# six==1.15.0
-# snowballstemmer==2.0.0
 Sphinx==3.2.1
 sphinxcontrib-websupport==1.2.4
 sphinx-markdown-builder==0.5.4
-# Werkzeug==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,44 +1,44 @@
 ai2thor==2.5.0
-alabaster==0.7.12
+# alabaster==0.7.12
 autopep8==1.5.4
-Babel==2.8.0
+# Babel==2.8.0
 boto3==1.15.2
-certifi==2020.6.20
-chardet==3.0.4
-click==7.1.2
+# certifi==2020.6.20
+# chardet==3.0.4
+# click==7.1.2
 commonmark==0.9.1
 dataclasses==0.8; python_version<"3.7"
-docutils==0.16
+# docutils==0.16
 flake8==3.8.3
-Flask==1.1.2
-idna==2.10
-imagesize==1.2.0
+# Flask==1.1.2
+# idna==2.10
+# imagesize==1.2.0
 isort==5.8.0
-itsdangerous==1.1.0
-Jinja2==2.11.3
-MarkupSafe==1.1.1
+# itsdangerous==1.1.0
+# Jinja2==2.11.3
+# MarkupSafe==1.1.1
 marshmallow==3.12.1
 matplotlib==3.3.2
 msgpack==1.0.0
 numpy==1.19.4
 opencv-python==4.4.0.44
-packaging==20.4
+# packaging==20.4
 pre-commit==2.12.1
-purepng==0.2.0
-Pygments==2.7.4
-pyparsing==2.4.7
-pytz==2020.1
+# purepng==0.2.0
+# Pygments==2.7.4
+# pyparsing==2.4.7
+# pytz==2020.1
 recommonmark==0.6.0
 requests==2.24.0
-rinoh-typeface-dejavuserif==0.1.1
-rinoh-typeface-texgyrecursor==0.1.1
-rinoh-typeface-texgyreheros==0.1.1
-rinoh-typeface-texgyrepagella==0.1.1
-rinohtype==0.4.2
+# rinoh-typeface-dejavuserif==0.1.1
+# rinoh-typeface-texgyrecursor==0.1.1
+# rinoh-typeface-texgyreheros==0.1.1
+# rinoh-typeface-texgyrepagella==0.1.1
+# rinohtype==0.4.2
 Shapely==1.7.1
-six==1.15.0
-snowballstemmer==2.0.0
+# six==1.15.0
+# snowballstemmer==2.0.0
 Sphinx==3.2.1
 sphinxcontrib-websupport==1.2.4
 sphinx-markdown-builder==0.5.4
-Werkzeug==1.0.1
+# Werkzeug==1.0.1


### PR DESCRIPTION
Removing packages from requirements.txt that were likely capture early in the project with a `pip freeze > requirements.txt`. 

Destroyed my current virtual environment and remade a new one with these reqs. Unit tests and integration tests all passed still.

https://nextcenturycorporation.github.io/MCS/dev.html#package-installation
```
(mcs) MCS $ deactivate
MCS $ rm -rf venv
MCS $ python3.6 -m venv --prompt mcs venv
MCS $ source venv/bin/activate
(mcs) MCS $ python -m pip install --upgrade pip setuptools wheel
(mcs) MCS $ python -m pip install -r requirements.txt
(mcs) MCS $ python -m pip install -e .
```