### PR TITLE
MCS-868 Update Python API Doc to Use Eval 4 Plan Terminology

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -247,29 +247,39 @@ class Controller():
         if self.__seed:
             random.seed(self.__seed)
 
-    def end_scene(self, choice, confidence=1.0):
+    def end_scene(
+        self,
+        rating: Union[float, int, str] = None,
+        score: float = 1.0
+    ):
         """
         Ends the current scene.  Calling end_scene() before calling
         start_scene() will do nothing.
 
         Parameters
         ----------
-        choice : string, optional
-            The selected choice required for ending scenes with
-            violation-of-expectation or classification goals.
-            Is not required for other goals. (default None)
-        confidence : float, optional
-            The choice confidence between 0 and 1 required for ending scenes
-            with violation-of-expectation or classification goals.
-            Is not required for other goals. (default None)
+        rating : float or int or string, required
+            The plausibility rating to classify a passive / VoE scene as either
+            plausible or implausible. Not used for any interactive scenes. For
+            passive agent scenes, this rating should be continuous, from 0.0
+            (completely implausible) to 1.0 (completely plausible). For other
+            passive scenes, this rating must be binary, either 0 (implausible)
+            or 1 (plausible). Please note that end-of-scene ratings are
+            required for all passive / VoE scenes. (default None)
+        score : float, optional
+            The continuous plausibility score between 0.0 (completely
+            implausible) and 1.0 (completely plausible). End-of-scene scores
+            are required for all passive / VoE scenes except agent scenes.
+            Not used for any interactive scenes or passive agent scenes.
+            (default 1.0)
 
             Note: when an issue causes the program to exit prematurely or
             end_scene isn't properly called but history_enabled is true,
             this value will be written to file as -1.
         """
         payloadArgs = self._create_event_payload_kwargs()
