### PR TITLE
Haptic feedback step output

### DIFF
--- a/integration_tests/data/066.end_habituation.scene.json
+++ b/integration_tests/data/066.end_habituation.scene.json
@@ -34,5 +34,8 @@
                 "z": 0.5
             }
         }]
-    }]
+    }],
+    "goal": {
+        "action_list": [[], [], [], ["EndHabituation"], [], [], [], ["EndHabituation,yRotation=30"], [], [], [], [], [], ["EndHabituation,xPosition=3"], [], [], ["EndHabituation,xPosition=0,zPosition=0"], [], [], [], [], [], [], ["EndHabituation,xPosition=0,zPosition=0,yRotation=0"]]
+    }
 }

--- a/integration_tests/habituation_trial_counts.scene.json
+++ b/integration_tests/habituation_trial_counts.scene.json
@@ -36,6 +36,7 @@
         }]
     }],
     "goal": {
+        "action_list": [[], [], ["EndHabituation"], [], [], [], [], [], [], [], [], [], [], ["EndHabituation"], ["EndHabituation"]],
         "habituation_total": 3
     }
 }

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -211,6 +211,8 @@ def run_single_scene(controller, scene_filename, metadata_tier, dev, autofix):
 
     # Run the specific actions for the test scene.
     for index, action_data in enumerate(action_list + [None]):
+        if not step_metadata:
+            return False, f'Step {index} failed: output step_metadata is None'
         # Validate the test scene's output metadata at each action step.
         failed_validation_list = validate_single_output(
             expected_output_data_list[index],

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -27,7 +27,7 @@ from .controller_events import (AfterStepPayload, BeforeStepPayload,
                                 EndScenePayload, EventType, StartScenePayload)
 from .controller_output_handler import ControllerOutputHandler
 from .goal_metadata import GoalMetadata
-from .parameter import Parameter
+from .parameter import Parameter, compare_param_values
 from .step_metadata import StepMetadata
 
 
@@ -283,15 +283,12 @@ class Controller():
             self.__step_number)
         # Only continue with this action step if the given action and
         # parameters are in the restricted action list.
-        continue_with_step = any(
-            action == restricted_action and (
-                len(restricted_params.items()) == 0 or all(
-                    restricted_params.get(key) == value
-                    for key, value in kwargs.items()
-                )
+        continue_with_step = any(action == restricted_action and (
+            len(restricted_params.items()) == 0 or all(
+                compare_param_values(restricted_params.get(key), value)
+                for key, value in kwargs.items()
             )
-            for restricted_action, restricted_params in action_list
-        )
+        ) for restricted_action, restricted_params in action_list)
 
         if not continue_with_step:
             logger.warning(

--- a/machine_common_sense/controller_logger.py
+++ b/machine_common_sense/controller_logger.py
@@ -52,6 +52,7 @@ class ControllerLogger(AbstractControllerSubscriber):
         logger.debug("  HEAD TILT: " + str(step_output.head_tilt))
         logger.debug("  POSITION: " + str(step_output.position))
         logger.debug("  ROTATION: " + str(step_output.rotation))
+        logger.debug("  HAPTIC FEEDBACK: " + str(step_output.haptic_feedback))
         logger.debug("OBJECTS: " +
                      str(len(step_output.object_list)) +
                      " TOTAL")

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -91,6 +91,10 @@ class SceneEvent():
             'clippingPlaneFar', ConfigManager.DEFAULT_CLIPPING_PLANE_FAR)
 
     @property
+    def haptic_feedback(self):
+        return self._raw_output.metadata.get('hapticFeedback')
+
+    @property
     def performer_radius(self):
         return self._raw_output.metadata.get('performerRadius')
 
@@ -272,6 +276,7 @@ class ControllerOutputHandler():
                 if goal.habituation_total >= habituation_trial
                 else None
             ),
