### PR TITLE
MCS-318 Rename color field

### DIFF
--- a/integration_tests/additional_integration_tests.py
+++ b/integration_tests/additional_integration_tests.py
@@ -65,7 +65,7 @@ def run_depth_and_segmentation_test(controller, metadata_tier):
                 f'Step 1 {metadata_tier} failed: object_mask_list with length '
                 f'{len(step_metadata_0.object_mask_list)} should be length 1'
             )
-    # Verify the consistent color of each object across both steps.
+    # Verify the consistent segment_id of each object across both steps.
     if metadata_tier == 'oracle':
         if (
             step_metadata_0.object_list[0].uuid !=
@@ -88,24 +88,24 @@ def run_depth_and_segmentation_test(controller, metadata_tier):
                 f'{step_metadata_1.object_list[1].uuid}'
             )
         if (
-            step_metadata_0.object_list[0].color !=
-            step_metadata_1.object_list[0].color
+            step_metadata_0.object_list[0].segment_id !=
+            step_metadata_1.object_list[0].segment_id
         ):
             return (
                 False,
-                f'Step 1 {metadata_tier} failed: object_list[0].color '
-                f'{step_metadata_0.object_list[0].color} != '
-                f'{step_metadata_1.object_list[0].color}'
+                f'Step 1 {metadata_tier} failed: object_list[0].segment_id '
+                f'{step_metadata_0.object_list[0].segment_id} != '
+                f'{step_metadata_1.object_list[0].segment_id}'
             )
         if (
-            step_metadata_0.object_list[1].color !=
-            step_metadata_1.object_list[1].color
+            step_metadata_0.object_list[1].segment_id !=
+            step_metadata_1.object_list[1].segment_id
         ):
             return (
                 False,
-                f'Step 1 {metadata_tier} failed: object_list[1].color '
-                f'{step_metadata_0.object_list[1].color} != '
-                f'{step_metadata_1.object_list[1].color}'
+                f'Step 1 {metadata_tier} failed: object_list[1].segment_id '
+                f'{step_metadata_0.object_list[1].segment_id} != '
+                f'{step_metadata_1.object_list[1].segment_id}'
             )
 
     # Stop the test scene.

--- a/integration_tests/additional_integration_tests.py
+++ b/integration_tests/additional_integration_tests.py
@@ -65,7 +65,7 @@ def run_depth_and_segmentation_test(controller, metadata_tier):
                 f'Step 1 {metadata_tier} failed: object_mask_list with length '
                 f'{len(step_metadata_0.object_mask_list)} should be length 1'
             )
