### PR TITLE
MCS-895 Initial version of handling scenes with multiple targets.

### DIFF
--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -654,17 +654,18 @@ class SceneConfiguration(BaseModel):
         return lava
 
     def update_goal_target_image(self, goal_output):
-        target_name_list = ['target', 'target_1', 'target_2']
-
-        for target_name in target_name_list:
-            # need to convert goal image data from string to array
-            if (
-                target_name in goal_output.metadata and
-                'image' in goal_output.metadata[target_name] and
-                isinstance(goal_output.metadata[target_name]['image'], str)
-            ):
-                image_list_string = goal_output.metadata[target_name]['image']
-                goal_output.metadata[target_name]['image'] = np.array(
-                    ast.literal_eval(image_list_string)).tolist()
-
+        metadata = goal_output.metadata or {}
+        # Different goal categories may use different property names
+        target_names = ['target', 'targets', 'target_1', 'target_2']
+        for target_name in target_names:
+            # Some properties may be dicts, and some may be lists of dicts
+            targets = metadata.get(target_name) or []
+            targets = targets if isinstance(targets, list) else [targets]
+            for target in targets:
+                # Backwards compatibility: target used to have image data
+                image = target.get('image')
+                # Convert the image data from a string to an array
+                if isinstance(image, str):
+                    image_array = np.array(ast.literal_eval(image)).tolist()
+                    target['image'] = image_array
         return goal_output

--- a/machine_common_sense/controller_media.py
+++ b/machine_common_sense/controller_media.py
@@ -258,15 +258,22 @@ class TopdownVideoEventHandler(AbstractVideoEventHandler):
             # The plotter used to be inside the for loop the same as
             # image_recorder, but it seems like it would only plot one per
             # step.
-            goal_id = None
-            # Is there a better way to do this test?
-            if (payload.goal is not None and
-                    payload.goal.metadata is not None):
-                goal_id = payload.goal.metadata.get(
-                    'target', {}).get('id', None)
+
+            target_ids = []
+            metadata = (payload.goal.metadata or {}) if payload.goal else {}
+            # Different goal categories may use different property names
+            target_names = ['target', 'targets', 'target_1', 'target_2']
+            for target_name in target_names:
+                # Some properties may be dicts, and some may be lists of dicts
+                targets = metadata.get(target_name) or []
+                targets = targets if isinstance(targets, list) else [targets]
+                for target in targets:
+                    if target.get('id'):
+                        target_ids.append(target.get('id'))
+
             plot = self.__plotter.plot(payload.step_metadata,
                                        payload.step_number,
-                                       goal_id)
+                                       target_ids)
             self.__recorder.add(plot)
 
     def on_end_scene(self, payload: BasePostActionEventPayload):

--- a/machine_common_sense/controller_output_handler.py
+++ b/machine_common_sense/controller_output_handler.py
@@ -387,15 +387,24 @@ class ControllerOutputHandler():
         step_output.lava = None
         step_output.room_dimensions = None
 
-        target_name_list = ['target', 'target_1', 'target_2']
-        for target_name in target_name_list:
-            if (target_name in step_output.goal.metadata):
-                step_output.goal = copy.deepcopy(
-                    step_output.goal)
-                if 'image' in step_output.goal.metadata[target_name]:
-                    step_output.goal.metadata[target_name]['image'] = None
-                if 'id' in step_output.goal.metadata[target_name]:
-                    step_output.goal.metadata[target_name]['id'] = None
-                if 'image_name' in step_output.goal.metadata[target_name]:
-                    step_output.goal.metadata[
-                        target_name]['image_name'] = None
+        # Copy the goal object to avoid deleting data from the original object
+        step_output.goal = copy.deepcopy(step_output.goal)
+
+        metadata = step_output.goal.metadata or {}
+        # Different goal categories may use different property names
+        target_names = ['target', 'targets', 'target_1', 'target_2']
+        for target_name in target_names:
+            target = metadata.get(target_name)
+            # Some properties may be dicts, and some may be lists of dicts
+            if isinstance(target, list):
+                # Clear the whole array, to avoid revealing the total count
+                metadata[target_name] = []
+            elif target:
+                # Pretty sure the target always has an id, but just in case...
+                if 'id' in target:
+                    del target['id']
+                # Backwards compatibility: target used to have image data
+                if 'image' in target:
+                    del target['image']
+                if 'image_name' in target:
+                    del target['image_name']

