### PR TITLE
MCS-1131 Fixed action push parameter so it works as described in the API

### DIFF
--- a/machine_common_sense/action.py
+++ b/machine_common_sense/action.py
@@ -268,12 +268,12 @@ class Action(Enum):
     PULL_OBJECT = (
         "PullObject",
         "5",
-        "Pull a nearby object. (objectId=string, rotation=float, " +
-        "horizon=float, force=float (default:0.5), " +
+        "Pull a nearby object. (objectId=string, force=float (default:0.5), " +
         "objectImageCoordsX=float, objectImageCoordsY=float)"
     )
     """
-    Pull a nearby object.
+    Pull a nearby object by applying a physical force directly toward you on
+    the X/Z axis to the center point of the object.
 
     Parameters
     ----------
@@ -315,12 +315,12 @@ class Action(Enum):
     PUSH_OBJECT = (
         "PushObject",
         "6",
-        "Push a nearby object. (objectId=string, rotation=float, " +
-        "horizon=float, force=float (default:0.5), " +
+        "Push a nearby object. (objectId=string, force=float (default:0.5), " +
         "objectImageCoordsX=float, objectImageCoordsY=float)"
     )
     """
-    Push a nearby object.
+    Push a nearby object by applying a physical force directly away from you on
+    the X/Z axis to the center point of the object.
 
     Parameters
     ----------

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -86,9 +86,6 @@ class Controller():
     config: ConfigManager
     """
 
-    MAX_FORCE = 50.0  # DW: used for testing but had it twice
-    # once at 50.0 and the other at 1.0
-
     @typeguard.typechecked
     def __init__(self, unity_app_file_path: str, config: ConfigManager):
 

--- a/machine_common_sense/parameter.py
+++ b/machine_common_sense/parameter.py
@@ -36,7 +36,7 @@ class Parameter:
     DEFAULT_IMG_COORD = 0
     DEFAULT_OBJECT_MOVE_AMOUNT = 1.0
 
-    FORCE_PERCENTAGE_MULTIPLIER = 250.0
+    UNITY_FORCE = 250.0
 
     MAX_AMOUNT = 1.0
     MIN_AMOUNT = 0.0
@@ -141,7 +141,7 @@ class Parameter:
                     f'({self.MIN_AMOUNT}-{self.MAX_AMOUNT})')
         else:
             force = self.DEFAULT_AMOUNT
-        return force * self.FORCE_PERCENTAGE_MULTIPLIER
+        return force * self.UNITY_FORCE
 
     def _get_number(self, key: str, **kwargs) -> Optional[Any]:
         val = kwargs.get(key)

--- a/machine_common_sense/parameter.py
+++ b/machine_common_sense/parameter.py
@@ -32,12 +32,12 @@ class Parameter:
 
     DEFAULT_HORIZON = 0.0
     DEFAULT_ROTATION = 0.0
-    DEFAULT_FORCE = 0.5
     DEFAULT_AMOUNT = 0.5
     DEFAULT_IMG_COORD = 0
     DEFAULT_OBJECT_MOVE_AMOUNT = 1.0
 
-    MAX_FORCE = 250.0
+    FORCE_PERCENTAGE_MULTIPLIER = 250.0
+
     MAX_AMOUNT = 1.0
     MIN_AMOUNT = 0.0
 
@@ -128,7 +128,7 @@ class Parameter:
         return amount
 
     def _get_force(self, **kwargs) -> float:
-        force = kwargs.get(self.FORCE_KEY, self.DEFAULT_FORCE)
+        force = kwargs.get(self.FORCE_KEY, self.DEFAULT_AMOUNT)
         if force is not None:
             try:
                 force = float(force)
@@ -140,8 +140,8 @@ class Parameter:
                     f'Force not in acceptable range of '
                     f'({self.MIN_AMOUNT}-{self.MAX_AMOUNT})')
         else:
-            force = self.DEFAULT_FORCE
-        return force * self.MAX_FORCE
+            force = self.DEFAULT_AMOUNT
+        return force * self.FORCE_PERCENTAGE_MULTIPLIER
 
     def _get_number(self, key: str, **kwargs) -> Optional[Any]:
         val = kwargs.get(key)

--- a/machine_common_sense/parameter.py
+++ b/machine_common_sense/parameter.py
@@ -37,8 +37,7 @@ class Parameter:
     DEFAULT_IMG_COORD = 0
     DEFAULT_OBJECT_MOVE_AMOUNT = 1.0
 
-    MAX_FORCE = 1.0
-    MIN_FORCE = 0.0
+    MAX_FORCE = 250.0
     MAX_AMOUNT = 1.0
     MIN_AMOUNT = 0.0
 
@@ -136,13 +135,13 @@ class Parameter:
             except ValueError as err:
                 raise ValueError('Force is not a number') from err
 
-            if force < self.MIN_FORCE or force > self.MAX_FORCE:
+            if force < self.MIN_AMOUNT or force > self.MAX_AMOUNT:
                 raise ValueError(
                     f'Force not in acceptable range of '
-                    f'({self.MIN_FORCE}-{self.MAX_FORCE})')
+                    f'({self.MIN_AMOUNT}-{self.MAX_AMOUNT})')
         else:
             force = self.DEFAULT_FORCE
-        return force
+        return force * self.MAX_FORCE
 
     def _get_number(self, key: str, **kwargs) -> Optional[Any]:
         val = kwargs.get(key)
@@ -170,7 +169,7 @@ class Parameter:
         # Set the Move Magnitude to the appropriate amount based on the action
         move_magnitude = DEFAULT_MOVE
         if action in self.FORCE_ACTIONS:
-            move_magnitude = force * self.MAX_FORCE
+            move_magnitude = force * self.MAX_AMOUNT
         elif action in self.OBJECT_MOVE_ACTIONS:
             move_magnitude = amount
         return move_magnitude

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -113,8 +113,8 @@ class TestAction(unittest.TestCase):
         self.assertEqual(mcs.Action.PULL_OBJECT.key, "5")
         self.assertEqual(
             mcs.Action.PULL_OBJECT.desc,
-            "Pull a nearby object. (objectId=string, rotation=float, " +
-            "horizon=float, force=float (default:0.5), " +
+            "Pull a nearby object. (objectId=string, " +
+            "force=float (default:0.5), " +
             "objectImageCoordsX=float, objectImageCoordsY=float)"
         )
         self.assertEqual(mcs.Action("PullObject"), mcs.Action.PULL_OBJECT)
@@ -125,8 +125,8 @@ class TestAction(unittest.TestCase):
         self.assertEqual(mcs.Action.PUSH_OBJECT.key, "6")
         self.assertEqual(
             mcs.Action.PUSH_OBJECT.desc,
-            "Push a nearby object. (objectId=string, rotation=float, " +
-            "horizon=float, force=float (default:0.5), " +
+            "Push a nearby object. (objectId=string, " +
+            "force=float (default:0.5), " +
             "objectImageCoordsX=float, objectImageCoordsY=float)"
         )
         self.assertEqual(mcs.Action("PushObject"), mcs.Action.PUSH_OBJECT)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -864,8 +864,7 @@ class TestController(unittest.TestCase):
             self.controller.get_last_step_data(),
             self.create_step_data(
                 action='PushObject',
-                horizon=0.0,
-                moveMagnitude=Parameter.MAX_FORCE,
+                moveMagnitude=250.0,
                 objectId='test_id_1'))
 
         self.controller.step(
@@ -876,8 +875,7 @@ class TestController(unittest.TestCase):
             self.controller.get_last_step_data(),
             self.create_step_data(
                 action='PushObject',
-                moveMagnitude=0.1 *
-                Parameter.MAX_FORCE,
+                moveMagnitude=25.0,
                 objectId='test_id_1'))
 
         self.assertRaises(
@@ -904,7 +902,7 @@ class TestController(unittest.TestCase):
             self.controller.get_last_step_data(),
             self.create_step_data(
                 action='PushObject',
-                moveMagnitude=Parameter.MAX_FORCE,
+                moveMagnitude=250.0,
                 objectImageCoords={'x': 1, 'y': 397}))
 
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -211,15 +211,15 @@ class TestParameter(unittest.TestCase):
     def test_get_force(self):
         force = self.parameter_converter._get_force(force=1)
         self.assertIsInstance(force, float)
-        self.assertAlmostEqual(force, 1.0)
+        self.assertAlmostEqual(force, 250.0)
 
         force = self.parameter_converter._get_force()
         self.assertIsInstance(force, float)
-        self.assertAlmostEqual(force, Parameter.DEFAULT_FORCE)
+        self.assertAlmostEqual(force, 125.0)
 
         force = self.parameter_converter._get_force(force=None)
         self.assertIsInstance(force, float)
-        self.assertAlmostEqual(force, Parameter.DEFAULT_FORCE)
+        self.assertAlmostEqual(force, 125.0)
 
         self.assertRaises(
             ValueError,


### PR DESCRIPTION
For our "force" actions (pull, push, and throw), the "force" input argument is intended to be a percentage from 0 to 1. We then multiply this force by the actual maximum force (in Newtons, I think) that we want to allow the robot to be able to apply in the Unity world. Since TA1 users would likely have no concept of what force values are useful in Unity, asking them to provide a simple percentage seemed more user-friendly than asking them to provide a value in Newtons (or whatever). I'm not tied to this approach, so I'm fine if we want to change it, but we'd need to update the documentation as well as the input parameter validation code.

Please note that while the previous max force was 50, that value was chosen somewhat arbitrarily, so I increased it to 250 in order to make tool pushing work properly.