### PR TITLE
Adding support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Mac and Ubuntu Python 3.6 Unit Tests 
+name: Mac/Ubuntu Python 3.6 Unit Tests 
 
 on:
   push:

--- a/.github/workflows/development-merge.yaml
+++ b/.github/workflows/development-merge.yaml
@@ -1,4 +1,4 @@
-name: Mac and Ubuntu Python 3.6, 3.7 and 3.8 Unit Tests
+name: Mac/Ubuntu Python 3.6-3.10 Unit Tests
 
 on:
   push:
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-versions: [3.6, 3.7, 3.8, 3.9]
+        python-versions: [3.6, 3.7, 3.8, 3.9, 3.10]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .venv
 env
 venv
+venv*
 ENV/
 env.bak/
 venv.bak/

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,14 @@ isort==5.8.0
 marshmallow==3.12.1
 matplotlib==3.3.3
 msgpack==1.0.0
-numpy==1.19.5
 numpyencoder==0.3.0
-opencv-python==4.4.0.46
+opencv-python==4.4.0.46; python_version<="3.9"
+opencv-python==4.5.4.60; python_version>="3.10"
 pre-commit==2.12.1
 recommonmark==0.6.0
 requests==2.24.0
-scikit-image==0.18.0rc1
+scikit-image==0.18.3; python_version>="3.7"
+scikit-image==0.17.2; python_version=="3.6"
 Shapely==1.7.1
 Sphinx==3.2.1
 sphinxcontrib-websupport==1.2.4

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
@@ -46,7 +47,7 @@ setuptools.setup(
         'Typing :: Typed'
     ],
     license='Apache-2',
-    python_requires=">3.6, <3.10",
+    python_requires=">3.6",
     packages=setuptools.find_packages(),
     package_data={'': ['*.ini'], },
     install_requires=[


### PR DESCRIPTION
Package dependencies all install properly. Integration tests pass. Unit tests pass albeit with numpy deprecation warnings with our new numpy-aware serialization.

(mcs-p310) MCS $ python -m unittest
............................................................................................................/home/dwetherby/workspace/MCS/tests/test_history_writer.py:242: DeprecationWarning: np.int is a deprecated alias for the builtin int. To silence this warning, use int by itself. Doing this will not modify any behavior and is safe. When replacing np.int, you may wish to use e.g. np.int64 or np.int32 to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: NumPy 1.20.0 Release Notes — NumPy v1.23.dev0 Manual 