### PR TITLE
MCS-1542: Fix case where an empty goal_objects would give the goal reward achieved

### DIFF
--- a/machine_common_sense/reward.py
+++ b/machine_common_sense/reward.py
@@ -87,7 +87,8 @@ class Reward(object):
                     goal_objects.append(goal_object)
 
         # Only attain the reward if all targets are picked up
-        if goal_objects and all([obj.get('isPickedUp', False) for obj in goal_objects]):
+        if goal_objects and all(
+                [obj.get('isPickedUp', False) for obj in goal_objects]):
             reward = goal_reward
 
         return reward

--- a/machine_common_sense/reward.py
+++ b/machine_common_sense/reward.py
@@ -80,14 +80,11 @@ class Reward(object):
             # Some properties may be dicts, and some may be lists of dicts
             targets = metadata.get(target_name) or []
             targets = targets if isinstance(targets, list) else [targets]
-            print(targets)
             for target in targets:
                 goal_id = target.get('id')
                 goal_object = Reward.__get_object_from_list(objects, goal_id)
                 if goal_object:
                     goal_objects.append(goal_object)
-
-        print(goal_objects)
 
         # Only attain the reward if all targets are picked up
         if goal_objects and all([obj.get('isPickedUp', False) for obj in goal_objects]):

--- a/machine_common_sense/reward.py
+++ b/machine_common_sense/reward.py
@@ -80,14 +80,17 @@ class Reward(object):
             # Some properties may be dicts, and some may be lists of dicts
             targets = metadata.get(target_name) or []
             targets = targets if isinstance(targets, list) else [targets]
+            print(targets)
             for target in targets:
                 goal_id = target.get('id')
                 goal_object = Reward.__get_object_from_list(objects, goal_id)
                 if goal_object:
                     goal_objects.append(goal_object)
 
+        print(goal_objects)
+
         # Only attain the reward if all targets are picked up
-        if all([obj.get('isPickedUp', False) for obj in goal_objects]):
+        if goal_objects and all([obj.get('isPickedUp', False) for obj in goal_objects]):
             reward = goal_reward
 
         return reward


### PR DESCRIPTION
If the goal_objects was an empty array and there was a goal id in the metadata object, it would say the reward was achieved, it appears that the only test this covered was 094.