### PR TITLE
Update test for passive scene to better catch issues in the future.

### DIFF
--- a/integration_tests/data/069.intuitive_physics_scene_start.actions.txt
+++ b/integration_tests/data/069.intuitive_physics_scene_start.actions.txt
@@ -1,1 +1,11 @@
 ﻿Pass
+Pass
+Pass
+Pass
+Pass
+Pass
+Pass
+Pass
+Pass
+Pass
+Pass

--- a/integration_tests/data/069.intuitive_physics_scene_start.level1.outputs.json
+++ b/integration_tests/data/069.intuitive_physics_scene_start.level1.outputs.json
@@ -16,4 +16,94 @@
     "rotation_y": null,
     "objects_count": 0,
     "structural_objects_count": 0
+}, {
+    "step_number": 2,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 3,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 4,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 5,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 6,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 7,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 8,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 9,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 10,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 11,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
 }]

--- a/integration_tests/data/069.intuitive_physics_scene_start.level2.outputs.json
+++ b/integration_tests/data/069.intuitive_physics_scene_start.level2.outputs.json
@@ -16,4 +16,94 @@
     "rotation_y": null,
     "objects_count": 0,
     "structural_objects_count": 0
+}, {
+    "step_number": 2,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 3,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 4,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 5,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 6,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 7,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 8,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 9,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 10,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
+}, {
+    "step_number": 11,
+    "head_tilt": 0,
+    "position_x": null,
+    "position_z": null,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": null,
+    "objects_count": 0,
+    "structural_objects_count": 0
 }]

--- a/integration_tests/data/069.intuitive_physics_scene_start.oracle.outputs.json
+++ b/integration_tests/data/069.intuitive_physics_scene_start.oracle.outputs.json
@@ -12,21 +12,6 @@
         "structural_objects": [
             {
                 "direction_x": 0.0,
-                "direction_y": 1.0,
-                "direction_z": 0.0,
-                "distance": 2.488,
-                "held": false,
-                "id": "ceiling",
-                "position_x": 0.0,
-                "position_z": 0.0,
-                "shape": "structural",
-                "texture_color_list": [
-                    "white"
-                ],
-                "visible": true
-            },
-            {
-                "direction_x": 0.0,
                 "direction_y": -0.36,
                 "direction_z": 0.93,
                 "distance": 4.83,
@@ -99,9 +84,39 @@
                     "white"
                 ],
                 "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.34050261974334717,
+                "direction_z": 0.9363821744918823,
+                "distance": 5.8736701011657715,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
             }
         ],
-        "structural_objects_count": 5
+        "structural_objects_count": 7
     },
     {
         "camera_height": 1.5,
@@ -116,11 +131,11 @@
         "structural_objects": [
             {
                 "direction_x": 0.0,
-                "direction_y": 1.0,
-                "direction_z": 0.0,
-                "distance": 2.488,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
                 "held": false,
-                "id": "ceiling",
+                "id": "floor",
                 "position_x": 0.0,
                 "position_z": 0.0,
                 "shape": "structural",
@@ -129,6 +144,110 @@
                 ],
                 "visible": true
             },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.37007471919059753,
+                "direction_z": 0.9251867532730103,
+                "distance": 5.9447455406188965,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.03619058057665825,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 2,
+        "structural_objects": [
             {
                 "direction_x": 0.0,
                 "direction_y": -0.36,
@@ -203,8 +322,1109 @@
                     "white"
                 ],
                 "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.39856332540512085,
+                "direction_z": 0.9133742451667786,
+                "distance": 6.021627902984619,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.07223937660455704,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
             }
         ],