-    # Verify the consistent segment_id of each object across both steps.
+    # Verify the consistent segment_color of each object across both steps.
     if metadata_tier == 'oracle':
         if (
             step_metadata_0.object_list[0].uuid !=
@@ -88,24 +88,24 @@ def run_depth_and_segmentation_test(controller, metadata_tier):
                 f'{step_metadata_1.object_list[1].uuid}'
             )
         if (
-            step_metadata_0.object_list[0].segment_id !=
-            step_metadata_1.object_list[0].segment_id
+            step_metadata_0.object_list[0].segment_color !=
+            step_metadata_1.object_list[0].segment_color
         ):
             return (
                 False,
-                f'Step 1 {metadata_tier} failed: object_list[0].segment_id '
-                f'{step_metadata_0.object_list[0].segment_id} != '
-                f'{step_metadata_1.object_list[0].segment_id}'
+                f'Step 1 {metadata_tier} failed: object_list[0].segment_color '
+                f'{step_metadata_0.object_list[0].segment_color} != '
+                f'{step_metadata_1.object_list[0].segment_color}'
             )
         if (
-            step_metadata_0.object_list[1].segment_id !=
-            step_metadata_1.object_list[1].segment_id
+            step_metadata_0.object_list[1].segment_color !=
+            step_metadata_1.object_list[1].segment_color
         ):
             return (
                 False,
-                f'Step 1 {metadata_tier} failed: object_list[1].segment_id '
-                f'{step_metadata_0.object_list[1].segment_id} != '
-                f'{step_metadata_1.object_list[1].segment_id}'
+                f'Step 1 {metadata_tier} failed: object_list[1].segment_color '
+                f'{step_metadata_0.object_list[1].segment_color} != '
+                f'{step_metadata_1.object_list[1].segment_color}'
             )
 
     # Stop the test scene.

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -205,7 +205,6 @@ class SceneEvent():
 
         return ObjectMetadata(
             uuid=object_metadata['objectId'],
-            color={'r': rgb[0], 'g': rgb[1], 'b': rgb[2]},
             dimensions=(
                 bounds['objectBoundsCorners']
                 if 'objectBoundsCorners' in bounds
@@ -224,6 +223,7 @@ class SceneEvent():
             material_list=material_list,
             position=object_metadata['position'],
             rotation=object_metadata['rotation'],
+            segment_id={'r': rgb[0], 'g': rgb[1], 'b': rgb[2]},
             shape=object_metadata['shape'],
             state_list=self._scene_config.retrieve_object_states(
                 object_metadata['objectId'],

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -223,7 +223,7 @@ class SceneEvent():
             material_list=material_list,
             position=object_metadata['position'],
             rotation=object_metadata['rotation'],
-            segment_id={'r': rgb[0], 'g': rgb[1], 'b': rgb[2]},
+            segment_color={'r': rgb[0], 'g': rgb[1], 'b': rgb[2]},
             shape=object_metadata['shape'],
             state_list=self._scene_config.retrieve_object_states(
                 object_metadata['objectId'],

--- a/machine_common_sense/object_metadata.py
+++ b/machine_common_sense/object_metadata.py
@@ -40,7 +40,7 @@ class ObjectMetadata(object):
     rotation : dict
         This object's rotation angles around the "x", "y", and "z" axes
         in degrees.
-    segment_id : dict
+    segment_color : dict
         The "r", "g", and "b" pixel values of this object in images from the
         StepMetadata's "object_mask_list".
     shape : string
@@ -71,7 +71,7 @@ class ObjectMetadata(object):
         material_list=None,
         position=None,
         rotation=None,
-        segment_id=None,
+        segment_color=None,
         shape="",
         state_list=None,
         texture_color_list=None,
@@ -90,9 +90,9 @@ class ObjectMetadata(object):
         self.material_list = [] if material_list is None else material_list
         self.position = {} if position is None else position
         self.rotation = {} if rotation is None else rotation
-        self.segment_id = {} \
-            if segment_id is None \
-            else segment_id
+        self.segment_color = {} \
+            if segment_color is None \
+            else segment_color
         self.shape = shape
         self.state_list = [] if state_list is None else state_list
         self.texture_color_list = (
@@ -119,7 +119,7 @@ class ObjectMetadata(object):
         yield 'material_list', self.material_list
         yield 'position', self.position
         yield 'rotation', self.rotation
-        yield 'segment_id', self.segment_id
+        yield 'segment_color', self.segment_color
         yield 'shape', self.shape
         yield 'state_list', self.state_list
         yield 'texture_color_list', self.texture_color_list

--- a/machine_common_sense/object_metadata.py
+++ b/machine_common_sense/object_metadata.py
@@ -9,9 +9,6 @@ class ObjectMetadata(object):
     ----------
     uuid : string
         The unique ID of this object, used with some actions.
-    color : dict
-        The "r", "g", and "b" pixel values of this object in images from the
-        StepMetadata's "object_mask_list".
     dimensions : list of dicts
         The dimensions of this object in the environment's 3D global
         coordinate system as a list of 8 points (dicts with "x", "y", and "z").
@@ -43,6 +40,9 @@ class ObjectMetadata(object):
     rotation : dict
         This object's rotation angles around the "x", "y", and "z" axes
         in degrees.
+    segment_id : dict
+        The "r", "g", and "b" pixel values of this object in images from the
+        StepMetadata's "object_mask_list".
     shape : string
         This object's shape in plain English.
     state_list : list of strings
@@ -61,7 +61,6 @@ class ObjectMetadata(object):
     def __init__(
         self,
         uuid="",
-        color=None,
         dimensions=None,
         direction=None,
         distance=-1.0,
@@ -72,6 +71,7 @@ class ObjectMetadata(object):
         material_list=None,
         position=None,
         rotation=None,
+        segment_id=None,
         shape="",
         state_list=None,
         texture_color_list=None,
@@ -80,7 +80,6 @@ class ObjectMetadata(object):
         openable=False
     ):
         self.uuid = uuid
-        self.color = {} if color is None else color
         self.dimensions = [] if dimensions is None else dimensions
         self.direction = {} if direction is None else direction
         self.distance = distance
@@ -91,6 +90,9 @@ class ObjectMetadata(object):
         self.material_list = [] if material_list is None else material_list
         self.position = {} if position is None else position
         self.rotation = {} if rotation is None else rotation
+        self.segment_id = {} \
+            if segment_id is None \
+            else segment_id
         self.shape = shape
         self.state_list = [] if state_list is None else state_list
         self.texture_color_list = (
@@ -107,7 +109,6 @@ class ObjectMetadata(object):
     #   certain fields to be left out of output file
     def __iter__(self):
         yield 'uuid', self.uuid
-        yield 'color', self.color
         yield 'dimensions', self.dimensions
         yield 'direction', self.direction
         yield 'distance', self.distance
@@ -118,6 +119,7 @@ class ObjectMetadata(object):
         yield 'material_list', self.material_list
         yield 'position', self.position
         yield 'rotation', self.rotation
+        yield 'segment_id', self.segment_id
         yield 'shape', self.shape
         yield 'state_list', self.state_list
         yield 'texture_color_list', self.texture_color_list

--- a/machine_common_sense/serializer.py
+++ b/machine_common_sense/serializer.py
@@ -157,13 +157,13 @@ class SerializerMsgPack(ISerializer):
         elif code == 5:
             uuid, dimensions, direction, distance, distance_in_steps, \
                 distance_in_world, held, mass, material_list, position, \
-                rotation, segment_id, shape, state_list, \
+                rotation, segment_color, shape, state_list, \
                 texture_color_list, visible = msgpack.unpackb(
                     data, ext_hook=SerializerMsgPack._ext_unpack)
             return ObjectMetadata(uuid, dimensions, direction, distance,
                                   distance_in_steps, distance_in_world, held,
                                   mass, material_list, position, rotation,
-                                  segment_id, shape, state_list,
+                                  segment_color, shape, state_list,
                                   texture_color_list, visible)
         elif code == 6:
             x = msgpack.unpackb(data, ext_hook=SerializerMsgPack._ext_unpack)
@@ -265,7 +265,7 @@ class SerializerJson(ISerializer):
                     'material_list': x.material_list,
                     'position': x.position,
                     'rotation': x.rotation,
-                    'segment_id': x.segment_id,
+                    'segment_color': x.segment_color,
                     'shape': x.shape,
                     'state_list': x.state_list,
                     'texture_color_list': x.texture_color_list,
@@ -294,7 +294,7 @@ class SerializerJson(ISerializer):
                 object_raw['material_list'],
                 object_raw['position'],
                 object_raw['rotation'],
-                object_raw['segment_id'],
+                object_raw['segment_color'],
                 object_raw['shape'],
                 object_raw['state_list'],
                 object_raw['texture_color_list'],

--- a/machine_common_sense/serializer.py
+++ b/machine_common_sense/serializer.py
@@ -155,16 +155,16 @@ class SerializerMsgPack(ISerializer):
                                 habituation_total, last_preview_phase_step,
                                 last_step, metadata)
         elif code == 5:
-            uuid, color, dimensions, direction, distance, distance_in_steps, \
+            uuid, dimensions, direction, distance, distance_in_steps, \
                 distance_in_world, held, mass, material_list, position, \
-                rotation, shape, state_list, texture_color_list, \
-                visible = msgpack.unpackb(
+                rotation, segment_id, shape, state_list, \
+                texture_color_list, visible = msgpack.unpackb(
                     data, ext_hook=SerializerMsgPack._ext_unpack)
-            return ObjectMetadata(uuid, color, dimensions, direction, distance,
+            return ObjectMetadata(uuid, dimensions, direction, distance,
                                   distance_in_steps, distance_in_world, held,
                                   mass, material_list, position, rotation,
-                                  shape, state_list, texture_color_list,
-                                  visible)
+                                  segment_id, shape, state_list,
+                                  texture_color_list, visible)
         elif code == 6:
             x = msgpack.unpackb(data, ext_hook=SerializerMsgPack._ext_unpack)
             return np.asarray(x)
@@ -255,7 +255,6 @@ class SerializerJson(ISerializer):
             elif isinstance(x, ObjectMetadata):
                 return {
                     'uuid': x.uuid,
-                    'color': x.color,
                     'dimensions': x.dimensions,
                     'direction': x.direction,
                     'distance': x.distance,
@@ -266,6 +265,7 @@ class SerializerJson(ISerializer):
                     'material_list': x.material_list,
                     'position': x.position,
                     'rotation': x.rotation,
+                    'segment_id': x.segment_id,
                     'shape': x.shape,
                     'state_list': x.state_list,
                     'texture_color_list': x.texture_color_list,
@@ -283,14 +283,22 @@ class SerializerJson(ISerializer):
         object_list = []
         for object_raw in raw_list:
             obj = ObjectMetadata(
-                object_raw['uuid'], object_raw['color'],
-                object_raw['dimensions'], object_raw['direction'],
-                object_raw['distance'], object_raw['distance_in_steps'],
-                object_raw['distance_in_world'], object_raw['held'],
-                object_raw['mass'], object_raw['material_list'],
-                object_raw['position'], object_raw['rotation'],
-                object_raw['shape'], object_raw['state_list'],
-                object_raw['texture_color_list'], object_raw['visible'])
+                object_raw['uuid'],
+                object_raw['dimensions'],
+                object_raw['direction'],
+                object_raw['distance'],
+                object_raw['distance_in_steps'],
+                object_raw['distance_in_world'],
+                object_raw['held'],
+                object_raw['mass'],
+                object_raw['material_list'],
+                object_raw['position'],
+                object_raw['rotation'],
+                object_raw['segment_id'],
+                object_raw['shape'],
+                object_raw['state_list'],
+                object_raw['texture_color_list'],
+                object_raw['visible'])
             object_list.append(obj)
         return object_list
 

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -508,7 +508,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(len(actual.object_list), 1)
         self.assertEqual(actual.object_list[0].uuid, "testId")
-        self.assertEqual(actual.object_list[0].color, {
+        self.assertEqual(actual.object_list[0].segment_id, {
             "r": 12,
             "g": 34,
             "b": 56
@@ -540,7 +540,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(len(actual.structural_object_list), 1)
         self.assertEqual(actual.structural_object_list[0].uuid, "testWallId")
-        self.assertEqual(actual.structural_object_list[0].color, {
+        self.assertEqual(actual.structural_object_list[0].segment_id, {
             "r": 101,
             "g": 102,
             "b": 103
@@ -917,7 +917,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual), 2)
 
         self.assertEqual(actual[0].uuid, "testId1")
-        self.assertEqual(actual[0].color, {
+        self.assertEqual(actual[0].segment_id, {
             "r": 12,
             "g": 34,
             "b": 56
@@ -942,7 +942,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(actual[0].visible, True)
 
         self.assertEqual(actual[1].uuid, "testId2")
-        self.assertEqual(actual[1].color, {
+        self.assertEqual(actual[1].segment_id, {
             "r": 98,
             "g": 76,
             "b": 54
@@ -1014,7 +1014,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual), 3)
 
         self.assertEqual(actual[0].uuid, "testId1")
-        self.assertEqual(actual[0].color, {
+        self.assertEqual(actual[0].segment_id, {
             "r": 12,
             "g": 34,
             "b": 56
@@ -1039,7 +1039,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(actual[0].visible, True)
 
         self.assertEqual(actual[1].uuid, "testId2")
-        self.assertEqual(actual[1].color, {
+        self.assertEqual(actual[1].segment_id, {
             "r": 98,
             "g": 76,
             "b": 54
@@ -1066,7 +1066,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(actual[1].visible, True)
 
         self.assertEqual(actual[2].uuid, "testId3")
-        self.assertEqual(actual[2].color, {
+        self.assertEqual(actual[2].segment_id, {
             "r": 101,
             "g": 102,
             "b": 103

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -508,7 +508,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(len(actual.object_list), 1)
         self.assertEqual(actual.object_list[0].uuid, "testId")
-        self.assertEqual(actual.object_list[0].segment_id, {
+        self.assertEqual(actual.object_list[0].segment_color, {
             "r": 12,
             "g": 34,
             "b": 56
@@ -540,7 +540,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(len(actual.structural_object_list), 1)
         self.assertEqual(actual.structural_object_list[0].uuid, "testWallId")
-        self.assertEqual(actual.structural_object_list[0].segment_id, {
+        self.assertEqual(actual.structural_object_list[0].segment_color, {
             "r": 101,
             "g": 102,
             "b": 103
@@ -917,7 +917,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual), 2)
 
         self.assertEqual(actual[0].uuid, "testId1")
-        self.assertEqual(actual[0].segment_id, {
+        self.assertEqual(actual[0].segment_color, {
             "r": 12,
             "g": 34,
             "b": 56
@@ -942,7 +942,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(actual[0].visible, True)
 
         self.assertEqual(actual[1].uuid, "testId2")
-        self.assertEqual(actual[1].segment_id, {
+        self.assertEqual(actual[1].segment_color, {
             "r": 98,
             "g": 76,
             "b": 54
@@ -1014,7 +1014,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual), 3)
 
         self.assertEqual(actual[0].uuid, "testId1")
-        self.assertEqual(actual[0].segment_id, {
+        self.assertEqual(actual[0].segment_color, {
             "r": 12,
             "g": 34,
             "b": 56
@@ -1039,7 +1039,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(actual[0].visible, True)
 
         self.assertEqual(actual[1].uuid, "testId2")
-        self.assertEqual(actual[1].segment_id, {
+        self.assertEqual(actual[1].segment_color, {
             "r": 98,
             "g": 76,
             "b": 54
@@ -1066,7 +1066,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(actual[1].visible, True)
 
         self.assertEqual(actual[2].uuid, "testId3")
-        self.assertEqual(actual[2].segment_id, {
+        self.assertEqual(actual[2].segment_color, {
             "r": 101,
             "g": 102,
             "b": 103

--- a/tests/test_object_metadata.py
+++ b/tests/test_object_metadata.py
@@ -18,7 +18,7 @@ class TestObjectMetadata(unittest.TestCase):
         "material_list": [],
         "position": {},
         "rotation": {},
-        "segment_id": {},
+        "segment_color": {},
         "shape": "",
         "state_list": [],
         "texture_color_list": [],
@@ -80,9 +80,9 @@ class TestObjectMetadata(unittest.TestCase):
         self.assertFalse(self.object_metadata.rotation)
         self.assertIsInstance(self.object_metadata.rotation, dict)
 
-    def test_segment_id(self):
-        self.assertFalse(self.object_metadata.segment_id)
-        self.assertIsInstance(self.object_metadata.segment_id, dict)
+    def test_segment_color(self):
+        self.assertFalse(self.object_metadata.segment_color)
+        self.assertIsInstance(self.object_metadata.segment_color, dict)
 
     def test_shape(self):
         self.assertEqual(self.object_metadata.shape, "")

--- a/tests/test_object_metadata.py
+++ b/tests/test_object_metadata.py
@@ -8,7 +8,6 @@ class TestObjectMetadata(unittest.TestCase):
 
     str_output = '''    {
         "uuid": "",
-        "color": {},
         "dimensions": [],
         "direction": {},
         "distance": -1.0,
@@ -19,6 +18,7 @@ class TestObjectMetadata(unittest.TestCase):
         "material_list": [],
         "position": {},
         "rotation": {},
+        "segment_id": {},
         "shape": "",
         "state_list": [],
         "texture_color_list": [],
@@ -39,10 +39,6 @@ class TestObjectMetadata(unittest.TestCase):
     def test_uuid(self):
         self.assertEqual(self.object_metadata.uuid, "")
         self.assertIsInstance(self.object_metadata.uuid, str)
-
-    def test_color(self):
-        self.assertFalse(self.object_metadata.color)
-        self.assertIsInstance(self.object_metadata.color, dict)
 
     def test_dimensions(self):
         self.assertFalse(self.object_metadata.dimensions)
@@ -83,6 +79,10 @@ class TestObjectMetadata(unittest.TestCase):
     def test_rotation(self):
         self.assertFalse(self.object_metadata.rotation)
         self.assertIsInstance(self.object_metadata.rotation, dict)
+
+    def test_segment_id(self):
+        self.assertFalse(self.object_metadata.segment_id)
+        self.assertIsInstance(self.object_metadata.segment_id, dict)
 
     def test_shape(self):
         self.assertEqual(self.object_metadata.shape, "")

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -38,7 +38,7 @@ class TestSerializer(unittest.TestCase):
         self.assertAlmostEqual(unpacked_metadata.rotation, 0.0, delta=1e-04)
         self.assertIsInstance(unpacked_metadata.object_list[-1].shape, str)
         self.assertIsInstance(
-            unpacked_metadata.object_list[0].segment_id, dict)
+            unpacked_metadata.object_list[0].segment_color, dict)
 
 
 if __name__ == '__main__':

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -37,6 +37,8 @@ class TestSerializer(unittest.TestCase):
         self.assertAlmostEqual(unpacked_metadata.reward, -0.036000000000000004)
         self.assertAlmostEqual(unpacked_metadata.rotation, 0.0, delta=1e-04)
         self.assertIsInstance(unpacked_metadata.object_list[-1].shape, str)
+        self.assertIsInstance(
+            unpacked_metadata.object_list[0].segment_id, dict)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Simply renaming 'color' to 'segment_id' in ObjectMetadata. Contrasts with other branch/PR which moves segmentation color to higher level StepMetadata.