### PR TITLE
MCS-1071 - bug fix for files being deleted incorrectly with --saveVideo flag enabled

### DIFF
--- a/docs/source/scenes/container_open_close.json
+++ b/docs/source/scenes/container_open_close.json
@@ -1,4 +1,5 @@
 {
+    "name": "container_open_close",
     "version": 2,
     "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
     "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",

--- a/docs/source/scenes/playroom.json
+++ b/docs/source/scenes/playroom.json
@@ -1,4 +1,5 @@
 {
+    "name": "playroom",
     "version": 2,
     "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
     "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -168,8 +168,11 @@ class Controller():
         skip_preview_phase = (scene_config.goal is not None and
                               scene_config.goal.skip_preview_phase)
 
-        if (self._scene_config.name is not None and
-                self._config.is_file_writing_enabled()):
+        if (not self._scene_config.name):
+            raise Exception('The `name` field in the scene ' +
+                            'file cannot be empty.')
+
+        if (self._config.is_file_writing_enabled()):
             os.makedirs('./' + scene_config.name, exist_ok=True)
             self.__output_folder = './' + scene_config.name + '/'
             file_list = glob.glob(self.__output_folder + '*')


### PR DESCRIPTION
Hopefully my explanation makes sense: There was a weird edge case where we were deleting/attempting to delete all files within the directory from which a run is attempted. 

This ended up being an issue with not being able to determine a scene name -- generally, if we're saving debug files, we delete all the old local versions of debug files if we're running a scene multiple times so we can save the new versions without issue, and we look for those files in a directory like `./(scene_name)`. In this case, the scene file had no scene name and the code couldn't parse it properly from the path given, so it was blank, and therefore a delete was attempted in the current directory (in this case, machine_common_sense/scripts). I added a `name` for the problematic scenes in the docs and decided to throw an exception if a name does not exist for a scene.