### PR TITLE
Mcs 909 write target visibility

### DIFF
--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -32,7 +32,7 @@ class HistoryEventHandler(AbstractControllerSubscriber):
             ] = payload.config.get_evaluation_name()
             hist_info[
                 payload.config.CONFIG_METADATA_TIER
-            ] = payload.config.get_metadata_tier()
+            ] = payload.config.get_metadata_tier().value
             hist_info[
                 payload.config.CONFIG_TEAM
             ] = payload.config.get_team()

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -63,8 +63,8 @@ class HistoryEventHandler(AbstractControllerSubscriber):
 
     def on_end_scene(self, payload):
         if (
-                self.__history_writer is not None and
-                payload.config.is_history_enabled()
+            self.__history_writer is not None and
+            payload.config.is_history_enabled()
         ):
             self.__history_writer.add_step(self.__history_item)
 

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -63,8 +63,8 @@ class HistoryEventHandler(AbstractControllerSubscriber):
 
     def on_end_scene(self, payload):
         if (
-            self.__history_writer is not None and
-            payload.config.is_history_enabled()
+                self.__history_writer is not None and
+                payload.config.is_history_enabled()
         ):
             self.__history_writer.add_step(self.__history_item)
 
@@ -73,11 +73,12 @@ class HistoryEventHandler(AbstractControllerSubscriber):
                 for step in self.__history_writer.current_steps:
                     currentStep = step.get("step")
 
-                    findStepInReport = (payload.report.get(
-                        currentStep) or
-                        payload.report.get(str(currentStep)))
+                    findStepInReport = (
+                        payload.report.get(currentStep) or
+                        payload.report.get(str(currentStep))
+                    )
 
-                    if(findStepInReport is not None):
+                    if (findStepInReport is not None):
                         # Use classification and confidence rather than rating
                         # and score to be compatible with old history files.
                         step["classification"] = findStepInReport.get("rating")
@@ -95,7 +96,6 @@ class HistoryEventHandler(AbstractControllerSubscriber):
 
 
 class HistoryWriter(object):
-
     HISTORY_DIRECTORY = "SCENE_HISTORY"
 
     def __init__(self, scene_config_data=None, hist_info={}, timestamp=''):
@@ -146,9 +146,9 @@ class HistoryWriter(object):
             targets = ['target', 'target_1', 'target2']
             for target in targets:
                 if (
-                    target in history.output.goal.metadata.keys() and
-                    history.output.goal.metadata[target].get('image', None)
-                    is not None
+                        target in history.output.goal.metadata.keys() and
+                        history.output.goal.metadata[target].get('image', None)
+                        is not None
                 ):
                     del history.output.goal.metadata[target]['image']
         return history
@@ -162,11 +162,12 @@ class HistoryWriter(object):
         """Add a new step to the array of history steps"""
         current_time = perf_counter() * 1000
         if step_obj is not None:
-            step_obj.delta_time_millis = current_time - \
-                self.last_step_time_millis
+            step_obj.delta_time_millis = \
+                current_time - self.last_step_time_millis
             self.last_step_time_millis = current_time
             if step_obj.output:
-                step_obj.output.target_visible = self.is_target_visible(step_obj)
+                step_obj.output.target_visible = \
+                    self.is_target_visible(step_obj)
             logger.debug("Adding history step")
             self.current_steps.append(
                 dict(self.filter_history_output(step_obj)))
@@ -183,7 +184,7 @@ class HistoryWriter(object):
                 if uuid == goal_id and hist_obj.visible:
                     return True
             return False
-        except Exception as e:
+        except Exception:
             return False
 
     def write_history_file(self, rating, score):
@@ -199,8 +200,6 @@ class HistoryWriter(object):
         self.history_obj["score"] = self.end_score
 
         self.write_file()
-
-
 
     def check_file_written(self):
         """ Will check to see if the file has been written, if not,

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -146,9 +146,9 @@ class HistoryWriter(object):
             targets = ['target', 'target_1', 'target2']
             for target in targets:
                 if (
-                        target in history.output.goal.metadata.keys() and
-                        history.output.goal.metadata[target].get('image', None)
-                        is not None
+                    target in history.output.goal.metadata.keys() and
+                    history.output.goal.metadata[target].get('image', None)
+                    is not None
                 ):
                     del history.output.goal.metadata[target]['image']
         return history

--- a/machine_common_sense/scene_history.py
+++ b/machine_common_sense/scene_history.py
@@ -17,7 +17,8 @@ class SceneHistory(object):
         violations_xy_list: List[Dict[str, float]] = None,
         internal_state: object = None,
         delta_time_millis=0,
-        output=None
+        output=None,
+        target_visible=False
 
     ):
         self.step = step
@@ -30,6 +31,7 @@ class SceneHistory(object):
         self.internal_state = internal_state
         self.delta_time_millis = delta_time_millis
         self.output = output
+        self.target_visible = target_visible
 
     def __str__(self):
         return Stringifier.class_to_str(self)
@@ -48,3 +50,4 @@ class SceneHistory(object):
         yield 'output', dict(self.output) if(
             self.output) is not None else self.output
         yield 'delta_time_millis', self.delta_time_millis
+        yield 'target_visible', self.target_visible

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -143,8 +143,7 @@ class StepMetadata:
         reward=0,
         rotation=0.0,
         step_number=0,
-        structural_object_list=None,
-        target_visible=False
+        structural_object_list=None
     ):
         self.action_list = [] if action_list is None else action_list
         self.camera_aspect_ratio = (
@@ -178,7 +177,6 @@ class StepMetadata:
         self.step_number = step_number
         self.structural_object_list = [
         ] if structural_object_list is None else structural_object_list
-        self.target_visible = target_visible
 
     def __str__(self):
         return Stringifier.class_to_str(self)
@@ -187,7 +185,7 @@ class StepMetadata:
         if obj_list is None:
             return None
         else:
-            return dict((obj.uuid, dict(obj)) for obj in obj_list)
+            return {obj.uuid: dict(obj) for obj in obj_list}
 
     def copy_without_depth_or_images(self):
         """Return a deep copy of this StepMetadata with default depth_map_list,
