### PR TITLE
MCS-513 (WIP for retrospective reporting)

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -135,12 +135,6 @@ class Controller():
     OBJECT_MOVE_ACTIONS = ["CloseObject", "OpenObject"]
     MOVE_ACTIONS = ["MoveAhead", "MoveLeft", "MoveRight", "MoveBack"]
 
-    AWS_CREDENTIALS_FOLDER = os.path.expanduser('~') + '/.aws/'
-    AWS_CREDENTIALS_FILE = os.path.expanduser('~') + '/.aws/credentials'
-
-    AWS_ACCESS_KEY_ID = 'aws_access_key_id'
-    AWS_SECRET_ACCESS_KEY = 'aws_secret_access_key'
-
     def __init__(self, unity_app_file_path, config):
 
         self._subscribers = []

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -241,7 +241,7 @@ class Controller():
         if self.__seed:
             random.seed(self.__seed)
 
-    def end_scene(self, choice, confidence=1.0, report={}):
+    def end_scene(self, choice, confidence=1.0, report=None):
         """
         Ends the current scene.  Calling end_scene() before calling
         start_scene() will do nothing.
@@ -261,27 +261,38 @@ class Controller():
             end_scene isn't properly called but history_enabled is true,
             this value will be written to file as -1.
         report : Dict[integer, object], optional
-            Variable for retrospective per frame reporting.
+            Variable for retrospective per frame reporting. (default None)
+
             Key is frame number take from step metadata (step number
             starts at 1). Value or payload contains:
-            - choice : string, optional
-            The selected choice for per frame prediction with
-            violation-of-expectation or classification goals.
-            Is not required for other goals. (default None)
-            - confidence : float, optional
-            The choice confidence between 0 and 1 required by the end
-            of scenes with violation-of-expectation or classification
-            goals. Is not required for other goals. (default None)
-            - violations_xy_list : List[Dict[str, float]], optional
-            A list of one or more (x, y) locations
-            (ex: [{"x": 1, "y": 3.4}]),
-            each representing a potential violation-of-expectation.
-            Required on each step for passive tasks. (default None)
-            - internal_state : object, optional
-            A properly formatted json object representing various
-            kinds of internal states at a particular moment. Examples
-            include the estimated position of the agent, current map
-            of the world, etc. (default None)
+
+                * choice : string, optional -
+                  The selected choice for per frame prediction with
+                  violation-of-expectation or classification goals.
+                  Is not required for other goals.
+                * confidence : float, optional -
+                  The choice confidence between 0 and 1 required by the end
+                  of scenes with violation-of-expectation or classification
+                  goals. Is not required for other goals.
+                * violations_xy_list : List[Dict[str, float]], optional -
+                  A list of one or more (x, y) locations
+                  (ex: ```[{"x": 1, "y": 3.4}]```),
+                  each representing a potential violation-of-expectation.
+                  Required on each step for passive tasks.
+                * internal_state : object, optional -
+                  A properly formatted json object representing various
+                  kinds of internal states at a particular moment. Examples
+                  include the estimated position of the agent, current map
+                  of the world, etc.
+
+            Example report:
+            ```{1: {
+            "choice": "plausible",
+            "confidence": .75,
+            "violations_xy_list": [{"x": 1,"y": 1}],
+            "internal_state": {"test": "some state"}
+            }}
+            ```
 
         """
         payloadArgs = self._create_event_payload_kwargs()

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -241,6 +241,8 @@ class Controller():
         if self.__seed:
             random.seed(self.__seed)
 
+    # TODO: MCS-513: do we need to update docs here + make_step_prediction/
+    # specify scores are for Agent tasks as well?
     def end_scene(self, choice, confidence=1.0, report=None):
         """
         Ends the current scene.  Calling end_scene() before calling
@@ -261,7 +263,9 @@ class Controller():
             end_scene isn't properly called but history_enabled is true,
             this value will be written to file as -1.
         report : Dict[integer, object], optional
-            Variable for retrospective per frame reporting. (default None)
+            Variable for retrospective per frame reporting for
+            passive / VoE scenes. Not required if make_step_prediction was
+            used. (default None)
 
             Key is frame number take from step metadata (step number
             starts at 1). Value or payload contains:
@@ -286,13 +290,22 @@ class Controller():
                   of the world, etc.
 
             Example report:
-            ```{1: {
-            "choice": "plausible",
-            "confidence": .75,
-            "violations_xy_list": [{"x": 1,"y": 1}],
-            "internal_state": {"test": "some state"}
-            }}
-            ```
+
+            {
+
+                    1: {
+
+                        "choice": "plausible",
+
+                        "confidence": .75,
+
+                        "violations_xy_list": [{"x": 1,"y": 1}],
+
+                        "internal_state": {"test": "some state"}
+
+                    }
+
+            }
 
         """
         payloadArgs = self._create_event_payload_kwargs()

