### PR TITLE
MCS-1142 Increase Depth Map Range and Precision

### DIFF
--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -46,7 +46,6 @@ class MetadataTier(Enum):
 
 class ConfigManager(object):
 
-    DEFAULT_CLIPPING_PLANE_FAR = 15.0
     DEFAULT_ROOM_DIMENSIONS = Vector3d(x=10, y=3, z=10)
 
     CONFIG_FILE_ENV_VAR = 'MCS_CONFIG_FILE_PATH'

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -53,7 +53,8 @@ def __image_depth_override(self, image_depth_data, **kwargs):
     return ai2thor.server.read_buffer_image(
         image_depth_data,
         self.screen_width,
-        self.screen_height
+        self.screen_height,
+        dtype=np.float32
     )
 
 

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -40,6 +40,10 @@ class SceneEvent():
                     unity_depth_array = event.depth_frame.astype(np.float32)
                     # Convert to a 2D array (screen length X width)
                     depth_float_array = np.squeeze(unity_depth_array)
+                    # Convert from (0.0, 1.0) to (0, max distance)
+                    depth_float_array = (
+                        depth_float_array * self.clipping_plane_far
+                    )
                     self.depth_map_list.append(np.array(depth_float_array))
 
                 if self._config.is_object_masks_enabled():

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -38,7 +38,8 @@ class SceneEvent():
 
                 if self._config.is_depth_maps_enabled():
                     unity_depth_array = event.depth_frame.astype(np.float32)
-                    depth_float_array = unity_depth_array[:, :, 0]
+                    # Convert to a 2D array (screen length X width)
+                    depth_float_array = np.squeeze(unity_depth_array)
                     self.depth_map_list.append(np.array(depth_float_array))
 
                 if self._config.is_object_masks_enabled():
@@ -76,8 +77,7 @@ class SceneEvent():
 
     @property
     def clipping_plane_far(self):
-        return self._raw_output.metadata.get(
-            'clippingPlaneFar', ConfigManager.DEFAULT_CLIPPING_PLANE_FAR)
+        return self._raw_output.metadata.get('clippingPlaneFar', 0.0)
 
     @property
     def haptic_feedback(self):

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -27,7 +27,6 @@ class SceneEvent():
     _step_number: int
 
     def __post_init__(self):
-        max_depth = self.clipping_plane_far
         self.image_list = []
         self.depth_map_list = []
         self.object_mask_list = []
@@ -38,18 +37,7 @@ class SceneEvent():
                 self.image_list.append(scene_image)
 
                 if self._config.is_depth_maps_enabled():
-                    # The Unity depth array (returned by Depth.shader) contains
-                    # a third of the total max depth in each RGB element.
-                    unity_depth_array = event.depth_frame.astype(np.float32)
-                    # Convert to values between 0 and max_depth for output.
-                    depth_float_array = (
-                        (unity_depth_array[:, :, 0] *
-                         (max_depth / 3.0) / 255.0) +
-                        (unity_depth_array[:, :, 1] *
-                         (max_depth / 3.0) / 255.0) +
-                        (unity_depth_array[:, :, 2] *
-                         (max_depth / 3.0) / 255.0)
-                    )
+                    depth_float_array = event.depth_frame.astype(np.float32)
                     self.depth_map_list.append(np.array(depth_float_array))
 
                 if self._config.is_object_masks_enabled():

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -37,7 +37,8 @@ class SceneEvent():
                 self.image_list.append(scene_image)
 
                 if self._config.is_depth_maps_enabled():
-                    depth_float_array = event.depth_frame.astype(np.float32)
+                    unity_depth_array = event.depth_frame.astype(np.float32)
+                    depth_float_array = unity_depth_array[:, :, 0]
                     self.depth_map_list.append(np.array(depth_float_array))
 
                 if self._config.is_object_masks_enabled():

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -53,8 +53,9 @@ class StepMetadata:
         for a scene with a scripted Preview Phase (Preview Phase case details
         TBD).
         Each depth float in a 2-dimensional numpy array is a value between 0
