### PR TITLE
Changed logging config to set root level logging higher and configurable

### DIFF
--- a/machine_common_sense/logging_config.py
+++ b/machine_common_sense/logging_config.py
@@ -134,7 +134,8 @@ class LoggingConfig():
             info_file: bool = False,
             log_file_name: str = "mcs",
             file_format: str = 'precise',
-            console_format: str = 'brief'):
+            console_format: str = 'brief',
+            root_log_level: str = 'WARN'):
         """[summary]
 
         Args:
@@ -218,7 +219,7 @@ class LoggingConfig():
         return {
             "version": 1,
             "root": {
-                "level": log_level,
+                "level": root_log_level,
                 "handlers": handler_tags,
                 "propagate": False
             },

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -6,11 +6,11 @@ from machine_common_sense import LoggingConfig
 class TestLoggingConfig(unittest.TestCase):
     def test_logging_config(self):
         cfg = LoggingConfig.get_configurable_logging_config(
-            'INFO', ['l1', 'l2'], False, False, True)
+            'INFO', ['l1', 'l2'], False, False, True, root_log_level='ERROR')
         root = cfg['root']
         loggers = cfg['loggers']
         handlers = cfg['handlers']
-        self.assertEqual(root['level'], 'INFO')
+        self.assertEqual(root['level'], 'ERROR')
         self.assertEqual(len(loggers), 2)
         self.assertEqual(len(handlers), 1)
         self.assertIn("l1", loggers)
@@ -30,7 +30,7 @@ class TestLoggingConfig(unittest.TestCase):
         root = cfg['root']
         loggers = cfg['loggers']
         handlers = cfg['handlers']
-        self.assertEqual(root['level'], 'ERROR')
+        self.assertEqual(root['level'], 'WARN')
         self.assertEqual(len(loggers), 1)
         self.assertEqual(len(handlers), 2)
         self.assertIn("l1", loggers)


### PR DESCRIPTION
This affects other libraries that use python logging.  I was getting some log from matlabplot on the debug level that I didn't want.  I seem to still be getting a print statement from them when i use breakpoints, but I can live with that.:

`Backend TkAgg is interactive backend. Turning interactive mode on.`