--- a/machine_common_sense/controller_events.py
+++ b/machine_common_sense/controller_events.py
@@ -68,6 +68,7 @@ class BeforeStepPayload(BaseEventPayload):
 class EndScenePayload(BaseEventPayload):
     choice: str
     confidence: float
+    report: dict
 
 
 class ControllerEventPayload(BaseEventPayload):

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -123,8 +123,10 @@ class GoalMetadata:
 @unique
 class GoalCategory(Enum):
     """
-    Each goal will have a "category" string and a "metadata" dict with one or
-    more properties depending on the "category".
+    Each goal dict will have a "category" string that describes the type of
+    scene (or, the type of task within the scene) being run. Each goal dict
+    will also have a "metadata" dict containing one or more properties
+    depending on the "category".
     """
 
     AGENTS = "agents"

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -82,19 +82,20 @@ class HistoryEventHandler(AbstractControllerSubscriber):
             # TODO: MCS-513: Kept the same property names as before.
             # Did we want to rename any of these properties?
             # If so we will need to update ingest.
-            for step in self.__history_writer.current_steps:
-                currentStep = step.get("step")
+            if payload.report is not None:
+                for step in self.__history_writer.current_steps:
+                    currentStep = step.get("step")
 
-                findStepInReport = payload.report.get(currentStep)
+                    findStepInReport = payload.report.get(currentStep)
 
-                if(findStepInReport is not None):
-                    step["classification"] = findStepInReport.get("choice")
-                    step["confidence"] = findStepInReport.get(
-                        "confidence")
-                    step["violations_xy_list"] = findStepInReport.get(
-                        "violations_xy_list")
-                    step["internal_state"] = findStepInReport.get(
-                        "internal_state")
+                    if(findStepInReport is not None):
+                        step["classification"] = findStepInReport.get("choice")
+                        step["confidence"] = findStepInReport.get(
+                            "confidence")
+                        step["violations_xy_list"] = findStepInReport.get(
+                            "violations_xy_list")
+                        step["internal_state"] = findStepInReport.get(
+                            "internal_state")
 
             self.__history_writer.write_history_file(
                 payload.choice, payload.confidence)

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -76,6 +76,26 @@ class HistoryEventHandler(AbstractControllerSubscriber):
             payload.config.is_history_enabled()
         ):
             self.__history_writer.add_step(self.__history_item)
+
+            # Loop back and fill out previous steps with
+            # retrospective report
+            # TODO: MCS-513: Kept the same property names as before.
+            # Did we want to rename any of these properties?
+            # If so we will need to update ingest.
+            for step in self.__history_writer.current_steps:
+                currentStep = step.get("step")
+
+                findStepInReport = payload.report.get(currentStep)
+
+                if(findStepInReport is not None):
+                    step["classification"] = findStepInReport.get("choice")
+                    step["confidence"] = findStepInReport.get(
+                        "classification")
+                    step["violations_xy_list"] = findStepInReport.get(
+                        "violations_xy_list")
+                    step["internal_state"] = findStepInReport.get(
+                        "internal_state")
+
             self.__history_writer.write_history_file(
                 payload.choice, payload.confidence)
 

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -77,8 +77,7 @@ class HistoryEventHandler(AbstractControllerSubscriber):
         ):
             self.__history_writer.add_step(self.__history_item)
 
-            # Loop back and fill out previous steps with
-            # retrospective report
+            # Loop back and fill out previous steps with retrospective report
             # TODO: MCS-513: Kept the same property names as before.
             # Did we want to rename any of these properties?
             # If so we will need to update ingest.
