### PR TITLE
MCS-1160 Added option for impulse force to MCS object config schema (Python)

### DIFF
--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -322,6 +322,7 @@ class ForceConfigSchema(Schema):
     step_begin = fields.Int(data_key='stepBegin')
     step_end = fields.Int(data_key='stepEnd')
     vector = fields.Nested(Vector3dSchema)
+    impulse = fields.Bool()
     relative = fields.Bool()
     repeat = fields.Bool()
     step_wait = fields.Int(data_key='stepWait')
@@ -622,6 +623,7 @@ class ForceConfig:
     step_begin: int
     step_end: int
     vector: Vector3d = Vector3d(0, 0, 0)
+    impulse: bool = False
     relative: bool = False
     repeat: bool = False
     step_wait: int = 0

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -283,6 +283,7 @@ class TestSceneConfig(unittest.TestCase):
                 'key': 'value'
             },
             'forces': [{
+                'impulse': True,
                 'relative': True,
                 'stepBegin': 11,
                 'stepEnd': 12,
@@ -464,6 +465,7 @@ class TestSceneConfig(unittest.TestCase):
         )]
         assert object_2.debug == {'key': 'value'}
         assert object_2.forces == [ForceConfig(
+            impulse=True,
             relative=True,
             step_begin=11,
             step_end=12,


### PR DESCRIPTION
Corresponding Unity PR: https://github.com/NextCenturyCorporation/ai2thor/pull/198

Impulse force will be useful for throwing the soccer ball in the "moving target" task, and possibly other tasks in the future.