### PR TITLE
MCS-1005-Update-OpenCV-Python-version

### DIFF
--- a/.github/workflows/development-merge.yaml
+++ b/.github/workflows/development-merge.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-versions: [3.6, 3.7, 3.8]
+        python-versions: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ matplotlib==3.3.2
 msgpack==1.0.0
 numpy==1.19.4
 numpyencoder==0.3.0
-opencv-python==4.4.0.44
+opencv-python==4.4.0.46
 pre-commit==2.12.1
 recommonmark==0.6.0
 requests==2.24.0


### PR DESCRIPTION
Jira link: https://nextcentury.atlassian.net/browse/MCS-1005

Update requirements.txt and development-merge.yml to allow Python 3.9. 