### PR TITLE
MCS-1164: End Scene if too many steps in Lava

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -158,6 +158,13 @@ lava_penalty
 
 Changes the negative penalty recieved for every step on lava.  Default: 100
 
+steps_allowed_in_lava
+^^^^^^^^^^^^^^^
+
+(int, optional)
+
+Number of steps allowed in lava before automatically calling end scene.  Default: 0
+
 noise_enabled
 ^^^^^^^^^^^^^^^
 

--- a/machine_common_sense/action.py
+++ b/machine_common_sense/action.py
@@ -606,6 +606,24 @@ class Action(Enum):
     """
 
     # Pass should always be the last action in the enum.
+    END_SCENE = (
+        "EndScene",
+        " ",
+        "There is no action available and end_scene needs to be called."
+    )
+    """
+    Call end_scene now there is no actions available.
+    Does nothing.
+
+    Returns
+    -------
+    "SUCCESSFUL"
+        Action successful.
+    "FAILED"
+        Unexpected error; please report immediately to development team.
+    """
+
+    # Pass should always be the last action in the enum.
     PASS = (
         "Pass",
         " ",

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -63,6 +63,7 @@ class ConfigManager(object):
     CONFIG_TEAM = 'team'
     CONFIG_VIDEO_ENABLED = 'video_enabled'
     CONFIG_LAVA_PENALTY = 'lava_penalty'
+    CONFIG_STEPS_ALLOWED_IN_LAVA = 'steps_allowed_in_lava'
     CONFIG_STEP_PENALTY = 'step_penalty'
     CONFIG_GOAL_REWARD = 'goal_reward'
 
@@ -70,6 +71,9 @@ class ConfigManager(object):
     # on this assumption.
     SCREEN_WIDTH_DEFAULT = 600
     SCREEN_WIDTH_MIN = 450
+
+    # Default steps allowed in lava before calling end scene
+    STEPS_ALLOWED_IN_LAVA_DEFAULT = 0
 
     def __init__(self, config_file_or_dict=None):
         '''
@@ -242,6 +246,13 @@ class ConfigManager(object):
             self.CONFIG_DEFAULT_SECTION,
             self.CONFIG_GOAL_REWARD,
             fallback=None
+        )
+
+    def get_steps_allowed_in_lava(self):
+        return self._config.getint(
+            self.CONFIG_DEFAULT_SECTION,
+            self.CONFIG_STEPS_ALLOWED_IN_LAVA,
+            fallback=self.STEPS_ALLOWED_IN_LAVA_DEFAULT
         )
 
 
@@ -824,7 +835,7 @@ class SceneConfiguration:
                 return [str(state) for state in state_list]
         return []
 
-    def retrieve_goal(self):
+    def retrieve_goal(self, config):
         if not self.goal:
             return self.update_goal_target_image(GoalMetadata())
 
@@ -852,6 +863,7 @@ class SceneConfiguration:
                 last_preview_phase_step=(goal.last_preview_phase_step or 0),
                 last_step=goal.last_step or None,
                 metadata=goal.metadata or {},
+                steps_allowed_in_lava=config.get_steps_allowed_in_lava()
             )
         )
 

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -835,9 +835,11 @@ class SceneConfiguration:
                 return [str(state) for state in state_list]
         return []
 
-    def retrieve_goal(self, config):
+    def retrieve_goal(self, steps_allowed_in_lava=0):
         if not self.goal:
-            return self.update_goal_target_image(GoalMetadata())
+            return self.update_goal_target_image(GoalMetadata(
+                steps_allowed_in_lava=steps_allowed_in_lava
+            ))
 
         goal = self.goal
 
@@ -863,7 +865,7 @@ class SceneConfiguration:
                 last_preview_phase_step=(goal.last_preview_phase_step or 0),
                 last_step=goal.last_step or None,
                 metadata=goal.metadata or {},
-                steps_allowed_in_lava=config.get_steps_allowed_in_lava()
+                steps_allowed_in_lava=steps_allowed_in_lava
             )
         )
 

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -281,10 +281,8 @@ class Controller():
         # if they call end scene action they should have
         #   called end_scene instead of step
         if action == Action.END_SCENE.value:
-            logger.error(
-                "You have called EndScene action. "
-                "Please call controller.end_scene() now.")
-            return None
+            raise ValueError("You have called EndScene action.  "
+                             "Call controler.end_scene() instead.")
 
         # reformulate hidden EndHabituation parameters
         if action == Action.END_HABITUATION.value:

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -161,7 +161,8 @@ class Controller():
         self.__habituation_trial = 1
         self.__step_number = 0
         self.__steps_in_lava = 0
-        self._goal = self._scene_config.retrieve_goal(self._config.get_steps_allowed_in_lava())
+        self._goal = self._scene_config.retrieve_goal(
+            self._config.get_steps_allowed_in_lava())
         self._end_scene_called = False
 
         skip_preview_phase = (scene_config.goal is not None and
@@ -343,7 +344,7 @@ class Controller():
         (pre_restrict_output, output) = self._output_handler.handle_output(
             step_output, self._goal, self.__step_number,
             self.__habituation_trial)
-        
+
         self.__steps_in_lava = output.steps_on_lava
 
         payload = self._create_post_step_event_payload_kwargs(

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -281,8 +281,8 @@ class Controller():
         # if they call end scene action they should have
         #   called end_scene instead of step
         if action == Action.END_SCENE.value:
-            raise ValueError("You have called EndScene action.  "
-                             "Call controler.end_scene() instead.")
+            self.end_scene()
+            raise SystemExit(0)
 
         # reformulate hidden EndHabituation parameters
         if action == Action.END_HABITUATION.value:

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -161,7 +161,7 @@ class Controller():
         self.__habituation_trial = 1
         self.__step_number = 0
         self.__steps_in_lava = 0
-        self._goal = self._scene_config.retrieve_goal(self._config)
+        self._goal = self._scene_config.retrieve_goal(self._config.get_steps_allowed_in_lava())
         self._end_scene_called = False
 
         skip_preview_phase = (scene_config.goal is not None and
@@ -193,9 +193,11 @@ class Controller():
         step_output = self._controller.step(ai2thor_step)
 
         self._output_handler.set_scene_config(scene_config)
-        (pre_restrict_output, output, self.__steps_in_lava) = self._output_handler.handle_output(
+        (pre_restrict_output, output) = self._output_handler.handle_output(
             step_output, self._goal, self.__step_number,
             self.__habituation_trial)
+
+        self.__steps_in_lava = output.steps_on_lava
 
         if not skip_preview_phase:
             if (self._goal is not None and
@@ -338,9 +340,11 @@ class Controller():
             action=action, **kwargs)
         step_output = self._controller.step(ai2thor_step)
 
-        (pre_restrict_output, output, self.__steps_in_lava) = self._output_handler.handle_output(
+        (pre_restrict_output, output) = self._output_handler.handle_output(
             step_output, self._goal, self.__step_number,
             self.__habituation_trial)
+        
+        self.__steps_in_lava = output.steps_on_lava
 
         payload = self._create_post_step_event_payload_kwargs(
             ai2thor_step, step_output, pre_restrict_output, output)

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -261,7 +261,7 @@ class ControllerOutputHandler():
             goal, habituation_trial, False)
         restricted = self._get_step_metadata(
             goal, habituation_trial, True)
-        return (unrestricted, restricted, self._scene_event.steps_on_lava)
+        return (unrestricted, restricted)
 
     def _get_step_metadata(self, goal, habituation_trial,
                            restricted=True) -> StepMetadata:

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -261,14 +261,15 @@ class ControllerOutputHandler():
             goal, habituation_trial, False)
         restricted = self._get_step_metadata(
             goal, habituation_trial, True)
-        return (unrestricted, restricted)
+        return (unrestricted, restricted, self._scene_event.steps_on_lava)
 
     def _get_step_metadata(self, goal, habituation_trial,
                            restricted=True) -> StepMetadata:
         (restrict_depth_map, restrict_object_mask_list, restrict_non_oracle) =\
             self.get_restrictions(restricted, self._config.get_metadata_tier())
         step_output = StepMetadata(
-            action_list=goal.retrieve_action_list_at_step(self._step_number),
+            action_list=goal.retrieve_action_list_at_step(
+                self._step_number, self._scene_event.steps_on_lava),
             camera_aspect_ratio=self._config.get_screen_size(),
             camera_clipping_planes=self._scene_event.clipping_plane,
             camera_field_of_view=self._scene_event.camera_field_of_view,

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -1,5 +1,5 @@
 from enum import Enum, unique
-from typing import List
+from typing import List, Optional
 
 import typeguard
 
@@ -120,7 +120,7 @@ class GoalMetadata:
 
     @typeguard.typechecked
     def retrieve_action_list_at_step(self, step_number: int, 
-                                     steps_in_lava: int=0) -> List:
+                                     steps_in_lava: Optional[int]=0) -> List:
         """Return the action list from the given goal at the given step as a
         a list of actions tuples by default."""
         action_list = self._retrieve_unfiltered_action_list(
@@ -133,10 +133,10 @@ class GoalMetadata:
         ]
 
     def _retrieve_unfiltered_action_list(self, step_number: int,
-                                         steps_in_lava: int=0) -> List:
+                                         steps_in_lava: Optional[int]=0) -> List:
         # If steps in lava is greater than allowed, over ride
         #   action list and only return EndScene
-        if steps_in_lava > self.steps_allowed_in_lava:
+        if steps_in_lava != None and steps_in_lava > self.steps_allowed_in_lava:
             return [("EndScene", {})]
 
         '''Unfiltered action list from goal'''

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -119,8 +119,8 @@ class GoalMetadata:
         yield 'metadata', self.metadata
 
     @typeguard.typechecked
-    def retrieve_action_list_at_step(self, step_number: int, 
-                                     steps_in_lava: Optional[int]=0) -> List:
+    def retrieve_action_list_at_step(self, step_number: int,
+                                     steps_in_lava: Optional[int] = 0) -> List:
         """Return the action list from the given goal at the given step as a
         a list of actions tuples by default."""
         action_list = self._retrieve_unfiltered_action_list(
@@ -132,11 +132,14 @@ class GoalMetadata:
             for (action, params) in action_list
         ]
 
-    def _retrieve_unfiltered_action_list(self, step_number: int,
-                                         steps_in_lava: Optional[int]=0) -> List:
+    def _retrieve_unfiltered_action_list(self,
+                                         step_number: int,
+                                         steps_in_lava: Optional[int] = 0
+                                         ) -> List:
         # If steps in lava is greater than allowed, over ride
         #   action list and only return EndScene
-        if steps_in_lava != None and steps_in_lava > self.steps_allowed_in_lava:
+        if steps_in_lava is not None and (
+                steps_in_lava > self.steps_allowed_in_lava):
             return [("EndScene", {})]
 
         '''Unfiltered action list from goal'''

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -71,6 +71,8 @@ class GoalMetadata:
     metadata : dict
         The metadata specific to this goal. See
         :mod:`Goal <machine_common_sense.GoalCategory>`.
+    steps_allowed_in_lava : integer
+        The number of steps allowed in lava before the scene ends
     """
 
     # Don't allow a user to call the EndHabituation action unless it's
