### PR TITLE
Exit the developer run script immediately if no scene files were found.

### DIFF
--- a/scripts/runner_script.py
+++ b/scripts/runner_script.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import glob
 import logging
@@ -22,7 +20,7 @@ class AbstractRunnerScript():
         self,
         name: str,
         action_callback: Callable[
-            [Dict, mcs.StepMetadata, AbstractRunnerScript],
+            [Dict, mcs.StepMetadata, 'AbstractRunnerScript'],
             Tuple[str, Dict]
         ]
     ):
@@ -179,7 +177,7 @@ class AbstractRunnerScript():
         controller: mcs.Controller,
         filename: str,
         action_callback: Callable[
-            [Dict, mcs.StepMetadata, AbstractRunnerScript],
+            [Dict, mcs.StepMetadata, 'AbstractRunnerScript'],
             Tuple[str, Dict]
         ],
         last_step: int,
@@ -246,7 +244,7 @@ class SingleFileRunnerScript(AbstractRunnerScript):
     def _read_subclass_args(
         self,
         parser: argparse.ArgumentParser
-    ) -> Tuple[argparse.Namespace, list[str]]:
+    ) -> Tuple[argparse.Namespace, List[str]]:
         args = parser.parse_args()
         return args, [args.mcs_scene_filename]
 
@@ -256,7 +254,7 @@ class MultipleFileRunnerScript(AbstractRunnerScript):
         self,
         name: str,
         action_callback: Callable[
-            [Dict, mcs.StepMetadata, AbstractRunnerScript],
+            [Dict, mcs.StepMetadata, 'AbstractRunnerScript'],
             Tuple[str, Dict]
         ]
     ):

--- a/scripts/runner_script.py
+++ b/scripts/runner_script.py
@@ -18,6 +18,9 @@ class AbstractRunnerScript():
     def __init__(self, name, action_callback):
         self._name = name
         args, filename_list = self._read_args()
+        if not len(filename_list):
+            print('No matching files found... Exiting')
+            exit()
         self.args = args
 
         debug = (args.save_videos or args.save_gifs or args.debug)
@@ -32,6 +35,7 @@ class AbstractRunnerScript():
         config_file_path = SCRIPT_FOLDER + '/config_' + config_suffix + '.ini'
         if args.config_file:
             config_file_path = args.config_file
+        print('========================================')
         controller = mcs.create_controller(
             unity_app_file_path=args.mcs_unity_build_file,
             unity_cache_version=args.mcs_unity_version,
@@ -254,6 +258,15 @@ class MultipleFileRunnerScript(AbstractRunnerScript):
     def _read_subclass_args(self, parser):
         args = parser.parse_args()
         filename_list = glob.glob(args.mcs_scene_prefix + '*_debug.json')
-        if len(filename_list) == 0:
+        print(
+            f'Found {len(filename_list)} files matching '
+            f'{args.mcs_scene_prefix + "*_debug.json"}'
+        )
+        if not len(filename_list):
+            print('No matching files found... trying non-debug files')
             filename_list = glob.glob(args.mcs_scene_prefix + '*.json')
+            print(
+                f'Found {len(filename_list)} files matching '
+                f'{args.mcs_scene_prefix + "*.json"}'
+            )
         return args, sorted(filename_list)


### PR DESCRIPTION
Example incorrect usage:

```
python3 scripts/run_passive_scenes.py --mcs_unity_build_file ~/Development/darpa/ai2thor/unity/MCS-AI2-THOR-Unity-App-v0.4.4.x86_64 docs/source/scenes/agents_preference_expected.json 
Loaded provided logging config dictionary
Found 0 files matching docs/source/scenes/agents_preference_expected.json*_debug.json
No matching files found... trying non-debug files
Found 0 files matching docs/source/scenes/agents_preference_expected.json*.json
No matching files found... Exiting
```

Example correct usage:
```
python3 scripts/run_passive_scenes.py --mcs_unity_build_file ~/Development/darpa/ai2thor/unity/MCS-AI2-THOR-Unity-App-v0.4.4.x86_64 docs/source/scenes/agents_preference_
Loaded provided logging config dictionary
Found 0 files matching docs/source/scenes/agents_preference_*_debug.json
No matching files found... trying non-debug files
Found 2 files matching docs/source/scenes/agents_preference_*.json
========================================
```

(etc.)