### PR TITLE
MCS-1202 Suppressed AI2-THOR Controller constructor print statements.

### DIFF
--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -1,6 +1,8 @@
 import atexit
+import contextlib
 import datetime
 import glob
+import io
 import json
 import logging
 import os
@@ -90,21 +92,23 @@ class Controller():
     @typeguard.typechecked
     def __init__(self, unity_app_file_path: str, config: ConfigManager):
 
-        self._controller = ai2thor.controller.Controller(
-            quality='Medium',
-            fullscreen=False,
-            headless=False,  # TODO confirm functionality
-            local_executable_path=unity_app_file_path,
-            width=config.get_screen_width(),
-            height=config.get_screen_height(),
-            scene='MCS',  # Unity scene name
-            logs=True,
-            # This constructor always initializes a scene, so add a scene
-            # config to ensure it doesn't error
-            sceneConfig={
-                "objects": []
-            }
-        )
+        # Suppress print statements from the AI2-THOR Controller's constructor.
+        with contextlib.redirect_stdout(io.StringIO()) as _:
+            self._controller = ai2thor.controller.Controller(
+                quality='Medium',
+                fullscreen=False,
+                headless=False,  # TODO confirm functionality
+                local_executable_path=unity_app_file_path,
+                width=config.get_screen_width(),
+                height=config.get_screen_height(),
+                scene='MCS',  # Unity scene name
+                logs=True,
+                # This constructor always initializes a scene, so add a scene
+                # config to ensure it doesn't error
+                sceneConfig={
+                    "objects": []
+                }
+            )
 
         if not self._controller:
             raise Exception('AI2-THOR/Unity Controller failed to initialize')


### PR DESCRIPTION
This is a funny little PR, and I'm looking for everyone's feedback on my solution. I'm tired of seeing the "Initialize return..." message that is printed by the AI2-THOR Controller in its constructor. This is now particularly problematic because it prints out the default (wrong) clipping planes rather than our modified (correct) ones. My change wraps the constructor to redirect stdout to an empty stream. This seemed easier than removing the print statement from the ai2thor python library, publishing a new version to pypi, updating our dependencies everywhere, and having to maintain the new published version. I'm looking forward to having a discussion here about the pros and cons of different approaches.