--- a/machine_common_sense/goal_metadata.py
+++ b/machine_common_sense/goal_metadata.py
@@ -207,7 +207,8 @@ class GoalCategory(Enum):
     behaviors, and their interactions with objects in the environment.
 
     This goal category is only used for the **passive/VoE agent tasks**. All
-    interactive agent tasks will use the `retrieval` goal category.
+    interactive agent tasks will use either the `retrieval` or
+    `multi retrieval` goal category.
 
     Notes
     -----
@@ -239,7 +240,10 @@ class GoalCategory(Enum):
     RETRIEVAL = "retrieval"
     """
     In a trial that has a retrieval goal, you must find and pickup a target
-    object. This may involve exploring the scene, avoiding obstacles,
+    object. In MCS Evaluation 4 and onward, the target object will always be a
+    soccer ball (football).
+
+    This may involve exploring the scene, avoiding obstacles,
     interacting with objects (like closed containers) or agents, and tracking
     moving objects. These trials will demand a "common sense" understanding of
     self navigation (how to move and rotate yourself within a scene and around
@@ -247,14 +251,40 @@ class GoalCategory(Enum):
     containers), the basic physics of movement (kinematics, gravity, friction,
     etc.), and agency (identifying people and using them to achieve a goal).
 
+    Notes
+    -----
+    At `oracle` metadata level, the `metadata` dict property of this
+    GoalMetadata object will contain a `target` property, which is a dict
+    containing the following parameters:
+
     Parameters
     ----------
-    target.id : string
-        The objectId of the target object to retrieve.
-        Will only be available at `oracle` metadata level.
+    id : string
+        The unique objectId of the target object to retrieve.
+    """
 
-    target.info : list of strings
-        Human-readable information describing the target object needed for the
-        visualization interface.
+    MULTI_RETRIEVAL = "multi retrieval"
+    """
+    In a trial that has a multi retrieval goal, you must find and pickup one or
+    more target objects. In MCS Evaluation 4 and onward, the target object will
+    always be a soccer ball (football).
 
+    This may involve exploring the scene, avoiding obstacles,
+    interacting with objects (like closed containers) or agents, and tracking
+    moving objects. These trials will demand a "common sense" understanding of
+    self navigation (how to move and rotate yourself within a scene and around
+    obstacles), object interaction (how objects work, including opening
+    containers), the basic physics of movement (kinematics, gravity, friction,
+    etc.), and agency (identifying people and using them to achieve a goal).
+
+    Notes
+    -----
+    At `oracle` metadata level, the `metadata` dict property of this
+    GoalMetadata object will contain a `targets` property, which is a list of
+    dicts that each contain the following parameters:
+
+    Parameters
+    ----------
+    id : string
+        The unique objectId of one of the target objects to retrieve.
     """

--- a/machine_common_sense/plotter.py
+++ b/machine_common_sense/plotter.py
@@ -227,16 +227,14 @@ class TopDownPlotter():
         return img
 
     def plot(self, scene_event: ai2thor.server.Event,
-             step_number: int,
-             goal_id: str = None
-             ) -> PIL.Image.Image:
+             step_number: int, goal_ids: list = None) -> PIL.Image.Image:
         '''Create a plot of the room, objects and robot'''
         plt_img = self.base_room_img.copy()
 
         plt_objects = self._find_plottable_objects(scene_event)
         plt_img = self._draw_objects(plt_img,
                                      plt_objects,
-                                     goal_id)
+                                     goal_ids)
 
         agent_metadata = scene_event.metadata.get('agent')
         plt_img = self._draw_robot(
@@ -631,12 +629,12 @@ class TopDownPlotter():
         return combined_objects
 
     def _draw_objects(self, img: np.ndarray, objects: Dict,
-                      goal_id: str = None) -> np.ndarray:
+                      goal_ids: list = None) -> np.ndarray:
         '''Plot the object bounds for each object in the scene'''
         for o in objects:
             obj = self._create_asset(o)
             if obj.bounds is not None:
