### PR TITLE
MCS-1179 Removed status from json loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ controller = mcs.create_controller(config_file_or_dict='./some-path/sample_confi
 
 # Either load the scene data dict from an MCS scene config JSON file or create your own.
 # We will give you the training scene config JSON files and the format to make your own.
-scene_data, status = mcs.load_scene_json_file(scene_json_file_path)
+scene_data = mcs.load_scene_json_file(scene_json_file_path)
 
 output = controller.start_scene(scene_data)
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -18,7 +18,7 @@ For the below example, make sure `MCS_CONFIG_FILE_PATH` is not set, since it wil
 
     # Either load the scene data dict from an MCS scene config JSON file or create your own.
     # We will give you the training scene config JSON files and the format to make your own.
-    scene_data, status = mcs.load_scene_json_file(scene_json_file_path)
+    scene_data = mcs.load_scene_json_file(scene_json_file_path)
 
     output = controller.start_scene(scene_data)
 
@@ -55,7 +55,7 @@ Run multiple scenes sequentially
     controller = mcs.create_controller(config_file_or_dict={})
 
     for scene_json_file_path in scene_json_file_list:
-        scene_data, status = mcs.load_scene_json_file(scene_json_file_path)
+        scene_data = mcs.load_scene_json_file(scene_json_file_path)
         output = controller.start_scene(scene_data)
         action, params = select_action(output)
         while action != '':
@@ -78,7 +78,7 @@ Run with console logging
     mcs.init_logging()
 
     controller = mcs.create_controller(config_file_or_dict='./some-path/config.ini')
-    scene_data, status = mcs.load_scene_json_file(scene_json_file_path)
+    scene_data = mcs.load_scene_json_file(scene_json_file_path)
     output = controller.start_scene(scene_data)
 
     action, params = select_action(output)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -222,7 +222,7 @@ Example Using the Config File to Generate Scene Graphs or Maps
     controller = mcs.create_controller(config_file_or_dict='path/to/config')
 
     for scene_file in scene_files:
-        scene_data, status = mcs.load_scene_json_file(scene_file)
+        scene_data = mcs.load_scene_json_file(scene_file)
 
         if status is not None:
             print(status)

--- a/docs/source/remotely.rst
+++ b/docs/source/remotely.rst
@@ -42,7 +42,7 @@ Run the following script to test MCS with the X11 server created above.
     controller = mcs.create_controller(config_file_or_dict={})
     # find a test scene
     scene_file_path = 'docs/source/scenes/ball_far.json'
-    scene_data, status = mcs.load_scene_json_file(scene_file_path)
+    scene_data = mcs.load_scene_json_file(scene_file_path)
     scene_file_name = scene_file_path[scene_file_path.rfind('/')+1]
     if 'name' not in scene_data.keys():
         scene_data['name'] = scene_file_name[0:scene_file_name.find('.')]

--- a/integration_tests/additional_integration_tests.py
+++ b/integration_tests/additional_integration_tests.py
@@ -25,10 +25,7 @@ SAMPLE_SCENES_FOLDER = (
 
 def run_depth_and_segmentation_test(controller, metadata_tier):
     # Load the test scene's JSON data.
-    scene_data, status = mcs.load_scene_json_file(DEPTH_AND_SEGMENTATION_SCENE)
-
-    if status is not None:
-        return False, status
+    scene_data = mcs.load_scene_json_file(DEPTH_AND_SEGMENTATION_SCENE)
 
     # Initialize the test scene.
     step_metadata_0 = controller.start_scene(scene_data)
@@ -117,12 +114,9 @@ def run_depth_and_segmentation_test(controller, metadata_tier):
 
 def run_habituation_trial_counts_test(controller, metadata_tier):
     # Load the test scene's JSON data.
-    scene_data, status = mcs.load_scene_json_file(
+    scene_data = mcs.load_scene_json_file(
         HABITUATION_TRIAL_COUNTS_SCENE
     )
-
-    if status is not None:
-        return False, status
 
     # Initialize the test scene.
     step_metadata = controller.start_scene(scene_data)
@@ -199,10 +193,7 @@ def run_habituation_trial_counts_test(controller, metadata_tier):
 
 def run_numpy_array_data_test(controller, metadata_tier):
     # Load the test scene's JSON data.
-    scene_data, status = mcs.load_scene_json_file(NUMPY_ARRAY_DATA_SCENE)
-
-    if status is not None:
-        return False, status
+    scene_data = mcs.load_scene_json_file(NUMPY_ARRAY_DATA_SCENE)
 
     # Convert the objects array to a numpy array
     scene_data['objects'] = np.array(scene_data.get("objects", []))
@@ -235,7 +226,7 @@ def run_public_sample_scenes_test(controller, metadata_tier):
 
     for scene_filename in scene_filename_list:
         # Load the sample scene's JSON data.
-        scene_data, status = mcs.load_scene_json_file(scene_filename)
+        scene_data = mcs.load_scene_json_file(scene_filename)
 
         # Initialize the test scene.
         step_metadata = controller.start_scene(scene_data)
@@ -258,10 +249,7 @@ def run_public_sample_scenes_test(controller, metadata_tier):
 
 def run_restricted_action_list_test(controller, metadata_tier):
     # Load the test scene's JSON data.
-    scene_data, status = mcs.load_scene_json_file(RESTRICTED_ACTION_LIST_SCENE)
-
-    if status is not None:
-        return False, status
+    scene_data = mcs.load_scene_json_file(RESTRICTED_ACTION_LIST_SCENE)
 
     # Initialize the test scene.
     step_metadata = controller.start_scene(scene_data)

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -178,10 +178,7 @@ def load_output_list(scene_filename, metadata_tier):
 
 def run_single_scene(controller, scene_filename, metadata_tier, dev, autofix):
     # Load the test scene's JSON data.
-    scene_data, status = mcs.load_scene_json_file(scene_filename)
-
-    if status is not None:
-        return False, status
+    scene_data = mcs.load_scene_json_file(scene_filename)
 
     # Load this test's expected output metadata at each action step.
     output_filename, expected_output_data_list = load_output_list(

--- a/machine_common_sense/__init__.py
+++ b/machine_common_sense/__init__.py
@@ -154,7 +154,7 @@ def change_config(controller: Controller,
 
 
 @typeguard.typechecked
-def load_scene_json_file(scene_json_file_path: str):
+def load_scene_json_file(scene_json_file_path: str) -> Dict:
     """
     Loads the given JSON scene config file and returns its data.
 
@@ -167,17 +167,12 @@ def load_scene_json_file(scene_json_file_path: str):
     -------
     dict
         The MCS scene configuration data from the given JSON file.
-    None or string
-        The error status (if any).
+
+    Raises
+    ------
+    FileNotFoundError
+    ValueError
     """
-    try:
-        with open(scene_json_file_path, encoding='utf-8-sig') \
-                as config_json_file_object:
-            try:
-                return json.load(config_json_file_object), None
-            except ValueError:
-                return {}, "The given file '" + scene_json_file_path + \
-                    "' does not contain valid JSON."
-    except IOError:
-        return {}, "The given file '" + scene_json_file_path + \
-            "' cannot be found."
+    with open(scene_json_file_path, encoding='utf-8-sig') \
+            as config_json_file_object:
+        return json.load(config_json_file_object)

--- a/machine_common_sense/scripts/run_human_input.py
+++ b/machine_common_sense/scripts/run_human_input.py
@@ -249,11 +249,7 @@ def run_scene(controller, scene_data):
 def main():
     mcs.init_logging(LoggingConfig.get_dev_logging_config())
     args = parse_args()
-    scene_data, status = mcs.load_scene_json_file(args.mcs_scene_json_file)
-
-    if status is not None:
-        print(status)
-        exit()
+    scene_data = mcs.load_scene_json_file(args.mcs_scene_json_file)
 
     controller = mcs.create_controller(
         unity_app_file_path=args.mcs_unity_build_file,

--- a/machine_common_sense/scripts/run_init_scenes.py
+++ b/machine_common_sense/scripts/run_init_scenes.py
@@ -29,12 +29,7 @@ def main():
         config_file_or_dict='./config_oracle_debug.ini')
 
     for json_file_name in json_file_list:
-        scene_data, status = mcs.load_scene_json_file(json_file_name)
-
-        if status is not None:
-            print('Error with JSON scene config file ' + json_file_name)
-            print(status)
-            continue
+        scene_data = mcs.load_scene_json_file(json_file_name)
 
         if 'name' not in scene_data.keys():
             scene_data['name'] = json_file_name[json_file_name.rfind(

--- a/machine_common_sense/scripts/run_scene_timer.py
+++ b/machine_common_sense/scripts/run_scene_timer.py
@@ -20,11 +20,7 @@ def parse_args():
 
 
 def run_scene(controller, file_name):
-    scene_data, status = mcs.load_scene_json_file(file_name)
-
-    if status is not None:
-        print(status)
-        return
+    scene_data = mcs.load_scene_json_file(file_name)
 
     scene_file_path = file_name
     scene_file_name = scene_file_path[scene_file_path.rfind('/') + 1:]

--- a/machine_common_sense/scripts/run_scene_with_command_file.py
+++ b/machine_common_sense/scripts/run_scene_with_command_file.py
@@ -36,12 +36,8 @@ def run_commands(controller, config_data, command_data):
 
 def main():
     args = parse_args()
-    config_data, status = mcs.load_scene_json_file(args.mcs_config_json_file)
+    config_data = mcs.load_scene_json_file(args.mcs_config_json_file)
     command_data = load_command_file(args.mcs_command_list_file)
-
-    if status is not None:
-        print(status)
-        exit()
 
     controller = mcs.create_controller(
         unity_app_file_path=args.mcs_unity_build_file,

--- a/machine_common_sense/scripts/runner_script.py
+++ b/machine_common_sense/scripts/runner_script.py
@@ -186,11 +186,7 @@ class AbstractRunnerScript():
         prefix: str,
         rename: bool
     ):
-        scene_data, status = mcs.load_scene_json_file(filename)
-
-        if status is not None:
-            print(status)
-            return
+        scene_data = mcs.load_scene_json_file(filename)
 
         if last_step:
             scene_data['goal'] = scene_data.get('goal', {})

--- a/scripts/generate_passive_quartet_videos.py
+++ b/scripts/generate_passive_quartet_videos.py
@@ -27,11 +27,7 @@ def parse_args():
 
 def run_scene(controller, file_name: str) -> None:
     '''Run the passive physics scene to generate the image frames'''
-    scene_data, status = mcs.load_scene_json_file(file_name)
-
-    if status is not None:
-        print(status)
-        return
+    scene_data = mcs.load_scene_json_file(file_name)
 
     scene_file_path = file_name
     scene_file_name = scene_file_path[scene_file_path.rfind('/') + 1:]

--- a/tests/test_mcs.py
+++ b/tests/test_mcs.py
@@ -183,7 +183,7 @@ class TestMCS(unittest.TestCase):
                              for subscriber in ctrl._subscribers]))
 
     def test_load_scene_file_json(self):
-        actual, status = mcs.load_scene_json_file("tests/test_scene.json")
+        actual = mcs.load_scene_json_file("tests/test_scene.json")
         expected = {
             "ceilingMaterial": "Walls/WallDrywallWhite",
             "floorMaterial": "Fabrics/RUG4",
@@ -218,25 +218,19 @@ class TestMCS(unittest.TestCase):
             }]
         }
         self.assertEqual(actual, expected)
-        self.assertEqual(status, None)
 
     def test_load_scene_file_json_is_invalid(self):
-        actual, status = mcs.load_scene_json_file(
-            "tests/test_scene_invalid.json")
-        self.assertEqual(actual, {})
-        self.assertEqual(
-            status,
-            "The given file 'tests/test_scene_invalid.json' does not " +
-            "contain valid JSON."
+        self.assertRaises(
+            ValueError,
+            lambda: mcs.load_scene_json_file("tests/test_scene_invalid.json")
         )
 
     def test_load_scene_file_json_is_missing(self):
-        actual, status = mcs.load_scene_json_file(
-            "tests/test_scene_missing.json")
-        self.assertEqual(actual, {})
-        self.assertEqual(
-            status,
-            "The given file 'tests/test_scene_missing.json' cannot be found.")
+        self.assertRaises(
+            FileNotFoundError,
+            lambda: mcs.load_scene_json_file(
+                "tests/test_scene_missing.json")
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Relying on exceptions per previous conversations rather than relying on status strings in the event that something unexpected happens.

Former
`scene_data, status = mcs.load_json_scene_file('playroom.json')`

New
`scene_data = mcs.load_json_scene_file('playroom.json')`

New approach will properly raise a ValueError when the json scene file can't be properly parsed and a FileNotFoundError if the file itself can't be found. This is more descriptive than string parsing including additional possible exceptions raised by the json library and open function call.