@@ -89,6 +88,8 @@ class HistoryEventHandler(AbstractControllerSubscriber):
                     findStepInReport = payload.report.get(currentStep)
 
                     if(findStepInReport is not None):
+                        # Use classification and confidence rather than rating
+                        # and score to be compatible with old history files.
                         step["classification"] = findStepInReport.get("rating")
                         step["confidence"] = findStepInReport.get("score")
                         step["violations_xy_list"] = findStepInReport.get(
@@ -181,6 +182,8 @@ class HistoryWriter(object):
     def write_history_file(self, rating, score):
         """ Add the end score obj, create the object
             that will be written to file"""
+        # Use classification and confidence rather than rating and score to be
+        # compatible with old history files.
         self.end_score["classification"] = rating
         self.end_score["confidence"] = str(score)
 

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -90,7 +90,7 @@ class HistoryEventHandler(AbstractControllerSubscriber):
                 if(findStepInReport is not None):
                     step["classification"] = findStepInReport.get("choice")
                     step["confidence"] = findStepInReport.get(
-                        "classification")
+                        "confidence")
                     step["violations_xy_list"] = findStepInReport.get(
                         "violations_xy_list")
                     step["internal_state"] = findStepInReport.get(

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -69,9 +69,6 @@ class HistoryEventHandler(AbstractControllerSubscriber):
             self.__history_writer.add_step(self.__history_item)
 
             # Loop back and fill out previous steps with retrospective report
-            # TODO: MCS-513: Kept the same property names as before.
-            # Did we want to rename any of these properties?
-            # If so we will need to update ingest.
             if payload.report is not None:
                 for step in self.__history_writer.current_steps:
                     currentStep = step.get("step")

--- a/machine_common_sense/scene_history.py
+++ b/machine_common_sense/scene_history.py
@@ -10,9 +10,9 @@ class SceneHistory(object):
         action=None,
         args=None,
         params=None,
-        # Use classification rather than rating for backwards compatibility.
+        # Use classification and confidence rather than rating and score to be
+        # compatible with old history files.
         classification: str = None,
-        # Use confidence rather than score for backwards compatibility.
         confidence: float = None,
         violations_xy_list: List[Dict[str, float]] = None,
         internal_state: object = None,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,12 +3,14 @@ import os
 import shutil
 import unittest
 from types import SimpleNamespace
+from unittest.mock import ANY, MagicMock
 
 import numpy
 
 import machine_common_sense as mcs
 from machine_common_sense.config_manager import (ConfigManager,
                                                  SceneConfiguration, Vector3d)
+from machine_common_sense.controller_events import EndScenePayload, EventType
 from machine_common_sense.goal_metadata import GoalMetadata
 
 from .mock_controller import MOCK_VARIABLES, MockControllerAI2THOR
@@ -21,6 +23,7 @@ class TestController(unittest.TestCase):
 
     def setUp(self):
         self.controller = MockControllerAI2THOR()
+        self.controller._publish_event = MagicMock()
         self.controller.set_metadata_tier('default')
         self.maxDiff = None
 
@@ -270,16 +273,49 @@ class TestController(unittest.TestCase):
 
         return data
 
-    # Removed test for "end_scene" but it really only tested writing the
-    # history file.  We should add tests for sending events and then separately
-    # test the event handlers
-    # TODO
+    def test_end_scene(self):
+        test_payload = self.controller._create_event_payload_kwargs()
+
+        test_payload["choice"] = "plausible"
+        test_payload["confidence"] = 0.5
+        test_payload["report"] = {
+            1: {
+                "choice": "plausible",
+                "classification": .75,
+                "violations_xy_list": [
+                    {
+                        "x": 1,
+                        "y": 1
+                    }
+                ]}
+        }
+
+        self.controller.end_scene("plausible", 0.5, {
+            1: {
+                "choice": "plausible",
+                "classification": .75,
+                "violations_xy_list": [
+                    {
+                        "x": 1,
+                        "y": 1
+                    }
+                ]}
+        })
+
+        self.controller._publish_event.assert_called_with(
+            EventType.ON_END_SCENE,
+            EndScenePayload(**test_payload)
+        )
 
     def test_start_scene(self):
         self.controller.set_metadata_tier(
             ConfigManager.CONFIG_METADATA_TIER_ORACLE)
         output = self.controller.start_scene({'name': TEST_FILE_NAME})
         self.assertIsNotNone(output)
+        self.controller._publish_event.assert_called_with(
+            EventType.ON_START_SCENE,
+            ANY
+        )
         self.assertEqual(
             output.action_list,
             GoalMetadata.ACTION_LIST)
@@ -352,6 +388,20 @@ class TestController(unittest.TestCase):
         self.assertEqual(len(output.structural_object_list),
                          len(MOCK_VARIABLES['metadata']['structuralObjects']))
 
+    def test_make_step_prediction(self):
+        self.controller.make_step_prediction(
+            "plausible",
+            0.51,
+            [{"x": 2, "y": 2}],
+            {"test": "some_state"}
+        )
+
+        # TODO: revisit ANY parameter usage, particularly here
+        self.controller._publish_event.assert_called_with(
+            EventType.ON_PREDICTION,
+            ANY
+        )
+
     def test_step(self):
         self.controller.set_metadata_tier(
             ConfigManager.CONFIG_METADATA_TIER_ORACLE)
@@ -395,6 +445,21 @@ class TestController(unittest.TestCase):
                          len(MOCK_VARIABLES['metadata']['objects']))
         self.assertEqual(len(output.structural_object_list),
                          len(MOCK_VARIABLES['metadata']['structuralObjects']))
