### PR TITLE
Enum and env var fixes

### DIFF
--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -108,10 +108,11 @@ class ConfigManager(object):
     def get_metadata_tier(self):
         metadata = self._config.get(
             self.CONFIG_DEFAULT_SECTION,
-            self.CONFIG_METADATA_TIER
+            self.CONFIG_METADATA_TIER,
+            fallback='default'
         )
 
-        return MetadataTier(metadata) if metadata else MetadataTier.DEFAULT
+        return MetadataTier(metadata)
 
     def set_metadata_tier(self, mode):
         self._config.set(

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -3,6 +3,7 @@ import configparser  # noqa: F401
 import logging
 import os
 from dataclasses import dataclass, field
+from enum import Enum, unique
 from typing import List
 
 import numpy as np
@@ -24,26 +25,28 @@ class Vector3d:
     z: float = 0
 
 
+@unique
+class MetadataTier(Enum):
+    # Normal metadata plus metadata for all hidden objects
+    ORACLE = 'oracle'
+    # No metadata, except for the images, depth masks, object masks,
+    # and haptic/audio feedback
+    LEVEL_2 = 'level2'
+    # No metadata, except for the images, depth masks, and haptic/audio
+    # feedback
+    LEVEL_1 = 'level1'
+    # No metadata, except for the images and haptic/audio
+    # feedback
+    NONE = 'none'
+    # Default metadata level if none specified, meant for use during
+    # development
+    DEFAULT = 'default'
+
+
 class ConfigManager(object):
 
     DEFAULT_CLIPPING_PLANE_FAR = 15.0
     DEFAULT_ROOM_DIMENSIONS = Vector3d(x=10, y=3, z=10)
-
-    # Normal metadata plus metadata for all hidden objects
-    CONFIG_METADATA_TIER_ORACLE = 'oracle'
-    # No metadata, except for the images, depth masks, object masks,
-    # and haptic/audio feedback
-    CONFIG_METADATA_TIER_LEVEL_2 = 'level2'
-    # No metadata, except for the images, depth masks, and haptic/audio
-    # feedback
-    CONFIG_METADATA_TIER_LEVEL_1 = 'level1'
-    # No metadata, except for the images and haptic/audio
-    # feedback
-    CONFIG_METADATA_TIER_NONE = 'none'
-
-    # Default metadata level if none specified, meant for use during
-    # development
-    CONFIG_METADATA_TIER_DEFAULT = 'default'
 
     CONFIG_FILE_ENV_VAR = 'MCS_CONFIG_FILE_PATH'
     DEFAULT_CONFIG_FILE = './mcs_config.ini'
@@ -103,11 +106,12 @@ class ConfigManager(object):
         )
 
     def get_metadata_tier(self):
