### PR TITLE
MCS-933 Updates to action_list

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -431,7 +431,7 @@ class TestController(unittest.TestCase):
         )
         self.assertEqual(
             output.action_list,
-            GoalMetadata.ACTION_LIST)
+            GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(output.return_status,
                          MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, 0)
@@ -451,7 +451,7 @@ class TestController(unittest.TestCase):
         self.assertIsNotNone(output)
         self.assertEqual(
             output.action_list,
-            GoalMetadata.ACTION_LIST)
+            GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(output.return_status,
                          MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, 0)
@@ -477,7 +477,7 @@ class TestController(unittest.TestCase):
         self.assertIsNotNone(output)
         self.assertEqual(
             output.action_list,
-            GoalMetadata.ACTION_LIST)
+            GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(output.return_status,
                          MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, -0.005)
@@ -509,7 +509,7 @@ class TestController(unittest.TestCase):
         self.assertIsNotNone(output)
         self.assertEqual(
             output.action_list,
-            GoalMetadata.ACTION_LIST)
+            GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(output.return_status,
                          MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, -0.001)
@@ -529,7 +529,7 @@ class TestController(unittest.TestCase):
         self.assertIsNotNone(output)
         self.assertEqual(
             output.action_list,
-            GoalMetadata.ACTION_LIST)
+            GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(output.return_status,
                          MOCK_VARIABLES['metadata']['lastActionStatus'])
         self.assertEqual(output.reward, -0.002)
@@ -587,7 +587,7 @@ class TestController(unittest.TestCase):
                 mcs.GoalMetadata(),
                 0
             ),
-            GoalMetadata.ACTION_LIST
+            GoalMetadata.DEFAULT_ACTIONS
         )
         # With empty action list
         self.assertEqual(
@@ -595,7 +595,7 @@ class TestController(unittest.TestCase):
                 mcs.GoalMetadata(action_list=[]),
                 0
             ),
-            GoalMetadata.ACTION_LIST
+            GoalMetadata.DEFAULT_ACTIONS
         )
         # With empty nested action list
         self.assertEqual(
@@ -603,7 +603,7 @@ class TestController(unittest.TestCase):
                 mcs.GoalMetadata(action_list=[[]]),
                 0
             ),
-            GoalMetadata.ACTION_LIST
+            GoalMetadata.DEFAULT_ACTIONS
         )
         # With test action list
         self.assertEqual(
@@ -619,7 +619,7 @@ class TestController(unittest.TestCase):
                 mcs.GoalMetadata(action_list=[test_action_list]),
                 1
             ),
-            GoalMetadata.ACTION_LIST
+            GoalMetadata.DEFAULT_ACTIONS
         )
         # With incorrect index
         self.assertEqual(
@@ -627,7 +627,7 @@ class TestController(unittest.TestCase):
                 mcs.GoalMetadata(action_list=[test_action_list, []]),
                 1
             ),
-            GoalMetadata.ACTION_LIST
+            GoalMetadata.DEFAULT_ACTIONS
         )
         # With incorrect index
         self.assertEqual(
@@ -635,7 +635,7 @@ class TestController(unittest.TestCase):
                 mcs.GoalMetadata(action_list=[[], test_action_list]),
                 0
             ),
-            GoalMetadata.ACTION_LIST
+            GoalMetadata.DEFAULT_ACTIONS
         )
         # With correct index
         self.assertEqual(

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -454,7 +454,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         coh.set_scene_config(SceneConfiguration((mock_scene_event_data)))
         (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
 
-        self.assertEqual(actual.action_list, GoalMetadata.ACTION_LIST)
+        self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 15))
         self.assertEqual(actual.camera_field_of_view, 42.5)
@@ -571,7 +571,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         coh.set_scene_config(SceneConfiguration((mock_scene_event_data)))
         (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
 
-        self.assertEqual(actual.action_list, GoalMetadata.ACTION_LIST)
+        self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 15))
         self.assertEqual(actual.camera_field_of_view, 42.5)
@@ -620,7 +620,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         coh.set_scene_config(SceneConfiguration((mock_scene_event_data)))
         (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
 
-        self.assertEqual(actual.action_list, GoalMetadata.ACTION_LIST)
+        self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 15))
         self.assertEqual(actual.camera_field_of_view, 42.5)
@@ -658,7 +658,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         coh.set_scene_config(SceneConfiguration((mock_scene_event_data)))
         (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
 
-        self.assertEqual(actual.action_list, GoalMetadata.ACTION_LIST)
+        self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 15))
         self.assertEqual(actual.camera_field_of_view, 42.5)
@@ -697,7 +697,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         coh.set_scene_config(SceneConfiguration((mock_scene_event_data)))
         (actual, res) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
 
-        self.assertEqual(actual.action_list, GoalMetadata.ACTION_LIST)
+        self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 15))
         self.assertEqual(actual.camera_field_of_view, 42.5)
@@ -745,7 +745,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         coh.set_scene_config(SceneConfiguration((mock_scene_event_data)))
         (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
 
-        self.assertEqual(actual.action_list, GoalMetadata.ACTION_LIST)
+        self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 15))
         self.assertEqual(actual.camera_field_of_view, 42.5)

