### PR TITLE
MCS-1342: Add 'targetIsVisibleAtStart' to first object in history

### DIFF
--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -53,7 +53,11 @@ class HistoryEventHandler(AbstractControllerSubscriber):
                 # We don't have the equivalent of params at this point
                 params=None,
                 output=payload.step_output.copy_without_depth_or_images(),
-                delta_time_millis=0)
+                delta_time_millis=0,
+                target_is_visible_at_start=(
+                    payload.step_metadata.metadata.get(
+                        'targetIsVisibleAtStart')
+                ))
             self.__history_writer.add_step(init_history)
             self.__history_item = None
 

--- a/machine_common_sense/history_writer.py
+++ b/machine_common_sense/history_writer.py
@@ -53,11 +53,7 @@ class HistoryEventHandler(AbstractControllerSubscriber):
                 # We don't have the equivalent of params at this point
                 params=None,
                 output=payload.step_output.copy_without_depth_or_images(),
-                delta_time_millis=0,
-                target_is_visible_at_start=(
-                    payload.step_metadata.metadata.get(
-                        'targetIsVisibleAtStart')
-                ))
+                delta_time_millis=0)
             self.__history_writer.add_step(init_history)
             self.__history_item = None
 
@@ -79,7 +75,10 @@ class HistoryEventHandler(AbstractControllerSubscriber):
             args=payload.action_kwargs,
             params=payload.step_params,
             output=output,
-            delta_time_millis=0)
+            delta_time_millis=0,
+            target_is_visible_at_start=(
+                payload.step_metadata.metadata.get(
+                    'targetIsVisibleAtStart')))
 
     def on_end_scene(self, payload: EndScenePayload):
         if (

--- a/machine_common_sense/scene_history.py
+++ b/machine_common_sense/scene_history.py
@@ -52,5 +52,6 @@ class SceneHistory(object):
             self.output) is not None else self.output
         yield 'delta_time_millis', self.delta_time_millis
         yield 'target_visible', self.target_visible
-        yield 'target_is_visible_at_start', (
-            self.target_is_visible_at_start)
+        if self.target_is_visible_at_start is not None:
+            yield 'target_is_visible_at_start', (
+                self.target_is_visible_at_start)

--- a/machine_common_sense/scene_history.py
+++ b/machine_common_sense/scene_history.py
@@ -18,8 +18,8 @@ class SceneHistory(object):
         internal_state: object = None,
         delta_time_millis=0,
         output=None,
-        target_visible=False
-
+        target_visible=False,
+        target_is_visible_at_start=None
     ):
         self.step = step
         self.action = action
@@ -32,6 +32,7 @@ class SceneHistory(object):
         self.delta_time_millis = delta_time_millis
         self.output = output
         self.target_visible = target_visible
+        self.target_is_visible_at_start = target_is_visible_at_start
 
     def __str__(self):
         return Stringifier.class_to_str(self)
@@ -51,3 +52,5 @@ class SceneHistory(object):
             self.output) is not None else self.output
         yield 'delta_time_millis', self.delta_time_millis
         yield 'target_visible', self.target_visible
+        yield 'target_is_visible_at_start', (
+            self.target_is_visible_at_start)

--- a/tests/test_history_event_handler.py
+++ b/tests/test_history_event_handler.py
@@ -42,8 +42,7 @@ class TestHistoryEventHandler(unittest.TestCase):
             "output_folder": None,
             "timestamp": "20210831-202203",
             "wrapped_step": {},
-            "step_metadata": Event({'screenWidth': 400, 'screenHeight': 600,
-                                    'targetIsVisibleAtStart': True}),
+            "step_metadata": Event({'screenWidth': 400, 'screenHeight': 600}),
             "step_output": StepMetadata(),
             "restricted_step_output": StepMetadata(),
             "goal": GoalMetadata()
@@ -69,7 +68,6 @@ class TestHistoryEventHandler(unittest.TestCase):
         self.assertIsNone(step['params'])
         self.assertIsNone(step['classification'])
         self.assertIsNone(step['confidence'])
-        self.assertTrue(step['target_is_visible_at_start'])
 
     def test_on_start_scene_hist_not_enabled(self):
         self.config_mngr._config[
@@ -156,7 +154,8 @@ class TestHistoryEventHandler(unittest.TestCase):
             "output_folder": None,
             "timestamp": "20210831-202203",
             "wrapped_step": StepMetadata(),
-            "step_metadata": Event({'screenHeight': 400, 'screenWidth': 600}),
+            "step_metadata": Event({'screenHeight': 400, 'screenWidth': 600,
+                                    'targetIsVisibleAtStart': True}),
             "step_output": StepMetadata(),
             "restricted_step_output": StepMetadata()
         }
@@ -172,6 +171,7 @@ class TestHistoryEventHandler(unittest.TestCase):
         self.assertEqual(hist.step, 1)
         self.assertEqual(hist.action, mcs.Action.MOVE_AHEAD.value)
         self.assertEqual(hist.delta_time_millis, 0)
+        self.assertTrue(hist.target_is_visible_at_start)
 
     def test_on_end_scene(self):
         self.histEvents._HistoryEventHandler__history_writer = HistoryWriter(

--- a/tests/test_history_event_handler.py
+++ b/tests/test_history_event_handler.py
@@ -42,7 +42,8 @@ class TestHistoryEventHandler(unittest.TestCase):
             "output_folder": None,
             "timestamp": "20210831-202203",
             "wrapped_step": {},
-            "step_metadata": Event({'screenWidth': 400, 'screenHeight': 600}),
+            "step_metadata": Event({'screenWidth': 400, 'screenHeight': 600,
+                'targetIsVisibleAtStart': True}),
             "step_output": StepMetadata(),
             "restricted_step_output": StepMetadata(),
             "goal": GoalMetadata()
@@ -68,6 +69,7 @@ class TestHistoryEventHandler(unittest.TestCase):
         self.assertIsNone(step['params'])
         self.assertIsNone(step['classification'])
         self.assertIsNone(step['confidence'])
+        self.assertTrue(step['target_is_visible_at_start'])
 
     def test_on_start_scene_hist_not_enabled(self):
         self.config_mngr._config[

--- a/tests/test_history_event_handler.py
+++ b/tests/test_history_event_handler.py
@@ -43,7 +43,7 @@ class TestHistoryEventHandler(unittest.TestCase):
             "timestamp": "20210831-202203",
             "wrapped_step": {},
             "step_metadata": Event({'screenWidth': 400, 'screenHeight': 600,
-                'targetIsVisibleAtStart': True}),
+                                    'targetIsVisibleAtStart': True}),
             "step_output": StepMetadata(),
             "restricted_step_output": StepMetadata(),
             "goal": GoalMetadata()


### PR DESCRIPTION
All, I have some more integration testing to do with the Jacobs branch, but wanted to get this in front of everyone.