### PR TITLE
MCS-1433 Added resetCenterOfMassAtY object schema property.

### DIFF
--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -277,6 +277,7 @@ class SceneObject(BaseModel):
     pickupable: Optional[bool]
     receptacle: Optional[bool]
     reset_center_of_mass: Optional[bool]
+    reset_center_of_mass_at_y: Optional[float]
     resizes: List[SizeConfig] = None
     rotates: List[MoveConfig] = None
     salient_materials: List[str] = None

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -424,6 +424,7 @@ class TestSceneConfig(unittest.TestCase):
             'pickupable': True,
             'receptacle': True,
             'resetCenterOfMass': True,
+            'resetCenterOfMassAtY': 0.321,
             'resizes': [{
                 'stepBegin': 19,
                 'stepEnd': 20,
@@ -538,6 +539,7 @@ class TestSceneConfig(unittest.TestCase):
         self.assertIsNone(object_1.pickupable)
         self.assertIsNone(object_1.receptacle)
         self.assertIsNone(object_1.reset_center_of_mass)
+        self.assertIsNone(object_1.reset_center_of_mass_at_y)
         self.assertIsNone(object_1.resizes)
         self.assertIsNone(object_1.rotates)
         self.assertIsNone(object_1.salient_materials)
@@ -659,6 +661,7 @@ class TestSceneConfig(unittest.TestCase):
         self.assertTrue(object_2.pickupable)
         self.assertTrue(object_2.receptacle)
         self.assertTrue(object_2.reset_center_of_mass)
+        self.assertEqual(object_2.reset_center_of_mass_at_y, 0.321)
         self.assertEqual(object_2.resizes, [SizeConfig(
             step_begin=19,
             step_end=20,


### PR DESCRIPTION
The `resetCenterOfMass` property was added to address visual behavior when the object hit the ground that the TA2 psychs deemed undesirable. Its intent was to reset the implausible center of mass (back to the object's normal center of mass) when the object first gained an upward velocity due to hitting and bouncing off the floor. The issue exposed during Eval 5 was that sometimes affected objects would bounce when initially placed on the visible support, causing their center of mass to be reset too soon. Therefore I've now added a `resetCenterOfMassAtY` property, replacing the previous behavior, which only resets the center of mass when the object falls past a specified Y position. As a fallback, in case this approach doesn't work for whatever reason, we can remove `resetCenterOfMass` entirely, though then we'd return to having the undesired visual behavior. I think this PR represents a good middle-ground.

Unity PR: https://github.com/NextCenturyCorporation/ai2thor/pull/264
Hypercube Scene Generator PR: https://github.com/NextCenturyCorporation/mcs-private/pull/278