-        payloadArgs['choice'] = choice
-        payloadArgs['confidence'] = confidence
+        payloadArgs['rating'] = str(rating)
+        payloadArgs['score'] = score
 
         self._publish_event(
             EventType.ON_END_SCENE,
@@ -365,7 +375,7 @@ class Controller():
             if(self._end_scene_not_registered is True and
                     self._config.is_history_enabled()):
                 # make sure history file is written when program exits
-                atexit.register(self.end_scene, choice="", confidence=-1)
+                atexit.register(self.end_scene, rating="", score=-1)
                 self._end_scene_not_registered = False
 
         payloadArgs = self._create_post_step_event_payload_kwargs(
@@ -619,26 +629,35 @@ class Controller():
 
         return output
 
-    def make_step_prediction(self, choice: str = None,
-                             confidence: float = None,
+    def make_step_prediction(self, rating: Union[float, int, str] = None,
+                             score: float = None,
                              violations_xy_list: List[Dict[str, float]] = None,
                              internal_state: object = None,) -> None:
         """Make a prediction on the previously taken step/action.
 
         Parameters
         ----------
-        choice : string, optional
-            The selected choice for per frame prediction with
-            violation-of-expectation or classification goals.
-            Is not required for other goals. (default None)
-        confidence : float, optional
-            The choice confidence between 0 and 1 required by the end of
-            scenes with violation-of-expectation or classification goals.
-            Is not required for other goals. (default None)
+        rating : float or int or string, optional
+            The plausibility rating to classify a passive / VoE scene as either
+            plausible or implausible. Not used for any interactive scenes. For
+            passive agent scenes, this rating should be continuous, from 0.0
+            (completely implausible) to 1.0 (completely plausible). For other
+            passive scenes, this rating must be binary, either 0 (implausible)
+            or 1 (plausible). Please note that frame-by-frame ratings are no
+            longer required for any scenes (but end-of-scene ratings are).
+            (default None)
+        score : float, optional
+            The continuous plausibility score between 0.0 (completely
+            implausible) and 1.0 (completely plausible). Frame-by-frame scores
+            are required for all passive / VoE scenes except agent scenes.
+            Not used for any interactive scenes or passive agent scenes.
+            (default None)
         violations_xy_list : List[Dict[str, float]], optional
             A list of one or more (x, y) locations (ex: [{"x": 1, "y": 3.4}]),
-            each representing a potential violation-of-expectation. Required
-            on each step for passive tasks. (default None)
+            each representing a potential violation-of-expectation. These
+            locations are required for all passive / VoE scenes except agent
+            scenes. Not used for any interactive scenes or passive agent
+            scenes. (default None)
         internal_state : object, optional
             A properly formatted json object representing various kinds of
             internal states at a particular moment. Examples include the
@@ -652,8 +671,8 @@ class Controller():
 
         payload = PredictionPayload(
             self._config,
-            choice,
-            confidence,
+            str(rating),
+            score,
             violations_xy_list,
             internal_state)
         self._publish_event(EventType.ON_PREDICTION, payload)

--- a/machine_common_sense/controller_events.py
+++ b/machine_common_sense/controller_events.py
@@ -66,8 +66,8 @@ class BeforeStepPayload(BaseEventPayload):
 
 @dataclass
 class EndScenePayload(BaseEventPayload):
-    choice: str
-    confidence: float
+    rating: str
+    score: float
 
 
 class ControllerEventPayload(BaseEventPayload):
@@ -114,13 +114,13 @@ class PredictionPayload(BaseEventPayload):
         When the prediction event occurs.
     '''
 
-    def __init__(self, config, choice: str = None,
-                 confidence: float = None,
+    def __init__(self, config, rating: str = None,
+                 score: float = None,
                  violations_xy_list: List[Dict[str, float]] = None,
                  internal_state: object = None):
         self.config = config
-        self.choice = choice
-        self.confidence = confidence
+        self.rating = rating
+        self.score = score
         self.violations_xy_list = violations_xy_list
         self.internal_state = internal_state
 

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -142,12 +142,14 @@ class GoalCategory(Enum):
     These trials will demand a "common sense" understanding of agents, their
     behaviors, and their interactions with objects in the environment.
 
-    Parameters
-    ----------
-    choose : list of strings
-        The list of choices, one of which must be given in your call to
-        end_scene. For Agents goals, this value will always be
-        ["expected", "unexpected"].
+    Notes
+    -----
+    You are not required to call `controller.make_step_prediction()`.
+
+    You are required to call `controller.end_scene()` at the end of each scene
+    with a continuous plausibility `rating`, from 0.0 (completely implausible)
+    to 1.0 (completely plausible). You are not required to also pass it a
+    `score`.
     """
 
     INTUITIVE_PHYSICS = "intuitive physics"
@@ -159,12 +161,17 @@ class GoalCategory(Enum):
     permanence or shape constancy. Inspired by Emmanuel Dupoux's "IntPhys: A
     Benchmark for Visual Intuitive Physics Reasoning" (http://intphys.com).
 
-    Parameters
-    ----------
-    choose : list of strings
-        The list of choices, one of which must be given in your call to
-        end_scene. For Intuitive Physics goals, this value will always be
-        ["plausible", "implausible"].
+    Notes
+    -----
+    You are required to call `controller.make_step_prediction()` after each
+    frame in a scene with a continuous plausibility `score` -- from 0.0
+    (completely implausible) to 1.0 (completely plausible) -- and a
+    `violations_xy_list`.
+
+    You are required to call `controller.end_scene()` at the end of each scene
+    with a binary plausibility `rating` -- either 0 (implausible) or 1
+    (plausible) -- and a continuous plausibility `score` -- from 0.0
+    (completely implausible) to 1.0 (completely plausible).
     """
 
     RETRIEVAL = "retrieval"
@@ -192,6 +199,8 @@ class GoalCategory(Enum):
 
     TRANSFERRAL = "transferral"
     """
+    NOT USED IN MCS EVAL 4+
+
     In a trial that has a transferral goal, you must find and pickup the
     first target object and put it down either next to or on top of the second
     target object. This may involve exploring the scene, avoiding obstacles,
@@ -251,6 +260,8 @@ class GoalCategory(Enum):
 
     TRAVERSAL = "traversal"
     """
+    NOT USED IN MCS EVAL 4+
+
     In a trial that has a traversal goal, you must find and move next to a
     target object. This may involve exploring the scene, and avoiding
     obstacles. These trials will demand a "common sense" understanding of

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -65,8 +65,8 @@ class HistoryEventHandler(AbstractControllerSubscriber):
         # add history step prediction attributes before add to the writer
         # in the next step
         if self.__history_item is not None:
-            self.__history_item.classification = payload.choice
-            self.__history_item.confidence = payload.confidence
+            self.__history_item.classification = payload.rating
+            self.__history_item.confidence = payload.score
             self.__history_item.violations_xy_list = payload.violations_xy_list
             self.__history_item.internal_state = payload.internal_state
 
@@ -77,7 +77,7 @@ class HistoryEventHandler(AbstractControllerSubscriber):
         ):
             self.__history_writer.add_step(self.__history_item)
             self.__history_writer.write_history_file(
-                payload.choice, payload.confidence)
+                payload.rating, payload.score)
 
     def _get_filename_without_timestamp(self, filepath: pathlib.Path):
         return filepath.stem[:-16] + filepath.suffix
@@ -158,11 +158,11 @@ class HistoryWriter(object):
             self.current_steps.append(
                 dict(self.filter_history_output(step_obj)))
 
-    def write_history_file(self, classification, confidence):
+    def write_history_file(self, rating, score):
         """ Add the end score obj, create the object
             that will be written to file"""
-        self.end_score["classification"] = classification
-        self.end_score["confidence"] = str(confidence)
+        self.end_score["classification"] = rating
+        self.end_score["confidence"] = str(score)
 
         self.history_obj["info"] = self.info_obj
         self.history_obj["steps"] = self.current_steps


### PR DESCRIPTION
- In `end_scene` and `make_step_prediction`, renamed `choice` to `rating` and `confidence` to `score`. Updated corresponding docstrings with expected variable types, required vs. optional arguments, and valid input. Did not rename any scene history file properties, so ingest should not be affected.
- Updated Agents and Intuitive Physics GoalCategory documentation with the same information.

Would probably be good to merge this before releasing 0.4.4, unless there are any major concerns.

Eval 4 Plan: https://nextcentury.atlassian.net/wiki/spaces/MCSC/pages/1874985098/Eval+4+Plan+Final#2.1-Passive-Observational-Physics-(VOE)-Tasks

Fixes GitHub Issue: https://github.com/NextCenturyCorporation/MCS/issues/237