### PR TITLE
Seesaw bug fix needs an integration test update for door closing

### DIFF
--- a/integration_tests/data/091.door_open_close.actions.txt
+++ b/integration_tests/data/091.door_open_close.actions.txt
@@ -4,4 +4,5 @@ OpenObject,objectId=testDoor
 MoveAhead
 MoveBack
 MoveBack
+MoveBack
 CloseObject,objectId=testDoor

--- a/integration_tests/data/091.door_open_close.level1.outputs.json
+++ b/integration_tests/data/091.door_open_close.level1.outputs.json
@@ -70,4 +70,13 @@
     "rotation_y": null,
     "objects_count": 0,
     "structural_objects_count": 0
+}, {
+    "step_number": 8,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
 }]

--- a/integration_tests/data/091.door_open_close.level2.outputs.json
+++ b/integration_tests/data/091.door_open_close.level2.outputs.json
@@ -70,4 +70,13 @@
     "rotation_y": null,
     "objects_count": 0,
     "structural_objects_count": 0
+}, {
+    "step_number": 8,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
 }]

--- a/integration_tests/data/091.door_open_close.oracle.outputs.json
+++ b/integration_tests/data/091.door_open_close.oracle.outputs.json
@@ -179,9 +179,9 @@
         "objects": [
             {
                 "direction_x": 0.0,
-                "direction_y": -0.885,
-                "direction_z": 0.465,
-                "distance": 0.861,
+                "direction_y": -0.836,
+                "direction_z": 0.549,
+                "distance": 0.911,
                 "held": false,
                 "id": "testDoor",
                 "mass": 1,
@@ -193,10 +193,35 @@
         ],
         "objects_count": 1,
         "position_x": 0.0,
-        "position_z": 0.0,
+        "position_z": -0.1,
         "return_status": "SUCCESSFUL",
         "rotation_y": 0.0,
         "step_number": 7,
+        "structural_objects_count": 6
+    },
+    {
+        "head_tilt": 0,
+        "objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.836,
+                "direction_z": 0.549,
+                "distance": 0.911,
+                "held": false,
+                "id": "testDoor",
+                "mass": 1,
+                "position_x": 0.0,
+                "position_z": 0.4,
+                "shape": "door_4",
+                "visible": true
+            }
+        ],
+        "objects_count": 1,
+        "position_x": 0.0,
+        "position_z": -0.1,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 8,
         "structural_objects_count": 6
     }
 ]


### PR DESCRIPTION
[Unity PR](https://github.com/NextCenturyCorporation/ai2thor/pull/185)
For some reason test 091 was inconsistent saying the door was visible on oracle output. Only happened sometimes when running all of the tests. This a quick fix to get rid of that because the action was still successful regardless.