### PR TITLE
Run specific additional integration test

### DIFF
--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -324,7 +324,8 @@ def start_handmade_tests(
         # Run each additional test at this metadata tier.
         for runner_function in (
                 [func for func in FUNCTION_LIST
-                 if only_test_name in str(func)]):
+                 if only_test_name is None or
+                 only_test_name in str(func)]):
             print(f'RUNNING TESTS: {runner_function.__name__}')
             successful, status = runner_function(controller, metadata_tier)
             test_name = runner_function.__name__

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -323,7 +323,8 @@ def start_handmade_tests(
                 failed_test_list.append((test_name, metadata_tier, status))
         # Run each additional test at this metadata tier.
         for runner_function in (
-                [] if only_test_name else FUNCTION_LIST):
+                [func for func in FUNCTION_LIST
+                 if only_test_name in str(func)]):
             print(f'RUNNING TESTS: {runner_function.__name__}')
             successful, status = runner_function(controller, metadata_tier)
             test_name = runner_function.__name__


### PR DESCRIPTION
Uses `only_test_name` to search FUNCTION_LIST in additional tests such as "depth_and_segmentation" or just "depth" for that matter. Allows developers to target these tests as well as the numbered tests.