--- a/tests/test_goal_metadata.py
+++ b/tests/test_goal_metadata.py
@@ -48,6 +48,108 @@ class TestGoalMetadata(unittest.TestCase):
         self.assertFalse(self.goal_metadata.metadata)
         self.assertIsInstance(self.goal_metadata.metadata, dict)
 
+    def test_retrieve_action_list_at_step(self):
+        self.assertEqual(self.goal_metadata.retrieve_action_list_at_step(0), [
+            ('CloseObject', {}),
+            ('DropObject', {}),
+            ('MoveAhead', {}),
+            ('MoveBack', {}),
+            ('MoveLeft', {}),
+            ('MoveRight', {}),
+            ('OpenObject', {}),
+            ('PickupObject', {}),
+            ('PullObject', {}),
+            ('PushObject', {}),
+            ('PutObject', {}),
+            ('LookUp', {}),
+            ('LookDown', {}),
+            ('RotateLeft', {}),
+            ('RotateRight', {}),
+            ('Pass', {})
+        ])
+        self.assertEqual(self.goal_metadata.retrieve_action_list_at_step(10), [
+            ('CloseObject', {}),
+            ('DropObject', {}),
+            ('MoveAhead', {}),
+            ('MoveBack', {}),
+            ('MoveLeft', {}),
+            ('MoveRight', {}),
+            ('OpenObject', {}),
+            ('PickupObject', {}),
+            ('PullObject', {}),
+            ('PushObject', {}),
+            ('PutObject', {}),
+            ('LookUp', {}),
+            ('LookDown', {}),
+            ('RotateLeft', {}),
+            ('RotateRight', {}),
+            ('Pass', {})
+        ])
+
+    def test_retrieve_action_list_at_step_with_custom_action_list(self):
+        goal_metadata = mcs.GoalMetadata(action_list=[
+            ['Pass'],
+            ['LookDown','LookUp','RotateLeft','RotateRight','Pass'],
+            [],
+            ['EndHabituation,xPosition=0,zPosition=0,yRotation=90'],
+            [('PickupObject', {'objectId': 'target'})]
+        ])
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(0), [
+            ('Pass', {})
+        ])
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(1), [
+            ('LookDown', {}),
+            ('LookUp', {}),
+            ('RotateLeft', {}),
+            ('RotateRight', {}),
+            ('Pass', {})
+        ])
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(2), [
+            ('CloseObject', {}),
+            ('DropObject', {}),
+            ('MoveAhead', {}),
+            ('MoveBack', {}),
+            ('MoveLeft', {}),
+            ('MoveRight', {}),
+            ('OpenObject', {}),
+            ('PickupObject', {}),
+            ('PullObject', {}),
+            ('PushObject', {}),
+            ('PutObject', {}),
+            ('LookUp', {}),
+            ('LookDown', {}),
+            ('RotateLeft', {}),
+            ('RotateRight', {}),
+            ('Pass', {})
+        ])
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(3), [
+            (
+                'EndHabituation',
+                {'xPosition': 0, 'zPosition': 0, 'yRotation': 90}
+            )
+        ])
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(4), [
+            ('PickupObject', {'objectId': 'target'})
+        ])
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(10), [
+            ('CloseObject', {}),
+            ('DropObject', {}),
+            ('MoveAhead', {}),
+            ('MoveBack', {}),
+            ('MoveLeft', {}),
+            ('MoveRight', {}),
+            ('OpenObject', {}),
+            ('PickupObject', {}),
+            ('PullObject', {}),
+            ('PushObject', {}),
+            ('PutObject', {}),
+            ('LookUp', {}),
+            ('LookDown', {}),
+            ('RotateLeft', {}),
+            ('RotateRight', {}),
+            ('Pass', {})
+        ])
+
     def test_str(self):
         self.assertEqual(str(self.goal_metadata),
                          textwrap.dedent(self.str_output))

--- a/tests/test_goal_metadata.py
+++ b/tests/test_goal_metadata.py
@@ -89,7 +89,7 @@ class TestGoalMetadata(unittest.TestCase):
     def test_retrieve_action_list_at_step_with_custom_action_list(self):
         goal_metadata = mcs.GoalMetadata(action_list=[
             ['Pass'],
-            ['LookDown','LookUp','RotateLeft','RotateRight','Pass'],
+            ['LookDown', 'LookUp', 'RotateLeft', 'RotateRight', 'Pass'],
             [],
             ['EndHabituation,xPosition=0,zPosition=0,yRotation=90'],
             [('PickupObject', {'objectId': 'target'})]


### PR DESCRIPTION
- Removed EndHabituation from the default `action_list`. EndHabituation should only be an allowable action if it's been specifically demanded for that step via the `action_list` in the scene file.
- Fixed `action_list` to always return data as tuples. Previously it might return actions and parameters as single comma-separated strings like `EndHabituation,xPosition=0,zPosition=0,yRotation=90` if they were depicted that way in the scene file (but the two should be interchangeable).