### PR TITLE
changed cache addressables to use the auto-downloader when build path isn't provided

### DIFF
--- a/machine_common_sense/scripts/cache_addressables.py
+++ b/machine_common_sense/scripts/cache_addressables.py
@@ -1,6 +1,9 @@
 import argparse
 import os
 
+from machine_common_sense.unity_executable_provider import \
+    UnityExecutableProvider
+
 '''
 Script will start Unity build with a flag to clear the addressables cache,
 cache all the data in catalog and then close the application.
@@ -20,8 +23,10 @@ executables.
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('build_path',
-                        help="Unity build path")
+    parser.add_argument('--build_path',
+                        help="Unity build path.",
+                        required=False,
+                        default=None)
     return parser.parse_args()
 
 
@@ -31,7 +36,10 @@ def run_caching_build(build_path):
 
 def main():
     args = parse_args()
-    run_caching_build(args.build_path)
+    path = args.build_path
+    if not path:
+        path = UnityExecutableProvider().get_executable(force_download=True)
+    run_caching_build(path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Jed wanted a script to run to download the proper unity build and then run cache addressables.  I figured this should be easy.  Additionally, maybe this is what we should have been doing, but never really thought about since cache_addressables was created prior to the auto downloader.

This was easy enough to just do the work and debate whether it is warranted in the PR.  We can easily delete if we don't want to do this.

Reference to conversation in with Jed:
https://machinecommonsense.slack.com/archives/CTR31V12M/p1648766818248429?thread_ts=1648692973.586849&cid=CTR31V12M