+            haptic_feedback=self._scene_event.haptic_feedback,
             head_tilt=self._scene_event.head_tilt,
             image_list=self._scene_event.image_list,
             object_list=(

--- a/machine_common_sense/parameter.py
+++ b/machine_common_sense/parameter.py
@@ -6,6 +6,22 @@ from .config_manager import ConfigManager, MetadataTier
 from .controller import DEFAULT_MOVE
 
 
+def compare_param_values(value_1: Any, value_2: Any) -> bool:
+    """Compares two parameter values and returns if they are equal,
+    making sure that string numbers are converted to floats, and integer
+    floats are converted to ints."""
+    data = {'value_1': value_1, 'value_2': value_2}
+    for key in data:
+        if isinstance(data[key], str):
+            try:
+                data[key] = float(data[key])
+            except ValueError:
+                ...
+        if isinstance(data[key], float) and data[key].is_integer():
+            data[key] = int(data[key])
+    return data['value_1'] == data['value_2']
+
+
 class Parameter:
 
     # AI2-THOR creates a square grid across the scene that is

--- a/machine_common_sense/scripts/run_human_input.py
+++ b/machine_common_sense/scripts/run_human_input.py
@@ -177,7 +177,7 @@ class HumanInputShell(cmd.Cmd):
     def show_available_actions(self, output):
         if (
             output.action_list and
-            len(output.action_list) < len(GoalMetadata.ACTION_LIST)
+            len(output.action_list) < len(GoalMetadata.DEFAULT_ACTIONS)
         ):
             print('Only actions available during this step:')
             for action, params in output.action_list:

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -58,6 +58,9 @@ class StepMetadata:
         Note that this list will be empty if the metadata level is 'none'.
     goal : GoalMetadata or None
         The goal for the whole scene. Will be None in "Exploration" scenes.
+    haptic_feedback : list of strings or None
+        The current contact surfaces of the agent. Current supported contacts
+        are [LAVA, SAFE]
     habituation_trial : int or None
         The current habituation trial (as a positive integer), or None if the
         scene is not currently in a habituation trial (meaning this scene is
@@ -126,6 +129,7 @@ class StepMetadata:
         depth_map_list=None,
         goal=None,
         habituation_trial=None,
+        haptic_feedback=None,
         head_tilt=0.0,
         image_list=None,
         object_list=None,
@@ -155,6 +159,9 @@ class StepMetadata:
         )
         self.goal = GoalMetadata() if goal is None else goal
         self.habituation_trial = habituation_trial
+        self.haptic_feedback = (
+            [] if haptic_feedback is None else haptic_feedback
+        )
         self.head_tilt = head_tilt
         self.image_list = [] if image_list is None else image_list
         self.object_list = [] if object_list is None else object_list
@@ -199,6 +206,7 @@ class StepMetadata:
         yield 'camera_height', self.camera_height
         yield 'goal', dict(self.goal)
         yield 'habituation_trial', self.habituation_trial
+        yield 'haptic_feedback', self.haptic_feedback
         yield 'head_tilt', self.head_tilt
         yield 'object_list', self.check_list_none(self.object_list)
         yield 'performer_radius', self.performer_radius

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -58,9 +58,10 @@ class StepMetadata:
         Note that this list will be empty if the metadata level is 'none'.
     goal : GoalMetadata or None
         The goal for the whole scene. Will be None in "Exploration" scenes.
-    haptic_feedback : list of strings or None
-        The current contact surfaces of the agent. Current supported contacts
-        are [LAVA, SAFE]
+    haptic_feedback : dict
+        Haptic feedback sources for the agent. Values are true or false
+        depending on if the agent is touching the haptic feedback source.
+        The only current supported contact is "on_lava"
     habituation_trial : int or None
         The current habituation trial (as a positive integer), or None if the
         scene is not currently in a habituation trial (meaning this scene is
@@ -160,7 +161,7 @@ class StepMetadata:
         self.goal = GoalMetadata() if goal is None else goal
         self.habituation_trial = habituation_trial
         self.haptic_feedback = (
-            [] if haptic_feedback is None else haptic_feedback
+            {} if haptic_feedback is None else haptic_feedback
         )
         self.head_tilt = head_tilt
         self.image_list = [] if image_list is None else image_list

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -2,7 +2,7 @@ import unittest
 
 from machine_common_sense.config_manager import ConfigManager
 from machine_common_sense.controller import DEFAULT_MOVE
-from machine_common_sense.parameter import Parameter
+from machine_common_sense.parameter import Parameter, compare_param_values
 
 
 class TestParameter(unittest.TestCase):
@@ -465,3 +465,52 @@ class TestParameter(unittest.TestCase):
                 "DropObject")
         self.assertIsInstance(ai2thor_action, str)
         self.assertEqual(ai2thor_action, "DropHandObject")
+
+    def test_compare_param_values(self):
+        self.assertTrue(compare_param_values('', ''))
+        self.assertTrue(compare_param_values('a', 'a'))
+
+        self.assertTrue(compare_param_values('1', '1'))
+        self.assertTrue(compare_param_values('1.0', '1.0'))
+        self.assertTrue(compare_param_values('1.234', '1.234'))
+        self.assertTrue(compare_param_values(1, 1))
+        self.assertTrue(compare_param_values(1.0, 1.0))
+        self.assertTrue(compare_param_values(1.234, 1.234))
+
+        self.assertTrue(compare_param_values('1', 1))
+        self.assertTrue(compare_param_values(1, '1'))
+        self.assertTrue(compare_param_values('1.0', 1.0))
+        self.assertTrue(compare_param_values(1.0, '1.0'))
+
+        self.assertTrue(compare_param_values('1', 1.0))
+        self.assertTrue(compare_param_values(1.0, '1'))
+        self.assertTrue(compare_param_values(1, '1.0'))
+        self.assertTrue(compare_param_values('1.0', 1))
+
+        self.assertTrue(compare_param_values('1', '1.0'))
+        self.assertTrue(compare_param_values('1.0', '1'))
+        self.assertTrue(compare_param_values(1, 1.0))
+        self.assertTrue(compare_param_values(1.0, 1))
+
+        self.assertTrue(compare_param_values('1.234', 1.234))
+        self.assertTrue(compare_param_values(1.234, '1.234'))
+        self.assertTrue(compare_param_values('1.234', 1.234))
+        self.assertTrue(compare_param_values(1.234, '1.234'))
+
+        self.assertFalse(compare_param_values('a', '1'))
+        self.assertFalse(compare_param_values('1', 'a'))
+
+        self.assertFalse(compare_param_values('a', '1.0'))
+        self.assertFalse(compare_param_values('1.0', 'a'))
+        self.assertFalse(compare_param_values('a', '1.234'))
+        self.assertFalse(compare_param_values('1.234', 'a'))
+
+        self.assertFalse(compare_param_values('1', '1.234'))
+        self.assertFalse(compare_param_values('1.234', '1'))
+        self.assertFalse(compare_param_values('1.0', '1.234'))
+        self.assertFalse(compare_param_values('1.234', '1.0'))
+
+        self.assertFalse(compare_param_values(1, 1.234))
+        self.assertFalse(compare_param_values(1.234, 1))
+        self.assertFalse(compare_param_values(1.0, 1.234))
+        self.assertFalse(compare_param_values(1.234, 1.0))

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -24,7 +24,7 @@ class TestStepMetadata(unittest.TestCase):
             "metadata": {}
         },
         "habituation_trial": null,
