### PR TITLE
MCS-1293 - Bug fix for Slack Issue

### DIFF
--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -42,9 +42,11 @@ class HistoryEventHandler(AbstractControllerSubscriber):
 
             # Create a new scene history writer with each new scene (config
             # data) so we always create a new, separate scene history file.
+            # Also, ensure previous history item is cleared.
             self.__history_writer = HistoryWriter(payload.scene_config,
                                                   hist_info,
                                                   payload.timestamp)
+            self.__history_item = None
 
     def on_before_step(self, payload: BeforeStepPayload):
         if payload.config.is_history_enabled():


### PR DESCRIPTION
Thread here along with run scripts to replicate on development: https://machinecommonsense.slack.com/archives/CTR31V12M/p1649208125675129

Fix turned out to be pretty easy. This happens when running multiple scenes in succession (originally I just fixed the original logged error with the object_list, but it turns out it after that it was writing the previous scene file's last history item to the new scene's history file). Wouldn't be an issue during evals since we run one at a time. 