### PR TITLE
found and fixed a vector3d that didn't get fixed from the pydantic change

### DIFF
--- a/machine_common_sense/plotter.py
+++ b/machine_common_sense/plotter.py
@@ -175,7 +175,7 @@ class TopDownPlotter():
 
         self._room_size = (
             # Room is automatically expanded in intuitive physics scenes.
-            Vector3d(14, 10, 10) if scene_config.intuitive_physics
+            Vector3d(x=14, y=10, z=10) if scene_config.intuitive_physics
             else scene_config.room_dimensions
         )
         self._team = team


### PR DESCRIPTION
This was causing the top down plotter to fail on intuitive physics scenes.  I'm not sure if they are important in that case, but they shouldn't throw exceptions.