### PR TITLE
Mcs 797 auto download dev

### DIFF
--- a/integration_tests/integration_test_utils.py
+++ b/integration_tests/integration_test_utils.py
@@ -47,4 +47,10 @@ def add_test_args(parser: argparse.ArgumentParser,
         default=None,
         help='Path to MCS unity build file'
     )
+    parser.add_argument(
+        '--mcs_unity_version',
+        type=str,
+        default=None,
+        help='version of MCS Unity executable.  Default: current'
+    )
     return parser

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -274,7 +274,8 @@ def start_handmade_tests(
     only_metadata_tier,
     only_test_name,
     dev,
-    autofix
+    autofix,
+    unity_version=None
 ):
 
     # Find all of the test scene JSON files.
@@ -294,6 +295,7 @@ def start_handmade_tests(
         if (not controller):
             controller = mcs.create_controller(
                 unity_app_file_path=mcs_unity_build,
+                unity_cache_version=unity_version,
                 config_file_path=config_filename)
         else:
             mcs.change_config(controller, config_file_path=config_filename)
@@ -359,5 +361,6 @@ if __name__ == "__main__":
         args.metadata,
         args.test,
         args.dev,
-        args.autofix
+        args.autofix,
+        unity_version=args.mcs_unity_version
     )

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -23,5 +23,6 @@ if __name__ == "__main__":
         args.metadata,
         args.test,
         args.dev,
-        args.autofix
+        args.autofix,
+        unity_version=args.mcs_unity_version
     )

--- a/machine_common_sense/unity_executable_provider.py
+++ b/machine_common_sense/unity_executable_provider.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 LINUX_URL = "https://github.com/NextCenturyCorporation/MCS/releases/download/{ver}/MCS-AI2-THOR-Unity-App-v{ver}-linux.zip"  # noqa
 MAC_URL = "https://github.com/NextCenturyCorporation/MCS/releases/download/{ver}/MCS-AI2-THOR-Unity-App-v{ver}-mac.zip"  # noqa
+LINUX_DEV_URL = "https://ai2thor-unity-releases.s3.amazonaws.com/MCS-AI2-THOR-Unity-App-vdevelop-linux.zip"  # noqa
+MAC_DEV_URL = "https://ai2thor-unity-releases.s3.amazonaws.com/MCS-AI2-THOR-Unity-App-vdevelop-mac.zip"  # noqa
 
 
 class UnityExecutableProvider():
@@ -234,10 +236,20 @@ class Downloader():
         sys = platform.system()
         if (sys == "Windows"):
             raise Exception("Windows is not supported")
-        elif (sys == "Linux"):
-            return LINUX_URL.format(ver=ver)
-        elif (sys == "Darwin"):
-            return MAC_URL.format(ver=ver)
+        elif sys == "Linux":
+            if ver not in ["dev", "development"]:
+                return LINUX_URL.format(ver=ver)
+            logger.warn(
+                "Warning: Attempting to use development version of " +
+                "MCS-AI2Thor.  This is intended for developers only.")
+            return LINUX_DEV_URL
+        elif sys == "Darwin":
+            if ver not in ["dev", "development"]:
+                return MAC_URL.format(ver=ver)
+            logger.warn(
+                "Warning: Attempting to use development version of " +
+                "MCS-AI2Thor.  This is intended for developers only.")
+            return MAC_DEV_URL
         else:
             raise Exception("OS '{}' not supported".format(sys))
 

--- a/machine_common_sense/unity_executable_provider.py
+++ b/machine_common_sense/unity_executable_provider.py
@@ -68,6 +68,8 @@ class UnityExecutableProvider():
         '''
         if version is None:
             version = __version__
+        if version in ["dev", "development"]:
+            version = "develop"
         if not force_download and self._cache.has_version(version):
             return self._cache.get_execution_location(version)
         if (download_if_missing or force_download):
@@ -237,14 +239,14 @@ class Downloader():
         if (sys == "Windows"):
             raise Exception("Windows is not supported")
         elif sys == "Linux":
-            if ver not in ["dev", "development"]:
+            if ver != "develop":
                 return LINUX_URL.format(ver=ver)
             logger.warn(
                 "Warning: Attempting to use development version of " +
                 "MCS-AI2Thor.  This is intended for developers only.")
             return LINUX_DEV_URL
         elif sys == "Darwin":
-            if ver not in ["dev", "development"]:
+            if ver != "develop":
                 return MAC_URL.format(ver=ver)
             logger.warn(
                 "Warning: Attempting to use development version of " +

--- a/machine_common_sense/unity_executable_provider.py
+++ b/machine_common_sense/unity_executable_provider.py
@@ -69,7 +69,10 @@ class UnityExecutableProvider():
         '''
         if version is None:
             version = __version__
-        if version in ["dev", "development"]:
+        if version in ["dev", "development", "develop"]:
+            logger.warn(
+                "Warning: Attempting to use development version of " +
+                "MCS-AI2Thor.  This is intended for developers only.")
             version = "develop"
             url = self._downloader.get_url(version)
             force_download |= self._downloader.is_updated(
@@ -257,16 +260,10 @@ class Downloader():
         elif sys == "Linux":
             if ver != "develop":
                 return LINUX_URL.format(ver=ver)
-            logger.warn(
-                "Warning: Attempting to use development version of " +
-                "MCS-AI2Thor.  This is intended for developers only.")
             return LINUX_DEV_URL
         elif sys == "Darwin":
             if ver != "develop":
                 return MAC_URL.format(ver=ver)
-            logger.warn(
-                "Warning: Attempting to use development version of " +
-                "MCS-AI2Thor.  This is intended for developers only.")
             return MAC_DEV_URL
         else:
             raise Exception("OS '{}' not supported".format(sys))

--- a/machine_common_sense/unity_executable_provider.py
+++ b/machine_common_sense/unity_executable_provider.py
@@ -311,8 +311,8 @@ class Downloader():
 
     def is_updated(self, url, date: datetime.datetime):
         # Default to true?
-        updated = True
         try:
+            updated = True
             r = requests.get(url, stream=True)
             r.raise_for_status()
             last_mod = r.headers['last-modified']
@@ -325,4 +325,5 @@ class Downloader():
             logger.warn(
                 "Error checking last modified of development build",
                 exc_info=e)
-        return updated
+        finally:
+            return updated

--- a/scripts/runner_script.py
+++ b/scripts/runner_script.py
@@ -39,6 +39,7 @@ class AbstractRunnerScript():
             config_file_path = args.config_file
         controller = mcs.create_controller(
             unity_app_file_path=args.mcs_unity_build_file,
+            unity_cache_version=args.mcs_unity_version,
             config_file_path=config_file_path
         )
 


### PR DESCRIPTION
Added develop option (or dev or development) for version for auto-downloader
Added ability to set mcs-unity-version for auto-downloader for integration test scripts and AbstractScriptRunner scripts.  More can be added as needed.