@@ -87,7 +89,8 @@ class GoalMetadata:
         habituation_total=0,
         last_preview_phase_step=0,
         last_step=None,
-        metadata=None
+        metadata=None,
+        steps_allowed_in_lava=0
     ):
         # The action_list must be None by default
         self.action_list = action_list
@@ -97,6 +100,7 @@ class GoalMetadata:
         self.last_preview_phase_step = last_preview_phase_step
         self.last_step = last_step
         self.metadata = {} if metadata is None else metadata
+        self.steps_allowed_in_lava = steps_allowed_in_lava
 
     def __str__(self):
         return Stringifier.class_to_str(self)
@@ -115,10 +119,12 @@ class GoalMetadata:
         yield 'metadata', self.metadata
 
     @typeguard.typechecked
-    def retrieve_action_list_at_step(self, step_number: int) -> List:
+    def retrieve_action_list_at_step(self, step_number: int, 
+                                     steps_in_lava: int=0) -> List:
         """Return the action list from the given goal at the given step as a
         a list of actions tuples by default."""
-        action_list = self._retrieve_unfiltered_action_list(step_number)
+        action_list = self._retrieve_unfiltered_action_list(
+            step_number, steps_in_lava)
         # remove EndHabituation parameters
         return [
             (action, params)
@@ -126,7 +132,13 @@ class GoalMetadata:
             for (action, params) in action_list
         ]
 
