### PR TITLE
Fix Jenkins Build (Jan 16 2023)

### DIFF
--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -349,10 +349,6 @@ def start_handmade_tests(
                 reset_config = True
                 mcs.change_config(
                     controller, config_file_or_dict=config_override_filename)
-            elif reset_config is True:
-                reset_config = False
-                mcs.change_config(
-                    controller, config_file_or_dict=config_filename)
 
             print(f'RUNNING SCENE: {os.path.basename(scene_filename)}')
             try:
@@ -375,6 +371,11 @@ def start_handmade_tests(
                 successful_test_list.append((test_name, metadata_tier))
             else:
                 failed_test_list.append((test_name, metadata_tier, status))
+
+            if reset_config is True:
+                reset_config = False
+                mcs.change_config(
+                    controller, config_file_or_dict=config_filename)
 
         # Run each additional test at this metadata tier.
         for runner_function in (


### PR DESCRIPTION
The final integration test (186) uses a custom MCS config file, but the MCS config wasn't being reset before the "additional tests" were run.

You can reproduce the issue using (you should see an IndexError on `development`, but not on here):
```
python integration_tests/run_handmade_tests.py --mcs_unity_version development --ignore 0,10,11,12,13,14,15,16,17,180,181,182,183,184,185 --metadata oracle
```

This ignore all the tests except the final one (186) and the "additional tests".