-        and the camera's far clipping plane (default 15) correspondings to the
-        depth in simulation units at that pixel in the image.
+        and 1.0 corresponding to the depth in simulation units at that pixel
+        in the image: 0 represents the camera's near clipping plane (default
+        0.01); 1.0 represents the camera's far clipping plane (default 150).
         Note that this list will be empty if the metadata level is 'none'.
     goal : GoalMetadata or None
         The goal for the whole scene. Will be None in "Exploration" scenes.
@@ -212,14 +213,14 @@ class StepMetadata:
         yield 'camera_height', self.camera_height
         # TODO MCS-1142 REMOVE
         yield 'depth_map_list', self.depth_map_list,
-        # Intentially no depth_map_list
+        # Intentionally no depth_map_list
         yield 'goal', dict(self.goal)
         yield 'habituation_trial', self.habituation_trial
         yield 'haptic_feedback', self.haptic_feedback
         yield 'head_tilt', self.head_tilt
-        # Intentially no image_list
+        # Intentionally no image_list
         yield 'object_list', self.check_list_none(self.object_list)
-        # Intentially no object_mask_list
+        # Intentionally no object_mask_list
         yield 'performer_radius', self.performer_radius
         yield 'performer_reach', self.performer_reach
         yield 'physics_frames_per_second', self.physics_frames_per_second

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -211,8 +211,6 @@ class StepMetadata:
         yield 'camera_clipping_planes', self.camera_clipping_planes
         yield 'camera_field_of_view', self.camera_field_of_view
         yield 'camera_height', self.camera_height
-        # TODO MCS-1142 REMOVE
-        yield 'depth_map_list', self.depth_map_list,
         # Intentionally no depth_map_list
         yield 'goal', dict(self.goal)
         yield 'habituation_trial', self.habituation_trial

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -39,23 +39,23 @@ class StepMetadata:
         The player camera's aspect ratio. This will remain constant for the
         whole scene.
     camera_clipping_planes : (float, float)
-        The player camera's near and far clipping planes. This will remain
-        constant for the whole scene.
+        The player camera's near and far clipping planes, in meters. This will
+        remain constant for the whole scene. Default (0.01, 150)
     camera_field_of_view : float
         The player camera's field of view. This will remain constant for
         the whole scene.
     camera_height : float
-        The player camera's height.
+        The player camera's height, in meters.
     depth_map_list : list of 2D numpy arrays
         The list of 2-dimensional numpy arrays of depth float data from the
         scene after the last action and physics simulation were run. This is
         usually a list with 1 array, except for the output from start_scene
         for a scene with a scripted Preview Phase (Preview Phase case details
         TBD).
-        Each depth float in a 2-dimensional numpy array is a value between 0
-        and 1.0 corresponding to the depth in simulation units at that pixel
-        in the image: 0 represents the camera's near clipping plane (default
-        0.01); 1.0 represents the camera's far clipping plane (default 150).
+        Each 32-bit depth float in the 2-dimensional numpy array is a value
+        between the camera's near clipping plane (default 0.01) and the
+        camera's far clipping plane (default 150) corresponding to the depth,
+        in meters, at that pixel in the image.
         Note that this list will be empty if the metadata level is 'none'.
     goal : GoalMetadata or None
         The goal for the whole scene. Will be None in "Exploration" scenes.
@@ -90,9 +90,9 @@ class StepMetadata:
         Note that this list will be empty if the metadata level is 'none'
         or 'level1'.
     performer_radius: float
-        The radius of the performer.
+        The radius of the performer, in meters.
     performer_reach: float
-        The max reach of the performer.
+        The max reach of the performer, in meters.
     position : dict
         The "x", "y", and "z" coordinates for your global position.
         Will be set to 'None' if using a metadata level below the