-    def _retrieve_unfiltered_action_list(self, step_number: int) -> List:
+    def _retrieve_unfiltered_action_list(self, step_number: int,
+                                         steps_in_lava: int=0) -> List:
+        # If steps in lava is greater than allowed, over ride
+        #   action list and only return EndScene
+        if steps_in_lava > self.steps_allowed_in_lava:
+            return [("EndScene", {})]
+
         '''Unfiltered action list from goal'''
         if self.action_list is not None:
             if step_number < self.last_preview_phase_step:

--- a/tests/test_goal_metadata.py
+++ b/tests/test_goal_metadata.py
@@ -13,7 +13,8 @@ class TestGoalMetadata(unittest.TestCase):
         "habituation_total": 0,
         "last_preview_phase_step": 0,
         "last_step": null,
-        "metadata": {}
+        "metadata": {},
+        "steps_allowed_in_lava": 0
     }'''
 
     @classmethod
@@ -77,6 +78,7 @@ class TestGoalMetadata(unittest.TestCase):
             ('LookDown', {}),
             ('RotateLeft', {}),
             ('RotateRight', {}),
+            ('EndScene', {}),
             ('Pass', {})
         ])
 
@@ -110,6 +112,24 @@ class TestGoalMetadata(unittest.TestCase):
         self.assertEqual(
             goal_metadata.retrieve_action_list_at_step(15), [])
 
+    def test_retrieve_action_too_many_steps_lava_default(self):
+        goal_metadata = mcs.GoalMetadata(
+            action_list=[],
+            last_step=10)
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(11, 1), [
+            ('EndScene', {})
+        ])
+
+    def test_retrieve_action_too_many_steps(self):
+        goal_metadata = mcs.GoalMetadata(
+            action_list=[],
+            last_step=10,
+            steps_allowed_in_lava=3)
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(11, 1), [])
+        self.assertEqual(goal_metadata.retrieve_action_list_at_step(11, 4), [
+            ('EndScene', {})
+        ])
+
     def test_retrieve_action_list_at_step(self):
         self.assertEqual(self.goal_metadata.retrieve_action_list_at_step(0), [
             ('CloseObject', {}),
@@ -129,6 +149,7 @@ class TestGoalMetadata(unittest.TestCase):
             ('LookDown', {}),
             ('RotateLeft', {}),
             ('RotateRight', {}),
+            ('EndScene', {}),
             ('Pass', {})
         ])
         self.assertEqual(self.goal_metadata.retrieve_action_list_at_step(10), [
@@ -149,6 +170,7 @@ class TestGoalMetadata(unittest.TestCase):
             ('LookDown', {}),
             ('RotateLeft', {}),
             ('RotateRight', {}),
+            ('EndScene', {}),
             ('Pass', {})
         ])
 
@@ -196,6 +218,7 @@ class TestGoalMetadata(unittest.TestCase):
             ('LookDown', {}),
             ('RotateLeft', {}),
             ('RotateRight', {}),
+            ('EndScene', {}),
             ('Pass', {})
         ])
         self.assertEqual(goal_metadata.retrieve_action_list_at_step(3), [
@@ -222,6 +245,7 @@ class TestGoalMetadata(unittest.TestCase):
             ('LookDown', {}),
             ('RotateLeft', {}),
             ('RotateRight', {}),
+            ('EndScene', {}),
             ('Pass', {})
         ])
 

--- a/tests/test_step_metadata.py
+++ b/tests/test_step_metadata.py
@@ -21,7 +21,8 @@ class TestStepMetadata(unittest.TestCase):
             "habituation_total": 0,
             "last_preview_phase_step": 0,
             "last_step": null,
-            "metadata": {}
+            "metadata": {},
+            "steps_allowed_in_lava": 0
         },
         "habituation_trial": null,
         "haptic_feedback": {},
@@ -55,7 +56,8 @@ class TestStepMetadata(unittest.TestCase):
             "habituation_total": 0,
             "last_preview_phase_step": 0,
             "last_step": null,
-            "metadata": {}
+            "metadata": {},
+            "steps_allowed_in_lava": 0
         },
         "habituation_trial": null,
         "haptic_feedback": {},


### PR DESCRIPTION
Add a config for the maximum number of steps allowed on lava.  The default is 0.  If the user exceeds the maximum allowable steps, the only option is to end the scene.