### PR TITLE
MCS-1339 Added start data to scene history file

### DIFF
--- a/machine_common_sense/controller_events.py
+++ b/machine_common_sense/controller_events.py
@@ -117,14 +117,14 @@ class AbstractControllerSubscriber(ABC):
             "default")(
             payload)
 
-    def on_start_scene(self, payload: ControllerEventPayload):
+    def on_start_scene(self, payload: StartScenePayload):
         pass
 
-    def on_before_step(self, payload: ControllerEventPayload):
+    def on_before_step(self, payload: BeforeStepPayload):
         pass
 
-    def on_after_step(self, payload: ControllerEventPayload):
+    def on_after_step(self, payload: AfterStepPayload):
         pass
 
-    def on_end_scene(self, payload: ControllerEventPayload):
+    def on_end_scene(self, payload: EndScenePayload):
         pass

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -46,6 +46,15 @@ class HistoryEventHandler(AbstractControllerSubscriber):
             self.__history_writer = HistoryWriter(payload.scene_config,
                                                   hist_info,
                                                   payload.timestamp)
+            init_history = SceneHistory(
+                step=payload.step_number,
+                action='Initialize',
+                args={},
+                # We don't have the equivalent of params at this point
+                params=None,
+                output=payload.step_output.copy_without_depth_or_images(),
+                delta_time_millis=0)
+            self.__history_writer.add_step(init_history)
             self.__history_item = None
 
     def on_before_step(self, payload: BeforeStepPayload):

--- a/tests/test_history_event_handler.py
+++ b/tests/test_history_event_handler.py
@@ -36,7 +36,7 @@ class TestHistoryEventHandler(unittest.TestCase):
 
     def test_on_start_scene(self):
         test_payload = {
-            "step_number": 1,
+            "step_number": 0,
             "config": self.config_mngr,
             "scene_config": self.scene_config,
             "output_folder": None,
@@ -55,8 +55,19 @@ class TestHistoryEventHandler(unittest.TestCase):
 
         self.assertIsNotNone(
             self.histEvents._HistoryEventHandler__history_writer)
-        self.assertIsNotNone(
+        writer: HistoryWriter = (
             self.histEvents._HistoryEventHandler__history_writer)
+        self.assertIsNotNone(writer.current_steps)
+        step = writer.current_steps[0]
+        self.assertEqual(step['step'], 0)
+        self.assertEqual(step['action'], 'Initialize')
+        self.assertEqual(step['args'], {})
+
+        self.assertIsNotNone(step['output'])
+
+        self.assertIsNone(step['params'])
+        self.assertIsNone(step['classification'])
+        self.assertIsNone(step['confidence'])
 
     def test_on_start_scene_hist_not_enabled(self):
         self.config_mngr._config[


### PR DESCRIPTION
Adds data from step 0 (when the action is 'initialize' and no real commands have been sent)