-                if goal_id is not None and o['objectId'] == goal_id:
+                if goal_ids is not None and o['objectId'] in goal_ids:
                     img = self._draw_goal(img, obj)
                 else:
                     img = self._draw_object(img, obj)

--- a/machine_common_sense/reward.py
+++ b/machine_common_sense/reward.py
@@ -171,7 +171,8 @@ class Reward(object):
             category = goal.metadata.get('category', None)
 
         switch = {
-            GoalCategory.RETRIEVAL.value: Reward._calc_retrieval_reward
+            GoalCategory.RETRIEVAL.value: Reward._calc_retrieval_reward,
+            GoalCategory.MULTI_RETRIEVAL.value: Reward._calc_retrieval_reward
         }
 
         current_score = switch.get(category, Reward._calculate_default_reward)(

--- a/machine_common_sense/reward.py
+++ b/machine_common_sense/reward.py
@@ -71,10 +71,23 @@ class Reward(object):
 
         '''
         reward = GOAL_NOT_ACHIEVED
-        goal_id = goal.metadata['target'].get('id', None)
-        goal_object = Reward.__get_object_from_list(objects, goal_id)
+        goal_objects = []
 
-        if goal_object and goal_object.get('isPickedUp', False):
+        metadata = goal.metadata or {}
+        # Different goal categories may use different property names
+        target_names = ['target', 'targets']
+        for target_name in target_names:
+            # Some properties may be dicts, and some may be lists of dicts
+            targets = metadata.get(target_name) or []
+            targets = targets if isinstance(targets, list) else [targets]
+            for target in targets:
+                goal_id = target.get('id')
+                goal_object = Reward.__get_object_from_list(objects, goal_id)
+                if goal_object:
+                    goal_objects.append(goal_object)
+
+        # Only attain the reward if all targets are picked up
+        if all([obj.get('isPickedUp', False) for obj in goal_objects]):
             reward = goal_reward
 
         return reward

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -709,7 +709,8 @@ class TestSceneConfig(unittest.TestCase):
             'metadata': {
                 'target': {'image': [0]},
                 'target_1': {'image': [1]},
-                'target_2': {'image': [2]}
+                'target_2': {'image': [2]},
+                'targets': [{'image': [3]}]
             }
         }
 
@@ -719,7 +720,8 @@ class TestSceneConfig(unittest.TestCase):
         self.assertEqual(actual.metadata, {
             'target': {'image': [0]},
             'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
+            'target_2': {'image': [2]},
+            'targets': [{'image': [3]}]
         })
 
     def test_retrieve_goal(self):
@@ -788,7 +790,8 @@ class TestSceneConfig(unittest.TestCase):
         goal = {'metadata': {
             'target': {'image': [0]},
             'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
+            'target_2': {'image': [2]},
+            'targets': [{'image': [3]}]
         }}
         goal = Goal(**goal)
         scene_config = SceneConfiguration(name="test", version=1, goal=goal)
@@ -796,30 +799,33 @@ class TestSceneConfig(unittest.TestCase):
         self.assertEqual(actual.metadata, {
             'target': {'image': [0]},
             'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
+            'target_2': {'image': [2]},
+            'targets': [{'image': [3]}]
         })
 
     def test_update_goal_target_image_img_as_str(self):
         goal = {'metadata': {
             'target': {'image': "[0]"},
             'target_1': {'image': "[1]"},
-            'target_2': {'image': "[2]"}
-        }
-        }
+            'target_2': {'image': "[2]"},
+            'targets': [{'image': "[3]"}]
+        }}
         goal = Goal(**goal)
         scene_config = SceneConfiguration(name="test", version=1, goal=goal)
         actual = scene_config.update_goal_target_image(scene_config.goal)
         self.assertEqual(actual.metadata, {
             'target': {'image': [0]},
             'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
+            'target_2': {'image': [2]},
+            'targets': [{'image': [3]}]
         })
 
     def test_update_goal_target_image_oracle(self):
         goal = {'metadata': {
             'target': {'image': [0]},
             'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
+            'target_2': {'image': [2]},
+            'targets': [{'image': [3]}]
         }}
         goal = Goal(**goal)
         scene_config = SceneConfiguration(name="test", version=1, goal=goal)
@@ -827,14 +833,16 @@ class TestSceneConfig(unittest.TestCase):
         self.assertEqual(actual.metadata, {
             'target': {'image': [0]},
             'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
+            'target_2': {'image': [2]},
+            'targets': [{'image': [3]}]
         })
 
     def test_update_goal_target_image_oracle_img_as_str(self):
         goal = {'metadata': {
             'target': {'image': "[0]"},
             'target_1': {'image': "[1]"},
-            'target_2': {'image': "[2]"}
+            'target_2': {'image': "[2]"},
+            'targets': [{'image': "[3]"}]
         }}
         goal = Goal(**goal)
         scene_config = SceneConfiguration(name="test", version=1, goal=goal)
@@ -842,7 +850,8 @@ class TestSceneConfig(unittest.TestCase):
         self.assertEqual(actual.metadata, {
             'target': {'image': [0]},
             'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
+            'target_2': {'image': [2]},
+            'targets': [{'image': [3]}]
         })
 
 

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -495,14 +495,18 @@ class TestControllerOutputHandler(unittest.TestCase):
         ], lava=[
             Vector2dInt(x=3, z=3), Vector2dInt(x=7, z=5), Vector2dInt(x=4, z=6)
         ]))
-        (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
+        goal = GoalMetadata(metadata={
+            'target': {'id': 'target_id_1'},
+            'targets': [{'id': 'target_id_2'}, {'id': 'target_id_3'}]
+        })
+        (res, actual) = coh.handle_output(mock_event, goal, 0, 1)
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
-        self.assertEqual(str(actual.goal), str(mcs.GoalMetadata()))
+        self.assertEqual(actual.goal.metadata, goal.metadata)
         self.assertEqual(actual.habituation_trial, None)
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.holes, [(0, 0), (1, 2), (9, 8)])
@@ -638,13 +642,21 @@ class TestControllerOutputHandler(unittest.TestCase):
         ], lava=[
             Vector2dInt(x=3, z=3), Vector2dInt(x=7, z=5), Vector2dInt(x=4, z=6)
         ]))
-        (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
+        goal = GoalMetadata(metadata={
+            'target': {'id': 'target_id_1'},
+            'targets': [{'id': 'target_id_2'}, {'id': 'target_id_3'}]
+        })
+        (res, actual) = coh.handle_output(mock_event, goal, 0, 1)
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
+        self.assertEqual(actual.goal.metadata, {
+            'target': {},
+            'targets': [],
+        })
         self.assertEqual(actual.habituation_trial, None)
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.position, None)
@@ -695,14 +707,21 @@ class TestControllerOutputHandler(unittest.TestCase):
         ], lava=[
             Vector2dInt(x=3, z=3), Vector2dInt(x=7, z=5), Vector2dInt(x=4, z=6)
         ]))
-        (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
+        goal = GoalMetadata(metadata={
+            'target': {'id': 'target_id_1'},
+            'targets': [{'id': 'target_id_2'}, {'id': 'target_id_3'}]
+        })
+        (res, actual) = coh.handle_output(mock_event, goal, 0, 1)
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
-        self.assertEqual(str(actual.goal), str(mcs.GoalMetadata()))
+        self.assertEqual(actual.goal.metadata, {
+            'target': {},
+            'targets': [],
+        })
         self.assertEqual(actual.habituation_trial, None)
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.position, None)
@@ -741,14 +760,21 @@ class TestControllerOutputHandler(unittest.TestCase):
         ], lava=[
             Vector2dInt(x=3, z=3), Vector2dInt(x=7, z=5), Vector2dInt(x=4, z=6)
         ]))
-        (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
+        goal = GoalMetadata(metadata={
+            'target': {'id': 'target_id_1'},
+            'targets': [{'id': 'target_id_2'}, {'id': 'target_id_3'}]
+        })
+        (res, actual) = coh.handle_output(mock_event, goal, 0, 1)
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
-        self.assertEqual(str(actual.goal), str(mcs.GoalMetadata()))
+        self.assertEqual(actual.goal.metadata, {
+            'target': {},
+            'targets': [],
+        })
         self.assertEqual(actual.habituation_trial, None)
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.position, None)
@@ -787,13 +813,18 @@ class TestControllerOutputHandler(unittest.TestCase):
         ], lava=[
             Vector2dInt(x=3, z=3), Vector2dInt(x=7, z=5), Vector2dInt(x=4, z=6)
         ]))
-        (actual, res) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
+        goal = GoalMetadata(metadata={
+            'target': {'id': 'target_id_1'},
+            'targets': [{'id': 'target_id_2'}, {'id': 'target_id_3'}]
+        })
+        (actual, res) = coh.handle_output(mock_event, goal, 0, 1)
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
+        self.assertEqual(actual.goal.metadata, goal.metadata)
         self.assertEqual(actual.habituation_trial, None)
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.position, {'x': 0.12, 'y': -0.23, 'z': 4.5})
@@ -848,13 +879,18 @@ class TestControllerOutputHandler(unittest.TestCase):
         ], lava=[
             Vector2dInt(x=3, z=3), Vector2dInt(x=7, z=5), Vector2dInt(x=4, z=6)
         ]))
-        (res, actual) = coh.handle_output(mock_event, GoalMetadata(), 0, 1)
+        goal = GoalMetadata(metadata={
+            'target': {'id': 'target_id_1'},
+            'targets': [{'id': 'target_id_2'}, {'id': 'target_id_3'}]
+        })
+        (res, actual) = coh.handle_output(mock_event, goal, 0, 1)
 
         self.assertEqual(actual.action_list, GoalMetadata.DEFAULT_ACTIONS)
         self.assertEqual(actual.camera_aspect_ratio, (600, 400))
         self.assertEqual(actual.camera_clipping_planes, (0, 150))
         self.assertEqual(actual.camera_field_of_view, 42.5)
         self.assertEqual(actual.camera_height, 0.1234)
+        self.assertEqual(actual.goal.metadata, goal.metadata)
         self.assertEqual(actual.habituation_trial, None)
         self.assertEqual(actual.head_tilt, 12.34)
         self.assertEqual(actual.position, {'x': 0.12, 'y': -0.23, 'z': 4.5})

--- a/tests/test_history_writer.py
+++ b/tests/test_history_writer.py
@@ -247,8 +247,8 @@ class TestHistoryWriter(unittest.TestCase):
         writer = mcs.HistoryWriter(self.prefix_config_data)
 
         goal = mcs.GoalMetadata(metadata={
-            'target': {'id': 'targetId',
-                       'image': 'something.png'}
+            'target': {'id': 'targetId', 'image': 'something.png'},
+            'targets': [{'id': 'targetId', 'image': 'something.png'}]
         })
         output = mcs.StepMetadata(
             action_list=[
@@ -285,6 +285,9 @@ class TestHistoryWriter(unittest.TestCase):
         self.assertEqual(
             writer.current_steps[0]["output"]["goal"]["metadata"]["target"],
             {'id': 'targetId', 'position': {'x': 1, 'y': 0.5, 'z': 1}})
+        self.assertEqual(
+            writer.current_steps[0]["output"]["goal"]["metadata"]["targets"],
+            [{'id': 'targetId', 'position': {'x': 1, 'y': 0.5, 'z': 1}}])
 
     def test_write_history_file_with_numpy(self):
         writer = mcs.HistoryWriter(self.prefix_config_data)

--- a/tests/test_history_writer.py
+++ b/tests/test_history_writer.py
@@ -317,6 +317,80 @@ class TestHistoryWriter(unittest.TestCase):
 
         self.assertTrue(os.path.exists(writer.scene_history_file))
 
+    def test_is_target_visible_retrieval(self):
+        writer = mcs.HistoryWriter(self.prefix_config_data)
+
+        history_1 = mcs.SceneHistory(output=mcs.StepMetadata(
+            goal=mcs.GoalMetadata(category='retrieval', metadata={
+                'target': {'id': 'target_1'}
+            }),
+            object_list=[
+                mcs.ObjectMetadata(uuid='target_1', visible=False)
+            ]
+        ))
+        actual = writer.is_target_visible(history_1)
+        self.assertFalse(actual)
+
+        history_2 = mcs.SceneHistory(output=mcs.StepMetadata(
+            goal=mcs.GoalMetadata(category='retrieval', metadata={
+                'target': {'id': 'target_1'}
+            }),
+            object_list=[
+                mcs.ObjectMetadata(uuid='target_1', visible=True)
+            ]
+        ))
+        actual = writer.is_target_visible(history_2)
+        self.assertTrue(actual)
+
+    def test_is_target_visible_multi_retrieval(self):
+        writer = mcs.HistoryWriter(self.prefix_config_data)
+
+        history_1 = mcs.SceneHistory(output=mcs.StepMetadata(
+            goal=mcs.GoalMetadata(category='multi retrieval', metadata={
+                'targets': [{'id': 'target_1'}]
+            }),
+            object_list=[
+                mcs.ObjectMetadata(uuid='target_1', visible=False)
+            ]
+        ))
+        actual = writer.is_target_visible(history_1)
+        self.assertEqual(actual, [])
+
+        history_2 = mcs.SceneHistory(output=mcs.StepMetadata(
+            goal=mcs.GoalMetadata(category='multi retrieval', metadata={
+                'targets': [{'id': 'target_1'}]
+            }),
+            object_list=[
+                mcs.ObjectMetadata(uuid='target_1', visible=True)
+            ]
+        ))
+        actual = writer.is_target_visible(history_2)
+        self.assertEqual(actual, ['target_1'])
+
+        history_3 = mcs.SceneHistory(output=mcs.StepMetadata(
+            goal=mcs.GoalMetadata(category='multi retrieval', metadata={
+                'targets': [{'id': 'target_1'}, {'id': 'target_2'}]
+            }),
+            object_list=[
+                mcs.ObjectMetadata(uuid='target_1', visible=True),
+                mcs.ObjectMetadata(uuid='target_2', visible=False)
+            ]
+        ))
+        actual = writer.is_target_visible(history_3)
+        self.assertEqual(actual, ['target_1'])
+
+        history_4 = mcs.SceneHistory(output=mcs.StepMetadata(
+            goal=mcs.GoalMetadata(category='multi retrieval', metadata={
+                'targets': [{'id': 'target_1'}, {'id': 'target_2'}]
+            }),
+            object_list=[
+                mcs.ObjectMetadata(uuid='target_1', visible=True),
+                mcs.ObjectMetadata(uuid='target_2', visible=True)
+            ]
+        ))
+        actual = writer.is_target_visible(history_4)
+        self.assertEqual(actual, ['target_1', 'target_2'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -488,15 +488,10 @@ class TestTopDownPlotter(unittest.TestCase):
             Vector2dInt(**{"x": -3, "z": 4}),
             Vector2dInt(**{"x": 3, "z": -4}),
         ]
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             holes=holes,
             room_dimensions=Vector3d(
                 x=6,
@@ -546,15 +541,10 @@ class TestTopDownPlotter(unittest.TestCase):
             Vector2dInt(
                 **{"x": 3, "z": -3}),  # out of bounds - don't draw
         ]
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             holes=holes,
             room_dimensions=Vector3d(
                 x=5,
@@ -617,15 +607,10 @@ class TestTopDownPlotter(unittest.TestCase):
                 **{"x": -5, "z": -5})  # out of bounds - dont draw
 
         ]
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             holes=holes,
             room_dimensions=Vector3d(
                 x=10,
@@ -658,15 +643,10 @@ class TestTopDownPlotter(unittest.TestCase):
         self.assertListEqual(stat.sum, [0.0, 0.0, 0.0])
 
     def test_draw_lava(self):
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(
                 x=6,
                 y=3,
@@ -722,15 +702,10 @@ class TestTopDownPlotter(unittest.TestCase):
         self.assertListEqual(stat.sum, [0.0, 0.0, 0.0])
 
     def test_draw_lava_from_partition_floor(self):
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(x=10, y=3, z=10),
             partition_floor=FloorPartitionConfig(left_half=0.2, right_half=0.8)
         )
@@ -753,15 +728,10 @@ class TestTopDownPlotter(unittest.TestCase):
 
     def test_draw_room(self):
         '''Floor grid plus walls'''
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(
                 x=10,
                 y=3,
@@ -788,15 +758,10 @@ class TestTopDownPlotter(unittest.TestCase):
         self.assertListEqual(stat.sum, [0.0, 0.0, 0.0])
 
     def test_draw_nonsquare_room(self):
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(
                 x=10,
                 y=3,
@@ -918,15 +883,10 @@ class TestTopDownPlotter(unittest.TestCase):
         self.assertListEqual(stat.sum, [0.0, 0.0, 0.0])
 
     def test_draw_goal_object(self):
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(
                 x=10,
                 y=3,
@@ -1091,15 +1051,10 @@ class TestTopDownPlotter(unittest.TestCase):
         self.assertListEqual(stat.sum, [0.0, 0.0, 0.0])
 
     def test_draw_visible_object(self):
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(
                 x=10,
                 y=3,
@@ -1186,15 +1141,10 @@ class TestTopDownPlotter(unittest.TestCase):
         self.assertListEqual(stat.sum, [0.0, 0.0, 0.0])
 
     def test_draw_hidden_object(self):
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(
                 x=10,
                 y=3,
@@ -1281,15 +1231,10 @@ class TestTopDownPlotter(unittest.TestCase):
         self.assertListEqual(stat.sum, [0.0, 0.0, 0.0])
 
     def test_draw_ramp_arrow(self):
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(
                 x=10,
                 y=3,
@@ -1337,15 +1282,10 @@ class TestTopDownPlotter(unittest.TestCase):
         self.assertListEqual(stat.sum, [0.0, 0.0, 0.0])
 
     def test_draw_hidden_ramp_arrow(self):
-        goal = {'metadata': {
-            'target': {'image': [0]},
-            'target_1': {'image': [1]},
-            'target_2': {'image': [2]}
-        }}
         scene_config = SceneConfiguration(
             name="testscene",
             version=1,
-            goal=goal,
+            goal={'metadata': {}},
             room_dimensions=Vector3d(
                 x=10,
                 y=3,

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -242,6 +242,50 @@ class TestReward(unittest.TestCase):
         self.assertEqual(reward, 0)
         self.assertIsInstance(reward, int)
 
+    def test_retrieval_reward_multi_target(self):
+        goal = mcs.GoalMetadata()
+        goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
+        obj_list = []
+        for i in range(10):
+            obj_list.append({'objectId': str(i), 'isPickedUp': True})
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
+                                                   performer_reach=1.0)
+        self.assertEqual(reward, 1)
+        self.assertIsInstance(reward, int)
+
+    def test_retrieval_reward_multi_target_nothing_pickedup(self):
+        goal = mcs.GoalMetadata()
+        goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
+        obj_list = []
+        for i in range(10):
+            obj_list.append({'objectId': str(i), 'isPickedUp': False})
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
+                                                   performer_reach=1.0)
+        self.assertEqual(reward, 0)
+        self.assertIsInstance(reward, int)
+
+    def test_retrieval_reward_multi_target_some_pickedup(self):
+        goal = mcs.GoalMetadata()
+        goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
+        obj_list = []
+        for i in range(10):
+            obj_list.append({'objectId': str(i), 'isPickedUp': (i == 0)})
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
+                                                   performer_reach=1.0)
+        self.assertEqual(reward, 0)
+        self.assertIsInstance(reward, int)
+
+    def test_retrieval_reward_multi_target_more_pickedup(self):
+        goal = mcs.GoalMetadata()
+        goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
+        obj_list = []
+        for i in range(10):
+            obj_list.append({'objectId': str(i), 'isPickedUp': (i != 0)})
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
+                                                   performer_reach=1.0)
+        self.assertEqual(reward, 0)
+        self.assertIsInstance(reward, int)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
My initial version of the implementation. Happy to have a team discussion and adjust this approach if we decide it's not ideal.

1. There's now a goal `category` called "multi retrieval", which is distinct from normal "retrieval". This seemed better to me than adding a new/separate boolean property.
2. The `metadata` in the "multi retrieval" goals will have a `targets` property, that's a list of target dicts, rather than a single `target` dict. Like the single `target` dict, each dict will have an `id` corresponding to the target's "id". This seemed better than trying to reuse `target`, but making it sometimes a dict, and sometimes a list.
3. Added code to make sure the `targets` are handled properly, including clearing them when not running at oracle metadata level.
4. As discussed this morning, no reward is given until ALL targets are picked up.

EDIT -- ILE Scene Generator PR: https://github.com/NextCenturyCorporation/mcs-private/pull/299