### PR TITLE
Added trace logging level.  Added call to init_logging such that it s…

### DIFF
--- a/machine_common_sense/logging_config.py
+++ b/machine_common_sense/logging_config.py
@@ -217,4 +217,4 @@ class LoggingConfig():
 
 # Call init logging early with no config to ensure it is called.  Logging
 # config can always be overwritten any time MCS is used.
-LoggingConfig.init_logging(LoggingConfig.get_no_logging_config())
+LoggingConfig.init_logging(LoggingConfig.get_errors_only_console_config())

--- a/machine_common_sense/logging_config.py
+++ b/machine_common_sense/logging_config.py
@@ -43,6 +43,8 @@ import os
 
 logger = logging.getLogger(__name__)
 
+TRACE = 5
+
 
 class LoggingConfig():
 
@@ -84,6 +86,7 @@ class LoggingConfig():
         If user file doesn't exist, then there is a base config that
         should be read.
         """
+        LoggingConfig._add_trace()
         init_message = ""
         if (os.path.exists(log_config_file)):
             with open(log_config_file, "r") as data:
@@ -99,6 +102,15 @@ class LoggingConfig():
             os.mkdir("logs")
         logging.config.dictConfig(log_config)
         logger.info(init_message)
+
+    @staticmethod
+    def _add_trace():
+        logging.addLevelName(TRACE, "TRACE")
+
+        def trace(self, message, *args, **kws):
+            if self.isEnabledFor(TRACE):
+                self._log(TRACE, message, args, **kws)
+        logging.Logger.trace = trace
 
     @staticmethod
     def get_default_console_config():
@@ -133,6 +145,14 @@ class LoggingConfig():
                     "format": "%(message)s"
                 }
             }
+        }
+
+    @staticmethod
+    def get_no_logging_config():
+        return {
+            "version": 1,
+            "loggers": {},
+            "handlers": {}
         }
 
     @staticmethod
@@ -193,3 +213,8 @@ class LoggingConfig():
                 }
             }
         }
+
+
+# Call init logging early with no config to ensure it is called.  Logging
+# config can always be overwritten any time MCS is used.
+LoggingConfig.init_logging(LoggingConfig.get_no_logging_config())


### PR DESCRIPTION
To test backup init_logging:

- Run your favorite entry point  (I.E. 'run_human_input.py') and verify default logging
- Remove init_logging from your favorite entry point (be sure to revert this when you are done)
- Run your favorite entry point and verify no logging (besides print statements. Note: run_human_input has a lot of print statements which will circumvent logging configurations.)
- Create a 'log.config.user.py' file in your working directory and add a config (copy and modify from 'Logging_config.py').  I recommend adding a prefix string to the format like this: '"format": "TEST%(message)s"' to make it obvious when this file is used.
- Run your favorite entry point.  Verify your logging works. 
- Remove or rename 'log.config.user.py' so it doesn't get used continuously

To test trace:
- add a logger.trace("message") somewhere
- Run and verify no message (assuming default logging config)
- add a 'log.config.user.py' file that supports trace logging
- Run and verify your log message now appears
- Remove or rename 'log.config.user.py' so it doesn't get used continuously

Here is an override 'log.config.user.py' file that I used:
`
{
    "version": 1,
    "root": {
        "level": "TRACE",
        "handlers": ["console"],
        "propagate": False
    },
    "loggers": {
        "machine_common_sense": {
            "level": "TRACE",
            "handlers": ["console"],
            "propagate": False
        }
    },
    "handlers": {
        "console": {
            "class": "logging.StreamHandler",
            "formatter": "brief",
            "level": "TRACE",
            "stream": "ext://sys.stdout"
        }
    },
    "formatters": {
        "brief": {
            "format": "TEST%(message)s"
        }
    }
}
`