-        "structural_objects_count": 5
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 3,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.43,
+                "direction_z": 0.9,
+                "distance": 6.1,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.11,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 4,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.45,
+                "direction_z": 0.89,
+                "distance": 6.19,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.14,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 5,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.08,
+                "direction_y": 0.48,
+                "direction_z": 0.88,
+                "distance": 6.28,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.18,
+                "direction_z": 0.98,
+                "distance": 5.61,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 6,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.45,
+                "direction_z": 0.89,
+                "distance": 6.19,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.14,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 7,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.43,
+                "direction_z": 0.9,
+                "distance": 6.1,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.11,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 8,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.39856332540512085,
+                "direction_z": 0.9133742451667786,
+                "distance": 6.021627902984619,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.07223937660455704,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 9,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.37,
+                "direction_z": 0.93,
+                "distance": 5.94,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.04,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 10,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.34,
+                "direction_z": 0.94,
+                "distance": 5.87,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.0,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
+    },
+    {
+        "camera_height": 1.5,
+        "head_tilt": 0,
+        "objects_count": 0,
+        "position_x": 0.0,
+        "position_y": 1.5,
+        "position_z": -4.5,
+        "return_status": "SUCCESSFUL",
+        "rotation_y": 0.0,
+        "step_number": 11,
+        "structural_objects": [
+            {
+                "direction_x": 0.0,
+                "direction_y": -0.36,
+                "direction_z": 0.93,
+                "distance": 4.83,
+                "held": false,
+                "id": "floor",
+                "position_x": 0.0,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.0,
+                "direction_z": -1.0,
+                "distance": 0.75,
+                "held": false,
+                "id": "wall_back",
+                "position_x": 0.0,
+                "position_z": -5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.0,
+                "direction_y": 0.15,
+                "direction_z": 0.99,
+                "distance": 9.86,
+                "held": false,
+                "id": "wall_front",
+                "position_x": 0.0,
+                "position_z": 5.25,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": -0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_left",
+                "position_x": -7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.854,
+                "direction_y": 0.0,
+                "direction_z": 0.513,
+                "distance": 8.778,
+                "held": false,
+                "id": "wall_right",
+                "position_x": 7.5,
+                "position_z": 0.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.34,
+                "direction_z": 0.94,
+                "distance": 5.87,
+                "held": false,
+                "id": "occluder_pole",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "white"
+                ],
+                "visible": true
+            },
+            {
+                "direction_x": 0.09053575247526169,
+                "direction_y": 0.0,
+                "direction_z": 0.993752658367157,
+                "distance": 5.534576416015625,
+                "held": false,
+                "id": "occluder_wall",
+                "position_x": 0.5,
+                "position_z": 1.0,
+                "shape": "structural",
+                "texture_color_list": [
+                    "orange"
+                ],
+                "visible": true
+            }
+        ],
+        "structural_objects_count": 7
     }
 ]

--- a/integration_tests/data/069.intuitive_physics_scene_start.scene.json
+++ b/integration_tests/data/069.intuitive_physics_scene_start.scene.json
@@ -15,5 +15,102 @@
             "y": 0
         }
     },
-    "objects": []
+    "objects": [
+        {
+            "id": "occluder_wall",
+            "type": "cube",
+            "kinematic": true,
+            "structure": true,
+            "mass": 100,
+            "materials": ["Custom/Materials/OrangeDrywallMCS"],
+            "shows": [
+              {
+                "stepBegin": 0,
+                "position": {
+                  "x": 0.5,
+                  "y": 1.5,
+                  "z": 1
+                },
+                "rotation": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 0
+                },
+                "scale": {
+                  "x": 2.3248018464562668,
+                  "y": 3,
+                  "z": 0.1
+                }
+              }
+            ],
+            "moves": [
+              {
+                "stepBegin": 1,
+                "stepEnd": 5,
+                "vector": {
+                  "x": 0,
+                  "y": 0.20,
+                  "z": 0
+                }
+              },
+              {
+                "stepBegin": 6,
+                "stepEnd": 10,
+                "vector": {
+                  "x": 0,
+                  "y": -0.20,
+                  "z": 0
+                }
+              }
+            ]
+          },
+          {
+            "id": "occluder_pole",
+            "type": "cylinder",
+            "kinematic": true,
+            "structure": true,
+            "mass": 100,
+            "materials": ["AI2-THOR/Materials/Metals/WhiteMetal"],
+            "shows": [
+              {
+                "stepBegin": 0,
+                "position": {
+                  "x": 0.5,
+                  "y": 3.5,
+                  "z": 1
+                },
+                "rotation": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 0
+                },
+                "scale": {
+                  "x": 0.095,
+                  "y": 0.5,
+                  "z": 0.095
+                }
+              }
+            ],
+            "moves": [
+              {
+                "stepBegin": 1,
+                "stepEnd": 5,
+                "vector": {
+                  "x": 0,
+                  "y": 0.20,
+                  "z": 0
+                }
+              },
+              {
+                "stepBegin": 6,
+                "stepEnd": 10,
+                "vector": {
+                  "x": 0,
+                  "y": -0.20,
+                  "z": 0
+                }
+              }
+            ]
+          }
+    ]
 }


### PR DESCRIPTION
Update related to the recent bug with passive scenes I mentioned this morning (belatedly made a ticket here: https://nextcentury.atlassian.net/browse/MCS-1239)

Thomas brought up the fair point on the Unity PR that the integration tests should've caught this. It didn't because our integration test passive scene was empty and only had one frame (this error in particular didn't result in Unity closing and you could still "Pass", but the frames just never updated properly after the first one). I added a moving occluder to the passive scene test (069) so that if something like this happens again, the test should fail. Note that this should pass with the recent ai2thor development build, but will fail (correctly) against 0.5.1.