### PR TITLE
MCS-1458 - Fixing dependency in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,15 +21,15 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
+        # Need to explicitly install requirementslib==1.6.9 here
+        # so that later isort step works
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel requirementslib==1.6.9
           python -m pip install -r requirements.txt
       - name: Run unit tests
         run: python -m unittest
       - name: Run isort
         uses: isort/isort-action@master
-        with:
-            requirementsFiles: "requirements.txt requirements-test.txt"
       - name: Flake8
         run: flake8
       - name: Autopep8


### PR DESCRIPTION
Compared logs, figured out it was this requirementslib dependency causing the issue. Also removed the requirementsFiles lines from the isort step, since it looks redundant (we already download our requirements.txt by that point) and it only seems to use the first file listed anyway from what I can tell. 

Tried this out on the depth map test branch, but decided to make a separate PR anyway.