-        "haptic_feedback": [],
+        "haptic_feedback": {},
         "head_tilt": 0.0,
         "image_list": [],
         "object_list": [],
@@ -57,7 +57,7 @@ class TestStepMetadata(unittest.TestCase):
             "metadata": {}
         },
         "habituation_trial": null,
-        "haptic_feedback": [],
+        "haptic_feedback": {},
         "head_tilt": 0.0,
         "image_list": [],
         "object_list": [],

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -24,6 +24,7 @@ class TestStepMetadata(unittest.TestCase):
             "metadata": {}
         },
         "habituation_trial": null,
+        "haptic_feedback": [],
         "head_tilt": 0.0,
         "image_list": [],
         "object_list": [],
@@ -56,6 +57,7 @@ class TestStepMetadata(unittest.TestCase):
             "metadata": {}
         },
         "habituation_trial": null,
+        "haptic_feedback": [],
         "head_tilt": 0.0,
         "image_list": [],
         "object_list": [],


### PR DESCRIPTION
[Unity](https://github.com/NextCenturyCorporation/ai2thor/pull/187)

Haptic feedback is currently an array of strings derived from an enum inside unity. The array has potential to be like ["LAVA", "UNDER_WATER"....] if we add more feedbacks. We could change the LAVA output to IN_LAVA or something like that too. Integration tests could be made too once we decide on how this should work.