### PR TITLE
MCS-1315 Trying to improve visibility of debug depth images.

### DIFF
--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -186,3 +186,15 @@ Releases
 
 Please see the following `Confluence page <https://nextcentury.atlassian.net/wiki/spaces/MCS/pages/1442742340/MCS+Release+Procedures>`_
 
+Depth Map Data
+--------------
+
+- In `machine_common_sense/step_metadata.py`, in the `StepMetadata` class, in the `__iter__` function, add `yield 'depth_map_list', self.depth_map_list` in order to save the depth map data in debug output files.
+- Run a scene with `debug` set to `true` and `metadata` NOT set to `none`.
+
+.. code-block:: console
+
+    (mcs) $ python machine_common_sense/scripts/run_human_input.py --config_file machine_common_sense/scripts/config_level1_debug.ini docs/source/scenes/playroom.json
+
+- Open one of the debug `mcs_output` files (like `playroom/mcs_output_0.json`) to see the `depth_map_list`
+

--- a/machine_common_sense/controller_media.py
+++ b/machine_common_sense/controller_media.py
@@ -21,8 +21,6 @@ def convert_depth_to_hsv(
     depth_float_array: np.array,
     clipping_plane_far: float
 ) -> np.array:
-    clipping_plane_far = 150.0
-
     # Split the depth data into multiple color bands. Each band corresponds to
     # the full hue spectrum, from red to purple, at a specific saturation and
     # value. Near bands have lower saturation (closer to white); far bands have

--- a/machine_common_sense/controller_media.py
+++ b/machine_common_sense/controller_media.py
@@ -42,6 +42,7 @@ def convert_depth_to_hsv(
         255 - np.floor((depth_float_array - mid_val) / band_size),
         255
     )
+    # Note that PIL images use HSV ints between 0 and 255 inclusive.
     depth_hsv_array[:shape[0], :shape[1], 0] = hue
     depth_hsv_array[:shape[0], :shape[1], 1] = sat
     depth_hsv_array[:shape[0], :shape[1], 2] = val

--- a/machine_common_sense/stringifier.py
+++ b/machine_common_sense/stringifier.py
@@ -12,7 +12,7 @@ class Stringifier:
     which is why this is seperate from serialization
     """
 
-    NUMBER_OF_DECIMALS = 8
+    NUMBER_OF_DECIMALS = 6
     NUMBER_OF_SPACES = 4
 
     @staticmethod

--- a/machine_common_sense/stringifier.py
+++ b/machine_common_sense/stringifier.py
@@ -12,7 +12,7 @@ class Stringifier:
     which is why this is seperate from serialization
     """
 
-    NUMBER_OF_DECIMALS = 4
+    NUMBER_OF_DECIMALS = 8
     NUMBER_OF_SPACES = 4
 
     @staticmethod

--- a/tests/test_controller_media.py
+++ b/tests/test_controller_media.py
@@ -1,0 +1,31 @@
+import unittest
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from machine_common_sense.controller_media import convert_depth_to_hsv
+
+
+class TestControllerMedia(unittest.TestCase):
+
+    def test_convert_depth_to_hsv_hue(self):
+        diff = 0.375 / 256.0
+        input_array = np.array([np.arange(0, 0.375, diff)])
+        actual_output = convert_depth_to_hsv(input_array, 150.0)
+        expected_output = np.array([[[i, 55, 255] for i in range(0, 256)]])
+        assert_array_equal(actual_output, expected_output)
+
+    def test_convert_depth_to_hsv_sat_and_val(self):
+        input_array = np.array([
+            np.arange(i, i + 3.75, 0.375) for i in np.arange(0, 150, 3.75)
+        ])
+        actual_output = convert_depth_to_hsv(input_array, 150.0)
+        expected_output = np.reshape(np.array([
+            [[0, i, 255] for i in range(55, 256)] +
+            [[0, 255, i] for i in reversed(range(56, 255))]
+        ]), (40, 10, 3))
+        assert_array_equal(actual_output, expected_output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_stringifier.py
+++ b/tests/test_stringifier.py
@@ -124,8 +124,11 @@ class TestStringifier(unittest.TestCase):
     def test_value_to_str_with_float(self):
         self.assertEqual(mcs.Stringifier.value_to_str(0.0), "0.0")
         self.assertEqual(mcs.Stringifier.value_to_str(1234.5678), "1234.5678")
-        self.assertEqual(mcs.Stringifier.value_to_str(0.12345678), "0.1235")
-        self.assertEqual(mcs.Stringifier.value_to_str(-0.12345678), "-0.1235")
+        self.assertEqual(mcs.Stringifier.value_to_str(0.12345678), "0.123457")
+        self.assertEqual(
+            mcs.Stringifier.value_to_str(-0.12345678),
+            "-0.123457"
+        )
 
     def test_value_to_str_with_integer(self):
         self.assertEqual(mcs.Stringifier.value_to_str(0), "0")


### PR DESCRIPTION
Here's my stab at improving the visibility in the debug depth images. Open to discussion and ideas for alternative approaches. Note that you'll need this fix: https://github.com/NextCenturyCorporation/ai2thor/pull/242 (Or temporarily hard-code the `clipping_plane_far` to `150.0`)

- Changed images from greyscale to RGB (technically they're HSV but then saved as RGB)
- Added 400 color bands across the camera's entire visibility range (from `0` to `150`). Each individual color band covers the entire hue spectrum (from red to purple), and each successive color band gets a little darker (from light red - light purple in the first band, to dark red - dark purple in the last band) by lowering the saturation or value. This sounds weird, but is effective.

Comparison of the playroom scene:

![depth_image_playroom_old](https://user-images.githubusercontent.com/10994382/165758086-806f750e-e838-4ea2-888d-8145306dc4ac.png)

![depth_image_playroom_new](https://user-images.githubusercontent.com/10994382/165758118-bf9ef865-7ba6-4481-a945-6d1760846227.png)

Comparison of the huge room scene:

![depth_image_huge_room_old](https://user-images.githubusercontent.com/10994382/165758159-7c7c7726-ad67-4161-879c-b85ef30d4a57.png)

![depth_image_huge_room_new](https://user-images.githubusercontent.com/10994382/165758177-20ab0cfa-eb0f-4145-aeed-11d38329d360.png)
