### PR TITLE
MCS-1045 Added timeout for long scenes

### DIFF
--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -156,7 +156,7 @@ timeout
 
 (int, optional)
 
-If the amount of time between steps exceeds the amount specified (represented in seconds), throw and error and attempt to end scene (default: 3600 (or 1 hour))
+If the amount of time between steps exceeds the amount specified (represented in seconds), throw and error and attempt to end scene (default: 3600 (or 1 hour)).
 
 
 Handling Pull Requests From Contributors

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -151,6 +151,13 @@ team
 
 Team name identifier to prefix to scene history and video files (default: '').
 
+timeout
+^^^^^^^
+
+(int, optional)
+
+If the amount of time between steps exceeds the amount specified (represented in seconds), throw and error and attempt to end scene (default: 3600 (or 1 hour))
+
 
 Handling Pull Requests From Contributors
 ----------------------------------------

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -513,6 +513,8 @@ class ConfigManager:
         )
 
     def get_timeout(self):
+        """ Time (in seconds) to allow a run to be idle
+        before attempting to end scene"""
         return self._config.getint(
             self.CONFIG_DEFAULT_SECTION,
             self.CONFIG_TIMEOUT,

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -318,6 +318,7 @@ class ConfigManager:
     CONFIG_GOAL_REWARD = 'goal_reward'
     CONFIG_TOP_DOWN_PLOTTER = 'top_down_plotter'
     CONFIG_TOP_DOWN_CAMERA = 'top_down_camera'
+    CONFIG_TIMEOUT = 'timeout'
 
     # Please keep the aspect ratio as 3:2 because the IntPhys scenes are built
     # on this assumption.
@@ -326,6 +327,10 @@ class ConfigManager:
 
     # Default steps allowed in lava before calling end scene
     STEPS_ALLOWED_IN_LAVA_DEFAULT = 0
+
+    # Default time to allow on a single step before timing out
+    # is 2 hours (represented in seconds)
+    TIMEOUT_DEFAULT = 7200
 
     def __init__(self, config_file_or_dict=None):
         '''
@@ -505,6 +510,13 @@ class ConfigManager:
             self.CONFIG_DEFAULT_SECTION,
             self.CONFIG_STEPS_ALLOWED_IN_LAVA,
             fallback=self.STEPS_ALLOWED_IN_LAVA_DEFAULT
+        )
+
+    def get_timeout(self):
+        return self._config.getint(
+            self.CONFIG_DEFAULT_SECTION,
+            self.CONFIG_TIMEOUT,
+            fallback=self.TIMEOUT_DEFAULT
         )
 
     def is_top_down_plotter(self) -> bool:

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -329,8 +329,8 @@ class ConfigManager:
     STEPS_ALLOWED_IN_LAVA_DEFAULT = 0
 
     # Default time to allow on a single step before timing out
-    # is 2 hours (represented in seconds)
-    TIMEOUT_DEFAULT = 7200
+    # is 1 hour (represented in seconds)
+    TIMEOUT_DEFAULT = 3600
 
     def __init__(self, config_file_or_dict=None):
         '''

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -150,21 +150,21 @@ class Controller():
 
         start_time = time.time()
         self._timer_in_progress = False
-        timeout_secs = self._config.get_timeout()
+        timeout_seconds = self._config.get_timeout()
 
         if(self._last_step_check < self.__step_number):
             # skip step check for Initialize step
             if(self.__step_number != 0):
                 self._last_step_check = self.__step_number
 
-            timer_secs = timeout_secs - \
-                ((time.time() - start_time) % timeout_secs)
-            self._timer = threading.Timer(timer_secs,
+            timer_seconds = timeout_seconds - \
+                ((time.time() - start_time) % timeout_seconds)
+            self._timer = threading.Timer(timer_seconds,
                                           self._check_step_for_timeout)
             self._timer.start()
             self._timer_in_progress = True
         else:
-            time_str = str(datetime.timedelta(seconds=timeout_secs))
+            time_str = str(datetime.timedelta(seconds=timeout_seconds))
             logger.debug(
                 f"Attempting to end scene due to inactivity (user not taking"
                 f" any steps) for {time_str} (hh:mm:ss)")

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -116,7 +116,6 @@ class Controller():
 
         self._on_init()
         self._set_config(config)
-        self._check_step_for_timeout()
 
     def _on_init(self):
         '''Set class variables after controller is initialized'''
@@ -161,6 +160,7 @@ class Controller():
                 ((time.time() - start_time) % timeout_seconds)
             self._timer = threading.Timer(timer_seconds,
                                           self._check_step_for_timeout)
+            self._timer.daemon = True
             self._timer.start()
             self._timer_in_progress = True
         else:
@@ -269,6 +269,8 @@ class Controller():
         start_scene_payload = StartScenePayload(**payload)
         self._publish_event(
             EventType.ON_START_SCENE, start_scene_payload)
+
+        self._check_step_for_timeout()
 
         return output
 

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import threading
+import time
 from typing import Dict, List, Optional, Union
 
 import ai2thor.controller
@@ -147,6 +148,7 @@ class Controller():
         '''Meant for use during eval, if a scene is hung on the same step
         for a period of time, end the scene.'''
 
+        start_time = time.time()
         self._timer_in_progress = False
         timeout_secs = self._config.get_timeout()
 
@@ -155,7 +157,9 @@ class Controller():
             if(self.__step_number != 0):
                 self._last_step_check = self.__step_number
 
-            self._timer = threading.Timer(timeout_secs,
+            timer_secs = timeout_secs - \
+                ((time.time() - start_time) % timeout_secs)
+            self._timer = threading.Timer(timer_secs,
                                           self._check_step_for_timeout)
             self._timer.start()
             self._timer_in_progress = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ commonmark==0.9.1
 flake8==3.9.1
 flake8-implicit-str-concat==0.2.0
 flake8-use-fstring==1.3
-importlib-metadata==4.13.0 python_version<"3.8"
+importlib-metadata==4.13.0; python_version<"3.8"
 isort==5.8.0
 Jinja2<3.1
 matplotlib==3.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ commonmark==0.9.1
 flake8==3.9.1
 flake8-implicit-str-concat==0.2.0
 flake8-use-fstring==1.3
+importlib-metadata==4.13.0 python_version<"3.8"
 isort==5.8.0
 Jinja2<3.1
 matplotlib==3.3.3

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -268,6 +268,18 @@ class TestConfigManager(unittest.TestCase):
 
         self.assertFalse(self.config_mngr.is_noise_enabled())
 
+    def test_timeout(self):
+        self.assertEqual(self.config_mngr.get_timeout(),
+                         self.config_mngr.TIMEOUT_DEFAULT)
+
+        self.config_mngr._config[
+            self.config_mngr.CONFIG_DEFAULT_SECTION
+        ][
+            self.config_mngr.CONFIG_TIMEOUT
+        ] = '50'
+
+        self.assertEqual(self.config_mngr.get_timeout(), 50)
+
 
 class TestSceneConfig(unittest.TestCase):
     def test_objects(self):


### PR DESCRIPTION
Uses instances of threading.Timer to check if we've been at the same step for x seconds (default is two hours). If so, end scene is called + an exception is thrown on the main thread. Added timeout value to the mcs config in case we need to change the length of time later. 