--- a/machine_common_sense/step_metadata.py
+++ b/machine_common_sense/step_metadata.py
@@ -197,6 +197,7 @@ class StepMetadata:
         """Return a deep copy of this StepMetadata with default depth_map_list,
         image_list, and object_mask_list properties."""
         step_metadata_copy = StepMetadata()
+        # This class's __iter__ function will ignore specific properties.
         for key, _ in self:
             setattr(step_metadata_copy, key, copy.deepcopy(getattr(self, key)))
         return step_metadata_copy
@@ -209,11 +210,16 @@ class StepMetadata:
         yield 'camera_clipping_planes', self.camera_clipping_planes
         yield 'camera_field_of_view', self.camera_field_of_view
         yield 'camera_height', self.camera_height
+        # TODO MCS-1142 REMOVE
+        yield 'depth_map_list', self.depth_map_list,
+        # Intentially no depth_map_list
         yield 'goal', dict(self.goal)
         yield 'habituation_trial', self.habituation_trial
         yield 'haptic_feedback', self.haptic_feedback
         yield 'head_tilt', self.head_tilt
+        # Intentially no image_list
         yield 'object_list', self.check_list_none(self.object_list)
+        # Intentially no object_mask_list
         yield 'performer_radius', self.performer_radius
         yield 'performer_reach', self.performer_reach
         yield 'physics_frames_per_second', self.physics_frames_per_second

--- a/machine_common_sense/stringifier.py
+++ b/machine_common_sense/stringifier.py
@@ -12,7 +12,8 @@ class Stringifier:
     which is why this is seperate from serialization
     """
 
-    NUMBER_OF_DECIMALS = 4
+    # TODO MCS-1142 Change back to 4
+    NUMBER_OF_DECIMALS = 8
     NUMBER_OF_SPACES = 4
 
     @staticmethod

--- a/machine_common_sense/stringifier.py
+++ b/machine_common_sense/stringifier.py
@@ -12,8 +12,7 @@ class Stringifier:
     which is why this is seperate from serialization
     """
 
-    # TODO MCS-1142 Change back to 4
-    NUMBER_OF_DECIMALS = 8
+    NUMBER_OF_DECIMALS = 4
     NUMBER_OF_SPACES = 4
 
     @staticmethod

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -37,7 +37,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
     def create_wrap_output_scene_event(self):
         image_data = numpy.array([[0]], dtype=numpy.uint8)
