### PR TITLE
MCS-863 Ensure outer walls are shown properly in top-down videos.

### DIFF
--- a/machine_common_sense/controller_media.py
+++ b/machine_common_sense/controller_media.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 import numpy as np
 import PIL
 
-from .config_manager import ConfigManager
+from .config_manager import ConfigManager, Vector3d
 from .controller_events import (AbstractControllerSubscriber,
                                 ControllerEventPayload)
 from .plotter import TopDownPlotter
@@ -188,7 +188,12 @@ class TopdownVideoEventHandler(AbstractVideoEventHandler):
         self.__plotter = TopDownPlotter(
             team=payload.config.get_team(),
             scene_name=payload.scene_config.name.replace('json', ''),
-            room_size=payload.scene_config.roomDimensions)
+            room_size=(
+                # Room is automatically expanded in intuitive physics scenes.
+                Vector3d(14, 10, 10) if payload.scene_config.intuitivePhysics
+                else payload.scene_config.roomDimensions
+            )
+        )
         self.save_video_for_step(payload)
 
     def on_after_step(self, payload: ControllerEventPayload):

--- a/machine_common_sense/plotter.py
+++ b/machine_common_sense/plotter.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import ai2thor.server
 import colour
@@ -112,8 +112,9 @@ class TopDownPlotter():
         self.center_x = int(x_dim / 2) - 1  # ex: 512 /2 = 256 - 1 = 255
         self.center_z = int(z_dim / 2) - 1  # ex: 256 /2 = 128 - 1 = 127
         largest_dimension = max(room_x, room_z)
-        self.x_scale = (x_dim - 1) / largest_dimension
-        self.z_scale = (z_dim - 1) / largest_dimension
+        # Add a buffer into the scale to properly show the room's walls.
+        self.x_scale = (x_dim - 12) / largest_dimension
+        self.z_scale = (z_dim - 12) / largest_dimension
 
         # outer buffer space to keep 1:1 aspect ratio
         buffer_x = (x_dim - (x_dim * room_x / largest_dimension)) / 2
@@ -241,6 +242,7 @@ class TopDownPlotter():
             obj = self._create_object(o)
             if obj.bounds is not None:
                 obj_pts = [(pt['x'], pt['z']) for pt in obj.bounds]
+                obj_pts = self._reduce_bounds_size_if_wall(obj.uuid, obj_pts)
                 polygon = geometry.MultiPoint(
                     obj_pts).convex_hull
                 pts = polygon.exterior.coords
@@ -339,3 +341,47 @@ class TopDownPlotter():
         if color == 'black':
             color = 'ivory'
         return color
+
+    def _reduce_bounds_size_if_wall(
+        self,
+        uuid: str,
+        points: List[Tuple[float]]
+    ) -> List[Tuple[float]]:
+        '''Reduce the size of the object bounds represented by the given points
+        if the corresponding object is a room wall.'''
+        reduce_top = False
+        reduce_bottom = False
+        reduce_left = False
+        reduce_right = False
+
+        if uuid == 'wall_back':
+            reduce_bottom = True
+            reduce_left = True
+            reduce_right = True
+        if uuid == 'wall_front':
+            reduce_top = True
+            reduce_left = True
+            reduce_right = True
+        if uuid == 'wall_left':
+            reduce_left = True
+            reduce_top = True
+            reduce_bottom = True
+        if uuid == 'wall_right':
+            reduce_right = True
+            reduce_top = True
+            reduce_bottom = True
+
+        points_list = [list(item) for item in points]
+        if reduce_top:
+            for index in [0, 1, 4, 5]:
+                points_list[index][1] -= 0.4
+        if reduce_bottom:
+            for index in [2, 3, 6, 7]:
+                points_list[index][1] += 0.4
+        if reduce_left:
+            for index in [1, 2, 5, 6]:
+                points_list[index][0] += 0.4
+        if reduce_right:
+            for index in [0, 3, 4, 7]:
+                points_list[index][0] -= 0.4
+        return [(item[0], item[1]) for item in points_list]


### PR DESCRIPTION
Changes:
- Previously, the room's walls would not always appear in the top-down videos because they're positioned outside the room bounds. For example, in a default room (X=[-5, 5], Z=[-5, 5]), the front wall's Z position is between 5 and 6. Now, I added a buffer to the X and Z scales so the walls would be shown properly.
- I reduced the size of the room walls so they don't take up as much real estate in the top-down videos.

Here are some examples of an 8x12 room with three blue walls and one red wall.

OLD (you can barely see the right wall, and can't even see the left wall!):
![MCS-863-old](https://user-images.githubusercontent.com/10994382/130272292-c16f1088-9ee0-4a4b-b8d8-78314d237587.png)

NEW:
![MCS-863-new](https://user-images.githubusercontent.com/10994382/130272300-4a3a3d4f-f4a0-4b74-b5bc-43e74dd50146.png)
