### PR TITLE
MCS-1154 TopDownPlotter driver

### DIFF
--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -115,6 +115,16 @@ First, install ffmpeg. Then (change the frame rate with the `-r` option):
 
     $ ffmpeg -r 3 -i frame_image_%d.png output.gif
 
+Testing TopDown Plots
+---------------------
+
+The plotter module has a main which is only executed when the plotter module is run. The developer can provide a scene file as a positional argument and the plotter's main will run with video_enabled for 1 step. This will create a visual, depth and topdown video for that scene for review.
+
+.. code-block:: bash
+
+    (venv) $ python plotter.py playroom.json
+
+
 More Config Options
 ---------------------------
 

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -118,7 +118,7 @@ First, install ffmpeg. Then (change the frame rate with the `-r` option):
 Testing TopDown Plots
 ---------------------
 
-The plotter module has a main which is only executed when the plotter module is run. The developer can provide a scene file as a positional argument and the plotter's main will run with video_enabled for 1 step. This will create a visual, depth and topdown video for that scene for review.
+The plotter module has a main which is only executed when the plotter module is run directly vs imported. The developer can provide a scene file as a positional argument and the plotter's main will run with video_enabled for 1 step. This will create a visual, depth and topdown video in a scene folder for quick review.
 
 .. code-block:: bash
 

--- a/machine_common_sense/plotter.py
+++ b/machine_common_sense/plotter.py
@@ -624,3 +624,17 @@ class TopDownPlotter():
             shape=img.shape[:2])
         img[rr, cc] = self.GOAL_COLOR
         return img
+
+
+if __name__ == '__main__':
+    import sys
+
+    import machine_common_sense as mcs
+    controller = mcs.create_controller(
+        unity_cache_version='dev',
+        config_file_or_dict={'metadata': 'level1',
+                             'video_enabled': True})
+
+    scene_data, _ = mcs.load_scene_json_file(sys.argv[1])
+    controller.start_scene(scene_data)
+    controller.end_scene()


### PR DESCRIPTION
Created an easier way to read in a scene and visualize a plot by making a driver main in the plotter module. This could go in the machine_common_sense/scripts folder along with the runner approach but seemed excessive for what this is trying to do.