+
+    def test_step_events(self):
+        self.controller.set_metadata_tier(
+            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+        output = self.controller.start_scene({'name': TEST_FILE_NAME})
+        output = self.controller.step('MoveAhead')
+        self.controller._publish_event.assert_any_call(
+            EventType.ON_BEFORE_STEP,
+            ANY
+        )
+        self.controller._publish_event.assert_any_call(
+            EventType.ON_AFTER_STEP,
+            ANY
+        )
+        self.assertIsNotNone(output)
 
     def test_step_last_step(self):
         output = self.controller.start_scene({'name': TEST_FILE_NAME})

--- a/tests/test_history_event_handler.py
+++ b/tests/test_history_event_handler.py
@@ -1,0 +1,296 @@
+import unittest
+from unittest.mock import MagicMock
+
+from machine_common_sense.config_manager import (ConfigManager,
+                                                 SceneConfiguration)
+from machine_common_sense.controller_events import (AfterStepPayload,
+                                                    BeforeStepPayload,
+                                                    EndScenePayload,
+                                                    PredictionPayload,
+                                                    StartScenePayload)
+from machine_common_sense.history_writer import (HistoryEventHandler,
+                                                 HistoryWriter, SceneHistory)
+
+TEST_FILE_NAME = "test_scene_file.json"
+
+
+class TestHistoryEventHandler(unittest.TestCase):
+
+    scene_config = SceneConfiguration(name=TEST_FILE_NAME)
+    config_mngr = ConfigManager()
+
+    def setUp(self):
+        self.config_mngr._config[
+            ConfigManager.CONFIG_DEFAULT_SECTION
+        ] = {
+            ConfigManager.CONFIG_EVALUATION_NAME: "test-name",
+            ConfigManager.CONFIG_HISTORY_ENABLED: True,
+            ConfigManager.CONFIG_METADATA_TIER: "level1",
+        }
+
+        self.histEvents = HistoryEventHandler()
+
+    def test_on_start_scene(self):
+        test_payload = {
+            "step_number": 1,
+            "config": self.config_mngr,
+            "scene_config": self.scene_config,
+            "output_folder": None,
+            "timestamp": "20210831-202203",
+            "wrapped_step": {},
+            "step_metadata": {},
+            "step_output": {},
+            "restricted_step_output": {},
+            "goal": {}
+        }
+
+        self.assertIsNone(
+            self.histEvents._HistoryEventHandler__history_writer)
+
+        self.histEvents.on_start_scene(StartScenePayload(**test_payload))
+
+        self.assertIsNotNone(
+            self.histEvents._HistoryEventHandler__history_writer)
+        self.assertIsNotNone(
+            self.histEvents._HistoryEventHandler__history_writer)
+
+    def test_on_start_scene_hist_not_enabled(self):
+        self.config_mngr._config[
+            ConfigManager.CONFIG_DEFAULT_SECTION
+        ] = {
+            ConfigManager.CONFIG_EVALUATION_NAME: "test-name",
+            ConfigManager.CONFIG_HISTORY_ENABLED: False,
+            ConfigManager.CONFIG_METADATA_TIER: "level1",
+        }
+        test_payload = {
+            "step_number": 0,
+            "config": self.config_mngr,
+            "scene_config": self.scene_config,
+            "output_folder": None,
+            "timestamp": "20210831-202203",
+            "wrapped_step": {},
+            "step_metadata": {},
+            "step_output": {},
+            "restricted_step_output": {},
+            "goal": {}
+        }
+
+        self.assertIsNone(
+            self.histEvents._HistoryEventHandler__history_writer)
+
+        self.histEvents.on_start_scene(StartScenePayload(**test_payload))
+
+        self.assertIsNone(
+            self.histEvents._HistoryEventHandler__history_writer)
+
+    def test_on_before_step_zero(self):
+        self.histEvents._HistoryEventHandler__history_writer = MagicMock()
+        test_payload = {
+            "step_number": 0,
+            "config": self.config_mngr,
+            "scene_config": self.scene_config,
+            "action": "Initialize",
+            "habituation_trial": None,
+            "goal": {}
+        }
+
+        self.histEvents.on_before_step(BeforeStepPayload(**test_payload))
+
+        hist_writer = self.histEvents._HistoryEventHandler__history_writer
+
+        hist_writer.init_timer.assert_called()
+        hist_writer.add_step.assert_not_called()
+
+    def test_on_before_step_one(self):
+        histItem = SceneHistory(
+            step=1,
+            action="MoveAhead",
+            args=None,
+            params=None,
+            output=None,
+            delta_time_millis=0)
+        self.histEvents._HistoryEventHandler__history_item = histItem
+        self.histEvents._HistoryEventHandler__history_writer = MagicMock()
+        test_payload = {
+            "step_number": 1,
+            "config": self.config_mngr,
+            "scene_config": self.scene_config,
+            "action": "Initialize",
+            "habituation_trial": None,
+            "goal": {}
+        }
+
+        self.histEvents.on_before_step(BeforeStepPayload(**test_payload))
+
+        hist_writer = self.histEvents._HistoryEventHandler__history_writer
+
+        hist_writer.init_timer.assert_not_called()
+        hist_writer.add_step.assert_called_with(histItem)
+
+    def test_on_after_step(self):
+        test_payload = {
+            "step_number": 1,
+            "ai2thor_action": "MoveAhead",
+            "action_kwargs": {},
+            "step_params": {},
+            "config": self.config_mngr,
+            "scene_config": self.scene_config,
+            "goal": {},
+            "output_folder": None,
+            "timestamp": "20210831-202203",
+            "wrapped_step": {},
+            "step_metadata": {},
+            "step_output": MagicMock(),
+            "restricted_step_output": {}
+        }
+
+        after_step_payload = AfterStepPayload(**test_payload)
+
+        self.histEvents.on_after_step(after_step_payload)
+
+        histItem = self.histEvents._HistoryEventHandler__history_item
+
+        after_step_payload.step_output.copy_without_depth_or_images.assert_called()  # noqa: E501
+        self.assertEqual(histItem.step, 1)
+        self.assertEqual(histItem.action, "MoveAhead")
+        self.assertEqual(histItem.delta_time_millis, 0)
+
+    def test_on_prediction(self):
+        self.histEvents._HistoryEventHandler__history_item = SceneHistory(
+            step=2,
+            action="MoveAhead",
+            args=None,
+            params=None,
+            output=None,
+            delta_time_millis=0)
+        test_payload = PredictionPayload(
+            self.config_mngr,
+            "plausible",
+            .8,
+            [{"x": 1, "y": 1}],
+            {"internal_state": "test"}
+        )
+
+        histItem = self.histEvents._HistoryEventHandler__history_item
+        self.histEvents.on_prediction(test_payload)
+        self.assertIsNotNone(histItem)
+        self.assertEqual(histItem.classification, "plausible")
+        self.assertEqual(histItem.confidence, .8)
+        self.assertEqual(histItem.violations_xy_list, [{"x": 1, "y": 1}])
+        self.assertEqual(histItem.internal_state, {"internal_state": "test"})
+
+    def test_on_prediction_no_hist_item(self):
+        self.histEvents._HistoryEventHandler__history_item = None
+        test_payload = PredictionPayload(
+            self.config_mngr,
+            "plausible",
+            .8,
+            [{"x": 1, "y": 1}],
+            {"internal_state": "test"}
+        )
+
+        self.histEvents.on_prediction(test_payload)
+        self.assertIsNone(self.histEvents._HistoryEventHandler__history_item)
+
+    def test_on_end_scene(self):
+        self.histEvents._HistoryEventHandler__history_writer = HistoryWriter(
+            self.scene_config, {}, "20210831-202203")
+        self.histEvents._HistoryEventHandler__history_writer.write_history_file = MagicMock()  # noqa: E501
+        histItem = SceneHistory(
+            step=1,
+            action="MoveAhead",
+            args=None,
+            params=None,
+            output=None,
+            delta_time_millis=0)
+        self.histEvents._HistoryEventHandler__history_item = histItem
+        test_payload = {}
+        test_payload["step_number"] = 1
+        test_payload["config"] = self.config_mngr
+        test_payload["scene_config"] = self.scene_config
+        test_payload["choice"] = "plausible"
+        test_payload["confidence"] = .8
+        test_payload["report"] = {1: {"choice": "plausible",
+                                      "confidence": .75,
+                                      "violations_xy_list": [
+                                          {
+                                              "x": 1,
+                                              "y": 1
+                                          }
+                                      ],
+                                      "internal_state": {
+                                          "test": "some state"
+                                      }}
+                                  }
+
+        self.histEvents.on_end_scene(EndScenePayload(**test_payload))
+
+        hist_writer = self.histEvents._HistoryEventHandler__history_writer
+        self.assertEqual(len(hist_writer.current_steps), 1)
+        self.assertEqual(
+            hist_writer.current_steps[0]["action"], "MoveAhead")
+        self.assertEqual(
+            hist_writer.current_steps[0]["classification"],
+            "plausible")
+        self.assertEqual(
+            hist_writer.current_steps[0]["confidence"],
+            0.75)
+        self.assertEqual(
+            hist_writer.current_steps[0]["violations_xy_list"],
+            [
+                {
+                    "x": 1,
+                    "y": 1
+                }
+            ])
+        self.assertEqual(
+            hist_writer.current_steps[0]["internal_state"],
+            {
+                "test": "some state"
+            })
+        self.assertEqual(
+            hist_writer.current_steps[0]["internal_state"],
+            {
+                "test": "some state"
+            })
+
+        hist_writer.write_history_file.assert_called_with("plausible", .8)
+
+    def test_on_end_scene_history_not_enabled(self):
+        self.config_mngr._config[
+            ConfigManager.CONFIG_DEFAULT_SECTION
+        ] = {
+            ConfigManager.CONFIG_EVALUATION_NAME: "test-name",
+            ConfigManager.CONFIG_HISTORY_ENABLED: False,
+            ConfigManager.CONFIG_METADATA_TIER: "level1",
+        }
+        self.histEvents._HistoryEventHandler__history_writer = MagicMock()  # noqa: E501
+
+        test_payload = {}
+        test_payload["step_number"] = 1
+        test_payload["config"] = self.config_mngr
+        test_payload["scene_config"] = self.scene_config
+        test_payload["choice"] = "plausible"
+        test_payload["confidence"] = .8
+        test_payload["report"] = {1: {"choice": "plausible",
+                                      "confidence": .75,
+                                      "violations_xy_list": [
+                                          {
+                                              "x": 1,
+                                              "y": 1
+                                          }
+                                      ],
+                                      "internal_state": {
+                                          "test": "some state"
+                                      }}
+                                  }
+
+        self.histEvents.on_end_scene(EndScenePayload(**test_payload))
+
+        hist_writer = self.histEvents._HistoryEventHandler__history_writer
+        hist_writer.add_step.assert_not_called()
+        hist_writer.write_history_file.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Need to wait for input from @deanwetherby on the TODOs (whether or not to get rid of make_step_prediction/if we'd like to maintain backwards compatibility, as well as anything we'd like to rename that could affect ingest). 

Spent the most time with unit tests here/trying to mock things with events. The test_history_event_handler.py may have been overkill in hindsight. 