-        return self._config.get(
+        metadata = self._config.get(
             self.CONFIG_DEFAULT_SECTION,
-            self.CONFIG_METADATA_TIER,
-            fallback='default'
+            self.CONFIG_METADATA_TIER
         )
+
+        return MetadataTier(metadata) if metadata else MetadataTier.DEFAULT
 
     def set_metadata_tier(self, mode):
         self._config.set(
@@ -175,19 +179,19 @@ class ConfigManager(object):
     def is_depth_maps_enabled(self) -> bool:
         metadata_tier = self.get_metadata_tier()
         return metadata_tier in [
-            self.CONFIG_METADATA_TIER_LEVEL_1,
-            self.CONFIG_METADATA_TIER_LEVEL_2,
-            self.CONFIG_METADATA_TIER_ORACLE,
+            MetadataTier.LEVEL_1,
+            MetadataTier.LEVEL_2,
+            MetadataTier.ORACLE,
         ]
 
     def is_object_masks_enabled(self) -> bool:
         metadata_tier = self.get_metadata_tier()
         return (
-            metadata_tier != self.CONFIG_METADATA_TIER_LEVEL_1 and
+            metadata_tier != MetadataTier.LEVEL_1 and
             metadata_tier in
             [
-                self.CONFIG_METADATA_TIER_LEVEL_2,
-                self.CONFIG_METADATA_TIER_ORACLE,
+                MetadataTier.LEVEL_2,
+                MetadataTier.ORACLE,
             ]
         )
 

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -46,7 +46,6 @@ class ConfigManager(object):
     CONFIG_METADATA_TIER_DEFAULT = 'default'
 
     CONFIG_FILE_ENV_VAR = 'MCS_CONFIG_FILE_PATH'
-    METADATA_ENV_VAR = 'MCS_METADATA_LEVEL'
     DEFAULT_CONFIG_FILE = './mcs_config.ini'
 
     CONFIG_DEFAULT_SECTION = 'MCS'
@@ -104,17 +103,11 @@ class ConfigManager(object):
         )
 
     def get_metadata_tier(self):
-        # Environment variable override for metadata property
-        metadata_env_var = os.getenv('MCS_METADATA_LEVEL', None)
-
-        if(metadata_env_var is None):
-            return self._config.get(
-                self.CONFIG_DEFAULT_SECTION,
-                self.CONFIG_METADATA_TIER,
-                fallback='default'
-            )
-
-        return metadata_env_var
+        return self._config.get(
+            self.CONFIG_DEFAULT_SECTION,
+            self.CONFIG_METADATA_TIER,
+            fallback='default'
+        )
 
     def set_metadata_tier(self, mode):
         self._config.set(

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_MOVE = 0.1
 
 from .action import Action
-from .config_manager import (ConfigManager, SceneConfiguration,
+from .config_manager import (MetadataTier, SceneConfiguration,
                              SceneConfigurationSchema)
 from .controller_events import (AfterStepPayload, BeforeStepPayload,
                                 EndScenePayload, EventType, StartScenePayload)
@@ -732,7 +732,7 @@ class Controller():
         # whether or not to randomize segmentation mask colors
         consistentColors = False
         metadata_tier = self._config.get_metadata_tier()
-        if(metadata_tier == ConfigManager.CONFIG_METADATA_TIER_ORACLE):
+        if(metadata_tier == MetadataTier.ORACLE):
             consistentColors = True
 
         # Create the step data dict for the AI2-THOR step function.
@@ -769,4 +769,4 @@ class Controller():
         string
             A string containing the current metadata level.
         """
-        return self._config.get_metadata_tier()
+        return self._config.get_metadata_tier().value

--- a/machine_common_sense/controller_logger.py
+++ b/machine_common_sense/controller_logger.py
@@ -18,7 +18,7 @@ class ControllerLogger(AbstractControllerSubscriber):
             payload.scene_config.name)
         logger.debug(
             "METADATA TIER: " +
-            payload.config.get_metadata_tier())
+            payload.config.get_metadata_tier().value)
         logger.debug(f"STEP: {payload.step_number}")
         logger.debug("ACTION: Initialize")
 

--- a/machine_common_sense/controller_media.py
+++ b/machine_common_sense/controller_media.py
@@ -70,7 +70,7 @@ class AbstractVideoEventHandler(AbstractControllerSubscriber):
         scene_name = payload.scene_config.name.replace('json', '')
         return '_'.join(
             [payload.config.get_evaluation_name(),
-             payload.config.get_metadata_tier(),
+             payload.config.get_metadata_tier().value,
              payload.config.get_team(),
              scene_name,
              AbstractVideoEventHandler.PLACEHOLDER, timestamp]) + '.mp4'

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -6,7 +6,7 @@ import numpy as np
 import PIL
 from ai2thor.server import Event
 
-from .config_manager import ConfigManager, SceneConfiguration
+from .config_manager import ConfigManager, MetadataTier, SceneConfiguration
 from .controller import DEFAULT_MOVE
 from .material import Material
 from .object_metadata import ObjectMetadata
@@ -115,7 +115,7 @@ class SceneEvent():
         # Return object list for all tier levels, the restrict output function
         # will then strip out the necessary metadata
         metadata_tier = self._config.get_metadata_tier()
-        show_all = metadata_tier != ConfigManager.CONFIG_METADATA_TIER_DEFAULT
+        show_all = metadata_tier != MetadataTier.DEFAULT
         # if no config specified, return visible objects (for now)
         return sorted(
             [
@@ -268,20 +268,20 @@ class ControllerOutputHandler():
         metadata_tier = self._config.get_metadata_tier()
         restrict_depth_map = (
             restricted and
-            metadata_tier == ConfigManager.CONFIG_METADATA_TIER_NONE
+            metadata_tier == MetadataTier.NONE
         )
 
         restrict_object_mask_list = (
             restricted and
-            (metadata_tier == ConfigManager.CONFIG_METADATA_TIER_NONE or
-             metadata_tier == ConfigManager.CONFIG_METADATA_TIER_LEVEL_1)
+            (metadata_tier == MetadataTier.NONE or
+             metadata_tier == MetadataTier.LEVEL_1)
         )
 
         restrict_non_oracle = (
             restricted and
-            (metadata_tier == ConfigManager.CONFIG_METADATA_TIER_NONE or
-             metadata_tier == ConfigManager.CONFIG_METADATA_TIER_LEVEL_1 or
-             metadata_tier == ConfigManager.CONFIG_METADATA_TIER_LEVEL_2)
+            (metadata_tier == MetadataTier.NONE or
+             metadata_tier == MetadataTier.LEVEL_1 or
+             metadata_tier == MetadataTier.LEVEL_2)
         )
 
         depth_map_list = [] if restrict_depth_map else (

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -32,7 +32,7 @@ class HistoryEventHandler(AbstractControllerSubscriber):
             ] = payload.config.get_evaluation_name()
             hist_info[
                 payload.config.CONFIG_METADATA_TIER
-            ] = payload.config.get_metadata_tier()
+            ] = payload.config.get_metadata_tier().value
             hist_info[
                 payload.config.CONFIG_TEAM
             ] = payload.config.get_team()

--- a/scripts/generate_passive_quartet_videos.py
+++ b/scripts/generate_passive_quartet_videos.py
@@ -69,7 +69,6 @@ def cleanup(quartet: List) -> None:
 
 
 def main():
-    os.environ['MCS_DEBUG_MODE'] = 'True'
     args = parse_args()
     quartets = list_quartets(args.input)
     output_dir = pathlib.Path(args.output)

--- a/scripts/run_init_scenes.py
+++ b/scripts/run_init_scenes.py
@@ -1,6 +1,5 @@
 import argparse
 import glob
-import os
 
 import machine_common_sense as mcs
 
@@ -20,7 +19,6 @@ def parse_args():
 
 
 def main():
-    os.environ['MCS_DEBUG_MODE'] = 'False'
     args = parse_args()
 
     output_folder = args.image_output_folder + '/'
@@ -28,7 +26,7 @@ def main():
 
     controller = mcs.create_controller(
         unity_app_file_path=args.mcs_unity_build_file,
-        config_file_path='./run_scripts_config_oracle_metadata.ini')
+        config_file_path='./config_oracle_debug.ini')
 
     for json_file_name in json_file_list:
         scene_data, status = mcs.load_scene_json_file(json_file_name)

--- a/tests/mock_controller.py
+++ b/tests/mock_controller.py
@@ -92,17 +92,6 @@ class MockControllerAI2THOR(Controller):
         if(check_config_path is not None):
             os.environ.pop(ConfigManager.CONFIG_FILE_ENV_VAR)
 
-        check_metadata_tier = os.getenv(
-            ConfigManager.METADATA_ENV_VAR, None)
-
-        if(check_metadata_tier is not None):
-            os.environ.pop(ConfigManager.METADATA_ENV_VAR)
-
-        check_debug_mode = os.getenv('MCS_DEBUG_MODE', None)
-
-        if(check_debug_mode is not None):
-            os.environ.pop('MCS_DEBUG_MODE')
-
         self._subscribers = []
 
         self._end_scene_not_registered = False  # atexit not needed for tests

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 from machine_common_sense.config_manager import (ChangeMaterialConfig,
                                                  ConfigManager, ForceConfig,
-                                                 GoalSchema, MoveConfig,
-                                                 OpenCloseConfig,
+                                                 GoalSchema, MetadataTier,
+                                                 MoveConfig, OpenCloseConfig,
                                                  PhysicsConfig,
                                                  SceneConfiguration,
                                                  SceneObjectSchema, ShowConfig,
@@ -86,7 +86,10 @@ class TestConfigManager(unittest.TestCase):
             'test_eval')
 
     def test_get_metadata_tier(self):
-        self.assertEqual(self.config_mngr.get_metadata_tier(), 'default')
+        self.assertEqual(
+            self.config_mngr.get_metadata_tier(),
+            MetadataTier.DEFAULT)
+        self.assertEqual(self.config_mngr.get_metadata_tier().value, 'default')
 
         self.config_mngr._config[
             self.config_mngr.CONFIG_DEFAULT_SECTION
@@ -96,6 +99,9 @@ class TestConfigManager(unittest.TestCase):
 
         self.assertEqual(
             self.config_mngr.get_metadata_tier(),
+            MetadataTier.ORACLE)
+        self.assertEqual(
+            self.config_mngr.get_metadata_tier().value,
             'oracle')
 
     def test_get_seed(self):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -85,7 +85,6 @@ class TestConfigManager(unittest.TestCase):
             self.config_mngr.get_evaluation_name(),
             'test_eval')
 
-    @mock_env()
     def test_get_metadata_tier(self):
         self.assertEqual(self.config_mngr.get_metadata_tier(), 'default')
 
@@ -98,10 +97,6 @@ class TestConfigManager(unittest.TestCase):
         self.assertEqual(
             self.config_mngr.get_metadata_tier(),
             'oracle')
-
-    @mock_env(MCS_METADATA_LEVEL='level2')
-    def test_get_metadata_tier_with_env_variable(self):
-        self.assertEqual(self.config_mngr.get_metadata_tier(), 'level2')
 
     def test_get_seed(self):
         self.assertEqual(self.config_mngr.get_seed(), None)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -8,7 +8,7 @@ from unittest.mock import ANY, MagicMock
 import numpy
 
 import machine_common_sense as mcs
-from machine_common_sense.config_manager import (ConfigManager,
+from machine_common_sense.config_manager import (ConfigManager, MetadataTier,
                                                  SceneConfiguration, Vector3d)
 from machine_common_sense.controller_events import EndScenePayload, EventType
 from machine_common_sense.goal_metadata import GoalMetadata
@@ -309,7 +309,7 @@ class TestController(unittest.TestCase):
 
     def test_start_scene(self):
         self.controller.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+            MetadataTier.ORACLE.value)
         output = self.controller.start_scene({'name': TEST_FILE_NAME})
         self.assertIsNotNone(output)
         self.controller._publish_event.assert_called_with(
@@ -356,7 +356,7 @@ class TestController(unittest.TestCase):
 
     def test_start_scene_preview_phase(self):
         self.controller.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+            MetadataTier.ORACLE.value)
         last_preview_phase_step = 5
         output = self.controller.start_scene({'name': TEST_FILE_NAME, 'goal': {
             'last_preview_phase_step': last_preview_phase_step}
@@ -390,7 +390,7 @@ class TestController(unittest.TestCase):
 
     def test_step(self):
         self.controller.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+            MetadataTier.ORACLE.value)
         output = self.controller.start_scene({'name': TEST_FILE_NAME})
         output = self.controller.step('MoveAhead')
         self.assertIsNotNone(output)
@@ -434,7 +434,7 @@ class TestController(unittest.TestCase):
 
     def test_step_events(self):
         self.controller.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+            MetadataTier.ORACLE.value)
         output = self.controller.start_scene({'name': TEST_FILE_NAME})
         output = self.controller.step('MoveAhead')
         self.controller._publish_event.assert_any_call(

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import numpy
 
 import machine_common_sense as mcs
-from machine_common_sense.config_manager import (ConfigManager,
+from machine_common_sense.config_manager import (ConfigManager, MetadataTier,
                                                  SceneConfiguration,
                                                  SceneConfigurationSchema)
 from machine_common_sense.controller_output_handler import (
@@ -477,7 +477,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
     def test_wrap_output(self):
         self._config.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_DEFAULT)
+            MetadataTier.DEFAULT.value)
         (
             mock_scene_event_data,
             image_data,
@@ -644,7 +644,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
     def test_wrap_output_with_config_metadata_level1(self):
         self._config.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_LEVEL_1)
+            MetadataTier.LEVEL_1.value)
         (
             mock_scene_event_data,
             image_data,
@@ -723,7 +723,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
     def test_wrap_output_with_config_metadata_oracle_non_restrict(self):
         self._config.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+            MetadataTier.ORACLE.value)
         (
             mock_scene_event_data,
             image_data,
@@ -772,7 +772,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
     def test_wrap_output_with_config_metadata_oracle(self):
         self._config.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+            MetadataTier.ORACLE.value)
         (
             mock_scene_event_data,
             image_data,
@@ -821,7 +821,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
     def test_save_images(self):
         self._config.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+            MetadataTier.ORACLE.value)
         image_data = numpy.array([[0]], dtype=numpy.uint8)
         depth_data = numpy.array([[[0, 0, 0]]], dtype=numpy.uint8)
         object_mask_data = numpy.array([[192]], dtype=numpy.uint8)
@@ -856,7 +856,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
     def test_save_images_with_multiple_images(self):
         self._config.set_metadata_tier(
-            ConfigManager.CONFIG_METADATA_TIER_ORACLE)
+            MetadataTier.ORACLE.value)
         image_data_1 = numpy.array([[64]], dtype=numpy.uint8)
         depth_data_1 = numpy.array([[[128, 64, 32]]], dtype=numpy.uint8)
         object_mask_data_1 = numpy.array([[192]], dtype=numpy.uint8)


### PR DESCRIPTION
Removed environment variables for metadata tier and references to an outdated debug level one, so now we just have an environment variable for the config file (MCS-839). 

Also made enums for metadata tier values (MCS-476). Still questioning the value add at this point for the metadata tier enums (its still a string value anyway in the config file itself + represented as so in the logging and get_metadata_level() controller function), but let me know what you think. 