### PR TITLE
Updating the instructions for running remotely.

### DIFF
--- a/docs/source/remotely.rst
+++ b/docs/source/remotely.rst
@@ -9,18 +9,26 @@ To run MCS on a remote GPU server, use the following steps to launch an X11 serv
 
 .. code-block:: console
 
-    # query the gpu bus ID
-    $ nvidia-xconfig --query-gpu-info
+    # Update and install dependencies
+    $ sudo apt-get install xserver-xorg
+    $ sudo apt-get install xorg
+    $ sudo apt-get install nvidia-driver-470
+    $ sudo apt-get install glxinfo
 
+    # Identify your machine's GPU BusID
+    $ nvidia-xconfig --query-gpu-info
     GPU #0:
     Name      : Tesla K80
     UUID      : GPU-d03a3d49-0641-40c9-30f2-5c3e4bdad498
     PCI BusID : PCI:0:30:0
-    # create the xserver configuration
+
+    # Create the Xserver configuration using the BusID
     $ sudo nvidia-xconfig --use-display-device=None --virtual=600x400 --output-xconfig=/etc/X11/xorg.conf --busid=PCI:0:30:0
-    # launch Xserver
+
+    # Launch Xserver
     $ sudo /usr/bin/Xorg :0 &
-    # test using glxinfo
+
+    # Test the display setting using glxinfo
     $ DISPLAY=:0 glxinfo
     name of display: :0
     display: :0  screen: 0
@@ -29,61 +37,40 @@ To run MCS on a remote GPU server, use the following steps to launch an X11 serv
     server glx version string: 1.4
 
 
-Remote Run Test Script
-----------------------
-
-Run the following script to test MCS with the X11 server created above.
-
-.. code-block:: python
-
-    # test.py
-    import machine_common_sense as mcs
-    # use your path to the MCS Unity executable
-    controller = mcs.create_controller(config_file_or_dict={})
-    # find a test scene
-    scene_file_path = 'docs/source/scenes/ball_far.json'
-    scene_data = mcs.load_scene_json_file(scene_file_path)
-    scene_file_name = scene_file_path[scene_file_path.rfind('/')+1]
-    if 'name' not in scene_data.keys():
-        scene_data['name'] = scene_file_name[0:scene_file_name.find('.')]
-    output = controller.start_scene(scene_data)
-    for i in range(1, 12):
-        output = controller.step('RotateLook')
-
-From your python environment, run test.py and check the output images for proper rendering.
+Remote Cache Addressables Script
+--------------------------------
 
 .. code-block:: console
 
-    DISPLAY=:0 python test.py
+    # Activate your python virtual environment
+    $ DISPLAY=:0 cache_addressables
 
-Remote on AWS 
--------------
+Remote Runs on AWS 
+------------------
 
 The following code was run on an AWS p2-xlarge with the Ubuntu Deep Learning AMI.
 
 .. code-block:: bash
 
-    sudo apt-get install xorg glxinfo python3-venv
-    nvidia-xconfig --query-gpu-info
+    # Follow the instructions listed above to launch Xserver
+    $ sudo nvidia-xconfig --use-display-device=None --virtual=600x400 --output-xconfig=/etc/X11/xorg.conf --busid=PCI:0:30:0
+    $ sudo /usr/bin/Xorg :0 &
 
-    # Get PCI BusID: and make sure it matches in the next command
+    # Download the MCS repository
+    $ git clone https://github.com/NextCenturyCorporation/MCS.git
+    $ cd MCS
 
-    sudo nvidia-xconfig --use-display-device=None --virtual=600x400 --output-xconfig=/etc/X11/xorg.conf --busid=PCI:0:30:0
+    # Install and activate a new python virtual environment
+    $ sudo apt-get install python3-venv
+    $ sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    $ python -m venv venv
+    $ . venv/bin/activate
 
-    sudo /usr/bin/Xorg :0 &
+    # Install the python dependencies
+    $ pip install --upgrade pip setuptools wheel
+    $ python -m pip install -r requirements.txt
+    $ python -m pip install -e .
 
-    sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-
-    git clone https://github.com/NextCenturyCorporation/MCS.git
-
-    cd MCS
-
-    python3.7 -m venv venv
-    . venv/bin/activate
-
-    pip install --upgrade pip
-    python -m pip install -r requirements.txt
-    python -m pip install -e .
-
-    python machine_common_sense/scripts/run_just_rotate.py docs/source/scenes/ball_far.json
+    # Do a test run
+    $ python machine_common_sense/scripts/run_just_rotate.py docs/source/scenes/ball_far.json
 


### PR DESCRIPTION
These instructions seemed a little stale. Notably, there was no information on running `cache_addressables` using `DISPLAY:=0`. Additionally, the "Remote Run Test Script" used an action that's no longer available. I cleaned up a few of the comments as well.

I think we should wait to finalize this PR until after the eval. Other folks can add documentation they think would be useful to make available for the TA1s.