### PR TITLE
MCS-1005-Bumping versions of scikit-image and numpy for python 3.9 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ isort==5.8.0
 marshmallow==3.12.1
 matplotlib==3.3.2
 msgpack==1.0.0
-numpy==1.21.2
+numpy==1.19.5
 numpyencoder==0.3.0
 opencv-python==4.4.0.46
 pre-commit==2.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ opencv-python==4.4.0.46
 pre-commit==2.12.1
 recommonmark==0.6.0
 requests==2.24.0
-scikit-image==0.18.2
+scikit-image==0.18.0rc1
 Shapely==1.7.1
 Sphinx==3.2.1
 sphinxcontrib-websupport==1.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,13 @@ isort==5.8.0
 marshmallow==3.12.1
 matplotlib==3.3.2
 msgpack==1.0.0
-numpy==1.19.4
+numpy==1.21.2
 numpyencoder==0.3.0
 opencv-python==4.4.0.46
 pre-commit==2.12.1
 recommonmark==0.6.0
 requests==2.24.0
-scikit-image==0.17.2
+scikit-image==0.18.2
 Shapely==1.7.1
 Sphinx==3.2.1
 sphinxcontrib-websupport==1.2.4


### PR DESCRIPTION
In addition to the changes in the [last pull request](https://github.com/NextCenturyCorporation/MCS/pull/430/files), we also need also upgrade scikit-image and numpy for this merge to build properly. 