-        depth_data = numpy.array([[[128, 0, 0]]], dtype=numpy.uint8)
+        depth_data = numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32)
         object_mask_data = numpy.array([[192]], dtype=numpy.uint8)
 
         return {
@@ -554,7 +554,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 0)
         '''numpy.testing.assert_almost_equal(
             numpy.array(actual.depth_map_list[0]),
-            numpy.array([[2.51]], dtype=numpy.float32),
+            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
             3
         )'''
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
@@ -727,7 +727,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 1)
         numpy.testing.assert_almost_equal(
             numpy.array(actual.depth_map_list[0]),
-            numpy.array([[2.51]], dtype=numpy.float32),
+            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
@@ -775,7 +775,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 1)
         numpy.testing.assert_almost_equal(
             numpy.array(actual.depth_map_list[0]),
-            numpy.array([[2.51]], dtype=numpy.float32),
+            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
@@ -788,7 +788,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self._config.set_metadata_tier(
             MetadataTier.ORACLE.value)
         image_data = numpy.array([[0]], dtype=numpy.uint8)
-        depth_data = numpy.array([[[0, 0, 0]]], dtype=numpy.uint8)
+        depth_data = numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32)
         object_mask_data = numpy.array([[192]], dtype=numpy.uint8)
 
         mock_scene_event_data = {
@@ -814,7 +814,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(numpy.array(image_list[0]), image_data)
         numpy.testing.assert_almost_equal(
             numpy.array(depth_map_list[0]),
-            numpy.array([[0.0]], dtype=numpy.float32),
+            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(object_mask_list[0]), object_mask_data)
@@ -823,11 +823,17 @@ class TestControllerOutputHandler(unittest.TestCase):
         self._config.set_metadata_tier(
             MetadataTier.ORACLE.value)
         image_data_1 = numpy.array([[64]], dtype=numpy.uint8)
-        depth_data_1 = numpy.array([[[128, 64, 32]]], dtype=numpy.uint8)
+        depth_data_1 = numpy.array(
+            [[0.2, 0.4], [0.6, 0.8]],
+            dtype=numpy.float32
+        )
         object_mask_data_1 = numpy.array([[192]], dtype=numpy.uint8)
 
         image_data_2 = numpy.array([[32]], dtype=numpy.uint8)
-        depth_data_2 = numpy.array([[[96, 0, 0]]], dtype=numpy.uint8)
+        depth_data_2 = numpy.array(
+            [[0.0001, 0.9999], [0.25, 0.75]],
+            dtype=numpy.float32
+        )
         object_mask_data_2 = numpy.array([[160]], dtype=numpy.uint8)
 
         mock_scene_event_data = {
@@ -859,7 +865,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(numpy.array(image_list[0]), image_data_1)
         numpy.testing.assert_almost_equal(
             numpy.array(depth_map_list[0]),
-            numpy.array([[4.392]], dtype=numpy.float32),
+            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(object_mask_list[0]), object_mask_data_1)
@@ -867,7 +873,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(numpy.array(image_list[1]), image_data_2)
         numpy.testing.assert_almost_equal(
             numpy.array(depth_map_list[1]),
-            numpy.array([[1.882]], dtype=numpy.float32),
+            numpy.array([[0.0001, 0.9999], [0.25, 0.75]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(object_mask_list[1]), object_mask_data_2)

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -67,7 +67,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                 "cameraPosition": {
                     "y": 0.1234
                 },
-                "clippingPlaneFar": 15,
+                "clippingPlaneFar": 150,
                 "clippingPlaneNear": 0,
                 "fov": 42.5,
                 "lastActionStatus": "SUCCESSFUL",
@@ -463,7 +463,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
-        self.assertEqual(actual.camera_clipping_planes, (0, 15))
+        self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
         self.assertEqual(str(actual.goal), str(mcs.GoalMetadata()))
@@ -554,7 +554,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 0)
         '''numpy.testing.assert_almost_equal(
             numpy.array(actual.depth_map_list[0]),
-            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
+            numpy.array([[30, 60], [90, 120]], dtype=numpy.float32),
             3
         )'''
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
@@ -580,7 +580,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
-        self.assertEqual(actual.camera_clipping_planes, (0, 15))
+        self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
         self.assertEqual(actual.habituation_trial, None)
@@ -629,7 +629,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
-        self.assertEqual(actual.camera_clipping_planes, (0, 15))
+        self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
         self.assertEqual(str(actual.goal), str(mcs.GoalMetadata()))
@@ -667,7 +667,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
-        self.assertEqual(actual.camera_clipping_planes, (0, 15))
+        self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
         self.assertEqual(str(actual.goal), str(mcs.GoalMetadata()))
@@ -706,7 +706,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
-        self.assertEqual(actual.camera_clipping_planes, (0, 15))
+        self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
         self.assertEqual(actual.habituation_trial, None)
@@ -727,7 +727,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 1)
         numpy.testing.assert_almost_equal(
             numpy.array(actual.depth_map_list[0]),
-            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
+            numpy.array([[30, 60], [90, 120]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
@@ -754,7 +754,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
-        self.assertEqual(actual.camera_clipping_planes, (0, 15))
+        self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
         self.assertEqual(actual.habituation_trial, None)
@@ -775,7 +775,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(len(actual.object_mask_list), 1)
         numpy.testing.assert_almost_equal(
             numpy.array(actual.depth_map_list[0]),
-            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
+            numpy.array([[30, 60], [90, 120]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(actual.image_list[0]), image_data)
@@ -797,7 +797,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                 "frame": image_data,
                 "instance_segmentation_frame": object_mask_data
             })],
-            "metadata": {"objects": []}
+            "metadata": {"clippingPlaneFar": 150, "objects": []}
         }
         mock_event = self.create_mock_scene_event(mock_scene_event_data)
         scene_event = SceneEvent(
@@ -814,7 +814,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(numpy.array(image_list[0]), image_data)
         numpy.testing.assert_almost_equal(
             numpy.array(depth_map_list[0]),
-            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
+            numpy.array([[30, 60], [90, 120]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(object_mask_list[0]), object_mask_data)
@@ -831,7 +831,7 @@ class TestControllerOutputHandler(unittest.TestCase):
 
         image_data_2 = numpy.array([[32]], dtype=numpy.uint8)
         depth_data_2 = numpy.array(
-            [[0.0001, 0.9999], [0.25, 0.75]],
+            [[0.0001, 0.99], [0.25, 0.75]],
             dtype=numpy.float32
         )
         object_mask_data_2 = numpy.array([[160]], dtype=numpy.uint8)
@@ -846,7 +846,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                 "frame": image_data_2,
                 "instance_segmentation_frame": object_mask_data_2
             })],
-            "metadata": {"objects": []}
+            "metadata": {"clippingPlaneFar": 150, "objects": []}
         }
 
         mock_event = self.create_mock_scene_event(mock_scene_event_data)
@@ -865,7 +865,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(numpy.array(image_list[0]), image_data_1)
         numpy.testing.assert_almost_equal(
             numpy.array(depth_map_list[0]),
-            numpy.array([[0.2, 0.4], [0.6, 0.8]], dtype=numpy.float32),
+            numpy.array([[30, 60], [90, 120]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(object_mask_list[0]), object_mask_data_1)
@@ -873,7 +873,7 @@ class TestControllerOutputHandler(unittest.TestCase):
         self.assertEqual(numpy.array(image_list[1]), image_data_2)
         numpy.testing.assert_almost_equal(
             numpy.array(depth_map_list[1]),
-            numpy.array([[0.0001, 0.9999], [0.25, 0.75]], dtype=numpy.float32),
+            numpy.array([[0.015, 148.5], [37.5, 112.5]], dtype=numpy.float32),
             3
         )
         self.assertEqual(numpy.array(object_mask_list[1]), object_mask_data_2)


### PR DESCRIPTION
Corresponding Unity PR: https://github.com/NextCenturyCorporation/ai2thor/pull/205

My method of testing:
1. Do a debug run of a scene using the development Unity build: `python machine_common_sense/scripts/run_just_pass.py <json_file> --last_step 1 --debug --oracle --mcs_unity_version development`
2. The debug run creates a new folder with the scene's name. Review and backup the `mcs_output` data, which contains a `depth_map_list`, as well as the `depth_map` image.
3. Do a debug run of the same scene using the MCS-1142 Unity build: `python machine_common_sense/scripts/run_just_pass.py <json_file> --last_step 1 --debug --oracle --mcs_unity_build_file <unity_build>`
4. Compare the new `mcs_output` data and `depth_map` image with the old ones.

Here's a "huge room" scene you can use for testing:

```json
{
    "name": "huge_room",
    "version": 2,
    "ceilingMaterial": "Custom/Materials/GreyDrywallMCS",
    "floorMaterial": "Custom/Materials/GreyCarpetMCS",
    "wallMaterial": "Custom/Materials/BlueDrywallMCS",
    "roomDimensions": {
        "x": 100,
        "y": 5,
        "z": 100
    },
    "performerStart": {
        "position": {
            "x": -49.5,
            "z": -49.5
        },
        "rotation": {
            "x": 0,
            "y": 0
        }
    },
    "objects": []
}
```