### PR TITLE
MCS-907 Fix Stringifier

### DIFF
--- a/machine_common_sense/stringifier.py
+++ b/machine_common_sense/stringifier.py
@@ -128,7 +128,11 @@ class Stringifier:
             return "null"
         if isinstance(input_value, dict):
             text_list = [
-                next_indent + "\"" + dict_key + "\": " +
+                # Below code for no quotes around ints, but that results in
+                # invalid debug output file.  Remove in code review.
+                # next_indent + (str(dict_key) if isinstance(dict_key, int)
+                #                else "\"" + dict_key + "\"") + ": " +
+                next_indent + "\"" + str(dict_key) + "\": " +
                 Stringifier.value_to_str(dict_value, depth + 1)
                 for dict_key, dict_value in input_value.items()
             ]

--- a/machine_common_sense/stringifier.py
+++ b/machine_common_sense/stringifier.py
@@ -128,10 +128,6 @@ class Stringifier:
             return "null"
         if isinstance(input_value, dict):
             text_list = [
-                # Below code for no quotes around ints, but that results in
-                # invalid debug output file.  Remove in code review.
-                # next_indent + (str(dict_key) if isinstance(dict_key, int)
-                #                else "\"" + dict_key + "\"") + ": " +
                 next_indent + "\"" + str(dict_key) + "\": " +
                 Stringifier.value_to_str(dict_value, depth + 1)
                 for dict_key, dict_value in input_value.items()

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -1,3 +1,4 @@
+import copy
 import textwrap
 import unittest
 
@@ -36,6 +37,46 @@ class TestStepMetadata(unittest.TestCase):
         "reward": 0,
         "rotation": 0.0,
         "segment_map": {},
+        "step_number": 0,
+        "structural_object_list": []
+    }'''
+
+    str_output_segment_map_ints = '''    {
+        "action_list": [],
+        "camera_aspect_ratio": [0.0,0.0],
+        "camera_clipping_planes": [0.0,0.0],
+        "camera_field_of_view": 0.0,
+        "camera_height": 0.0,
+        "depth_map_list": [],
+        "goal": {
+            "action_list": null,
+            "category": "",
+            "description": "",
+            "habituation_total": 0,
+            "last_preview_phase_step": 0,
+            "last_step": null,
+            "metadata": {}
+        },
+        "habituation_trial": null,
+        "head_tilt": 0.0,
+        "image_list": [],
+        "object_list": [],
+        "object_mask_list": [],
+        "performer_radius": 0.0,
+        "performer_reach": 0.0,
+        "physics_frames_per_second": 0,
+        "pose": "UNDEFINED",
+        "position": {},
+        "return_status": "UNDEFINED",
+        "reward": 0,
+        "rotation": 0.0,
+        "segment_map": {
+            "0": {
+                "r": 218,
+                "g": 65,
+                "b": 21
+            }
+        },
         "step_number": 0,
         "structural_object_list": []
     }'''
@@ -136,6 +177,19 @@ class TestStepMetadata(unittest.TestCase):
     def test_str(self):
         self.assertEqual(str(self.step_metadata),
                          textwrap.dedent(self.str_output))
+
+    def test_str_int_segment_map(self):
+        metadata = copy.deepcopy(self.step_metadata)
+        metadata.segment_map = {
+            0: {
+                'r': 218,
+                'g': 65,
+                'b': 21
+            }
+        }
+        # test = str(metadata)
+        self.assertEqual(str(metadata),
+                         textwrap.dedent(self.str_output_segment_map_ints))
 
     def test_copy_without_depth_or_images(self):
         data = mcs.StepMetadata(

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -187,7 +187,6 @@ class TestStepMetadata(unittest.TestCase):
                 'b': 21
             }
         }
-        # test = str(metadata)
         self.assertEqual(str(metadata),
                          textwrap.dedent(self.str_output_segment_map_ints))
 


### PR DESCRIPTION
Requires MCS-318-colormap to be merged before this is merged into development.

Stringifier is used when we create debug output files as well as anyone in code tries to print step_metadata.  We now handle integer keys by quoting them such that we create valid JSON.  There is an argument that we may not want to quote the keys in the output, but then we need another mechanism to write the debug output.  There is commented out code that will handle this without quoting the keys, but it is commented out.  We should remove that during this PR.