### PR TITLE
Two ways of importing getch module

### DIFF
--- a/machine_common_sense/scripts/run_human_input.py
+++ b/machine_common_sense/scripts/run_human_input.py
@@ -5,7 +5,10 @@ import machine_common_sense as mcs
 from machine_common_sense.goal_metadata import GoalMetadata
 from machine_common_sense.logging_config import LoggingConfig
 
-from .getch_helper import getch
+try:
+    from getch_helper import getch
+except ImportError:
+    from .getch_helper import getch  # noqa: F401
 
 commands = []
 
@@ -164,7 +167,7 @@ class HumanInputShell(cmd.Cmd):
             action.key for action in mcs.Action]
 
         while True:
-            char = getch.__call__()
+            char = mcs.getch.__call__()
             print('\n(shortcut-command)->', char)
             if char == 'e':  # exit shortcut key mode
                 break

--- a/machine_common_sense/scripts/run_human_input.py
+++ b/machine_common_sense/scripts/run_human_input.py
@@ -167,7 +167,7 @@ class HumanInputShell(cmd.Cmd):
             action.key for action in mcs.Action]
 
         while True:
-            char = mcs.getch.__call__()
+            char = getch.__call__()
             print('\n(shortcut-command)->', char)
             if char == 'e':  # exit shortcut key mode
                 break


### PR DESCRIPTION
Adding getch to the MCS package init places that module within the auto-documentation path which I am not in favor of. The best way to handle this in my opinion is with try/except ImportError.