@@ -220,4 +218,3 @@ class StepMetadata:
         yield 'step_number', self.step_number
         yield 'structural_object_list', self.check_list_none(
             self.structural_object_list)
-        yield 'target_visible', self.target_visible

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -16,12 +16,10 @@ class StepMetadata:
         The list of all actions that are available for the next step.
         Each action is returned as a tuple containing the action string and
         the action's restricted parameters, if any.
-
         For example: ("Pass", {}) forces a Pass action; ("PickupObject", {})
         forces a PickupObject action with any parameters; and
         ("PickupObject", {"objectId": "a"}) forces a PickupObject action with
         the specific parameters objectId=a.
-
         An action_list of None or an empty list means that all actions will
         be available for the next step.
 
@@ -145,7 +143,8 @@ class StepMetadata:
         reward=0,
         rotation=0.0,
         step_number=0,
-        structural_object_list=None
+        structural_object_list=None,
+        target_visible=False
     ):
         self.action_list = [] if action_list is None else action_list
         self.camera_aspect_ratio = (
@@ -179,6 +178,7 @@ class StepMetadata:
         self.step_number = step_number
         self.structural_object_list = [
         ] if structural_object_list is None else structural_object_list
+        self.target_visible = target_visible
 
     def __str__(self):
         return Stringifier.class_to_str(self)
@@ -220,3 +220,4 @@ class StepMetadata:
         yield 'step_number', self.step_number
         yield 'structural_object_list', self.check_list_none(
             self.structural_object_list)
+        yield 'target_visible', self.target_visible

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -37,7 +37,8 @@ class TestStepMetadata(unittest.TestCase):
         "reward": 0,
         "rotation": 0.0,
         "step_number": 0,
-        "structural_object_list": []
+        "structural_object_list": [],
+        "target_visible": false
     }'''
 
     str_output_segment_map_ints = '''    {
@@ -71,6 +72,7 @@ class TestStepMetadata(unittest.TestCase):
         "rotation": 0.0,
         "step_number": 0,
         "structural_object_list": [],
+        "target_visible": false,
         "segment_map": {
             "0": {
                 "r": 218,
@@ -215,7 +217,8 @@ class TestStepMetadata(unittest.TestCase):
             structural_object_list=[
                 mcs.ObjectMetadata(uuid='structure_1'),
                 mcs.ObjectMetadata(uuid='structure_2')
-            ]
+            ],
+            target_visible=False
         )
         copy = data.copy_without_depth_or_images()
         # Assert are exactly equal

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -37,8 +37,7 @@ class TestStepMetadata(unittest.TestCase):
         "reward": 0,
         "rotation": 0.0,
         "step_number": 0,
-        "structural_object_list": [],
-        "target_visible": false
+        "structural_object_list": []
     }'''
 
     str_output_segment_map_ints = '''    {
@@ -72,7 +71,6 @@ class TestStepMetadata(unittest.TestCase):
         "rotation": 0.0,
         "step_number": 0,
         "structural_object_list": [],
-        "target_visible": false,
         "segment_map": {
             "0": {
                 "r": 218,
@@ -217,8 +215,7 @@ class TestStepMetadata(unittest.TestCase):
             structural_object_list=[
                 mcs.ObjectMetadata(uuid='structure_1'),
                 mcs.ObjectMetadata(uuid='structure_2')
-            ],
-            target_visible=False
+            ]
         )
         copy = data.copy_without_depth_or_images()
         # Assert are exactly equal


### PR DESCRIPTION
For one of the scorecard values, we need to know whether or not the target is visible.  Add this to the step metadata output.  This means a change to the step metadata object, _init__, and __iter__, and associated unit test.   

The determination of whether or not the target is visible is done in history_writer.  It's not clear that this is the right place for the logic, but there are other manipulations for of the step metadata and it was the easiest place to put it.  