### PR TITLE
Round all floats in history

### DIFF
--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -145,9 +145,9 @@ class HistoryWriter(object):
                         cls=NumpyEncoder))
 
     # This could easily be moved to a more accessible utility file.
-    def _round_all(self, obj):
+    def _round_all(self, obj, num_digits=4):
         if isinstance(obj, float):
-            obj = round(obj, 4)
+            obj = round(obj, num_digits)
         elif isinstance(obj, list):
             obj = [self._round_all(item) for item in obj]
         elif isinstance(obj, dict):
@@ -155,6 +155,9 @@ class HistoryWriter(object):
                 subkey: self._round_all(val) for subkey,
                 val in obj.items()}
             obj = new_obj
+        elif isinstance(obj, tuple):
+            obj = list(obj)
+            obj = tuple(self._round_all(obj))
         return obj
 
     def update_history_output(

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -138,10 +138,24 @@ class HistoryWriter(object):
         if self.scene_history_file:
             logger.info(f"Saving history file {self.scene_history_file}")
             with open(self.scene_history_file, "a+") as history_file:
+                history = self._round_all(self.history_obj)
                 history_file.write(
                     json.dumps(
-                        self.history_obj,
+                        history,
                         cls=NumpyEncoder))
+
+    # This could easily be moved to a more accessible utility file.
+    def _round_all(self, obj):
+        if isinstance(obj, float):
+            obj = round(obj, 4)
+        elif isinstance(obj, list):
+            obj = [self._round_all(item) for item in obj]
+        elif isinstance(obj, dict):
+            new_obj = {
+                subkey: self._round_all(val) for subkey,
+                val in obj.items()}
+            obj = new_obj
+        return obj
 
     def update_history_output(
             self,


### PR DESCRIPTION
This work rounds all the float values in the history file just before writing.  It should be tested in ingest, but I've been unable to figure out how to test ingest based on the readme.  `python mcs_scene_ingest.py --folder <folder> --eval_name <name>` was not working for me.