### PR TITLE
MCS-1707 Added optional pickup_number property in goal metadata for multi-retrieval reward calculations of ambiguous scenes.

### DIFF
--- a/integration_tests/data/193.multi_retrieval_pickup_number.actions.txt
+++ b/integration_tests/data/193.multi_retrieval_pickup_number.actions.txt
@@ -1,0 +1,2 @@
+﻿LookDown
+PickupObject,objectId=soccer_ball_1

--- a/integration_tests/data/193.multi_retrieval_pickup_number.level1.outputs.json
+++ b/integration_tests/data/193.multi_retrieval_pickup_number.level1.outputs.json
@@ -1,0 +1,35 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.999,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/193.multi_retrieval_pickup_number.level2.outputs.json
+++ b/integration_tests/data/193.multi_retrieval_pickup_number.level2.outputs.json
@@ -1,0 +1,35 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.999,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/193.multi_retrieval_pickup_number.oracle.outputs.json
+++ b/integration_tests/data/193.multi_retrieval_pickup_number.oracle.outputs.json
@@ -1,0 +1,41 @@
+﻿[
+    {
+        "camera_height": 0.762,
+        "head_tilt": 20,
+        "objects": [],
+        "objects_count": 2,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": 0.0,
+        "step_number": 0,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 2,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": 0.0,
+        "step_number": 1,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 2,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.999,
+        "rotation_y": 0.0,
+        "step_number": 2,
+        "structural_objects_count": 5
+    }
+]

--- a/integration_tests/data/193.multi_retrieval_pickup_number.scene.json
+++ b/integration_tests/data/193.multi_retrieval_pickup_number.scene.json
@@ -1,0 +1,60 @@
+﻿{
+    "name": "multi retrieval scene with pickup number",
+    "version": 2,
+    "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
+    "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",
+    "wallMaterial": "AI2-THOR/Materials/Walls/DrywallBeige",
+    "performerStart": {
+        "position": {
+            "x": 0,
+            "z": 0
+        },
+        "rotation": {
+            "x": 20,
+            "y": 0
+        }
+    },
+    "objects": [{
+        "id": "soccer_ball_1",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": -0.5,
+                "y": 0.22,
+                "z": 0.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }, {
+        "id": "soccer_ball_2",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": 0.5,
+                "y": 0.22,
+                "z": 0.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }],
+    "goal": {
+        "category": "multi retrieval",
+        "metadata": {
+            "pickup_number": 1,
+            "targets": [
+                {"id": "soccer_ball_1"},
+                {"id": "soccer_ball_2"}
+            ]
+        }
+    }
+}

--- a/integration_tests/data/194.multi_retrieval_pickup_number_two.actions.txt
+++ b/integration_tests/data/194.multi_retrieval_pickup_number_two.actions.txt
@@ -1,0 +1,4 @@
+﻿LookDown
+PickupObject,objectId=soccer_ball_2
+Pass
+PickupObject,objectId=soccer_ball_1

--- a/integration_tests/data/194.multi_retrieval_pickup_number_two.level1.outputs.json
+++ b/integration_tests/data/194.multi_retrieval_pickup_number_two.level1.outputs.json
@@ -1,0 +1,57 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": null,
+        "step_number": 3,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": null,
+        "step_number": 4,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/194.multi_retrieval_pickup_number_two.level2.outputs.json
+++ b/integration_tests/data/194.multi_retrieval_pickup_number_two.level2.outputs.json
@@ -1,0 +1,57 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": null,
+        "step_number": 3,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": null,
+        "step_number": 4,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/194.multi_retrieval_pickup_number_two.oracle.outputs.json
+++ b/integration_tests/data/194.multi_retrieval_pickup_number_two.oracle.outputs.json
@@ -1,0 +1,67 @@
+﻿[
+    {
+        "camera_height": 0.762,
+        "head_tilt": 20,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": 0.0,
+        "step_number": 0,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": 0.0,
+        "step_number": 1,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": 0.0,
+        "step_number": 2,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": 0.0,
+        "step_number": 3,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": 0.0,
+        "step_number": 4,
+        "structural_objects_count": 5
+    }
+]

--- a/integration_tests/data/194.multi_retrieval_pickup_number_two.scene.json
+++ b/integration_tests/data/194.multi_retrieval_pickup_number_two.scene.json
@@ -1,0 +1,77 @@
+﻿{
+    "name": "multi retrieval scene with pickup number version two",
+    "version": 2,
+    "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
+    "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",
+    "wallMaterial": "AI2-THOR/Materials/Walls/DrywallBeige",
+    "performerStart": {
+        "position": {
+            "x": 0,
+            "z": 0
+        },
+        "rotation": {
+            "x": 20,
+            "y": 0
+        }
+    },
+    "objects": [{
+        "id": "soccer_ball_1",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": -0.5,
+                "y": 0.22,
+                "z": 0.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }, {
+        "id": "soccer_ball_2",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": 0.5,
+                "y": 0.22,
+                "z": 0.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }, {
+        "id": "soccer_ball_3",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": 0,
+                "y": 0.22,
+                "z": 1.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }],
+    "goal": {
+        "category": "multi retrieval",
+        "metadata": {
+            "pickup_number": 2,
+            "targets": [
+                {"id": "soccer_ball_1"},
+                {"id": "soccer_ball_2"},
+                {"id": "soccer_ball_3"}
+            ]
+        }
+    }
+}

--- a/integration_tests/data/195.multi_retrieval_drop.actions.txt
+++ b/integration_tests/data/195.multi_retrieval_drop.actions.txt
@@ -1,0 +1,4 @@
+﻿LookDown
+PickupObject,objectId=soccer_ball_1
+DropObject,objectId=soccer_ball_1
+PickupObject,objectId=soccer_ball_2

--- a/integration_tests/data/195.multi_retrieval_drop.level1.outputs.json
+++ b/integration_tests/data/195.multi_retrieval_drop.level1.outputs.json
@@ -1,0 +1,57 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": null,
+        "step_number": 3,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": null,
+        "step_number": 4,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/195.multi_retrieval_drop.level2.outputs.json
+++ b/integration_tests/data/195.multi_retrieval_drop.level2.outputs.json
@@ -1,0 +1,57 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": null,
+        "step_number": 3,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": null,
+        "step_number": 4,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/195.multi_retrieval_drop.oracle.outputs.json
+++ b/integration_tests/data/195.multi_retrieval_drop.oracle.outputs.json
@@ -1,0 +1,67 @@
+﻿[
+    {
+        "camera_height": 0.762,
+        "head_tilt": 20,
+        "objects": [],
+        "objects_count": 2,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": 0.0,
+        "step_number": 0,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 2,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": 0.0,
+        "step_number": 1,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 2,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": 0.0,
+        "step_number": 2,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 2,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": 0.0,
+        "step_number": 3,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 2,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": 0.0,
+        "step_number": 4,
+        "structural_objects_count": 5
+    }
+]

--- a/integration_tests/data/195.multi_retrieval_drop.scene.json
+++ b/integration_tests/data/195.multi_retrieval_drop.scene.json
@@ -1,0 +1,59 @@
+﻿{
+    "name": "multi retrieval scene with drop",
+    "version": 2,
+    "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
+    "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",
+    "wallMaterial": "AI2-THOR/Materials/Walls/DrywallBeige",
+    "performerStart": {
+        "position": {
+            "x": 0,
+            "z": 0
+        },
+        "rotation": {
+            "x": 20,
+            "y": 0
+        }
+    },
+    "objects": [{
+        "id": "soccer_ball_1",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": -0.5,
+                "y": 0.22,
+                "z": 0.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }, {
+        "id": "soccer_ball_2",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": 0.5,
+                "y": 0.22,
+                "z": 0.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }],
+    "goal": {
+        "category": "multi retrieval",
+        "metadata": {
+            "targets": [
+                {"id": "soccer_ball_1"},
+                {"id": "soccer_ball_2"}
+            ]
+        }
+    }
+}

--- a/integration_tests/data/196.multi_retrieval_pickup_number_drop.actions.txt
+++ b/integration_tests/data/196.multi_retrieval_pickup_number_drop.actions.txt
@@ -1,0 +1,4 @@
+﻿LookDown
+PickupObject,objectId=soccer_ball_1
+DropObject,objectId=soccer_ball_1
+PickupObject,objectId=soccer_ball_2

--- a/integration_tests/data/196.multi_retrieval_pickup_number_drop.level1.outputs.json
+++ b/integration_tests/data/196.multi_retrieval_pickup_number_drop.level1.outputs.json
@@ -1,0 +1,57 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": null,
+        "step_number": 3,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": null,
+        "step_number": 4,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/196.multi_retrieval_pickup_number_drop.level2.outputs.json
+++ b/integration_tests/data/196.multi_retrieval_pickup_number_drop.level2.outputs.json
@@ -1,0 +1,57 @@
+﻿[
+    {
+        "head_tilt": 20,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": null,
+        "step_number": 0,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": null,
+        "step_number": 1,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": null,
+        "step_number": 2,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": null,
+        "step_number": 3,
+        "structural_objects_count": 0
+    },
+    {
+        "head_tilt": 30,
+        "objects_count": 0,
+        "position_x": null,
+        "position_z": null,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": null,
+        "step_number": 4,
+        "structural_objects_count": 0
+    }
+]

--- a/integration_tests/data/196.multi_retrieval_pickup_number_drop.oracle.outputs.json
+++ b/integration_tests/data/196.multi_retrieval_pickup_number_drop.oracle.outputs.json
@@ -1,0 +1,67 @@
+﻿[
+    {
+        "camera_height": 0.762,
+        "head_tilt": 20,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.0,
+        "rotation_y": 0.0,
+        "step_number": 0,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.001,
+        "rotation_y": 0.0,
+        "step_number": 1,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.002,
+        "rotation_y": 0.0,
+        "step_number": 2,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": -0.003,
+        "rotation_y": 0.0,
+        "step_number": 3,
+        "structural_objects_count": 5
+    },
+    {
+        "camera_height": 0.762,
+        "head_tilt": 30,
+        "objects": [],
+        "objects_count": 3,
+        "position_x": 0.0,
+        "position_z": 0.0,
+        "return_status": "SUCCESSFUL",
+        "reward": 0.997,
+        "rotation_y": 0.0,
+        "step_number": 4,
+        "structural_objects_count": 5
+    }
+]

--- a/integration_tests/data/196.multi_retrieval_pickup_number_drop.scene.json
+++ b/integration_tests/data/196.multi_retrieval_pickup_number_drop.scene.json
@@ -1,0 +1,77 @@
+﻿{
+    "name": "multi retrieval scene with pickup number and drop",
+    "version": 2,
+    "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
+    "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",
+    "wallMaterial": "AI2-THOR/Materials/Walls/DrywallBeige",
+    "performerStart": {
+        "position": {
+            "x": 0,
+            "z": 0
+        },
+        "rotation": {
+            "x": 20,
+            "y": 0
+        }
+    },
+    "objects": [{
+        "id": "soccer_ball_1",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": -0.5,
+                "y": 0.22,
+                "z": 0.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }, {
+        "id": "soccer_ball_2",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": 0.5,
+                "y": 0.22,
+                "z": 0.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }, {
+        "id": "soccer_ball_3",
+        "type": "soccer_ball",
+        "shows": [{
+            "stepBegin": 0,
+            "position": {
+                "x": 0,
+                "y": 0.22,
+                "z": 1.5
+            },
+            "scale": {
+                "x": 2,
+                "y": 2,
+                "z": 2
+            }
+        }]
+    }],
+    "goal": {
+        "category": "multi retrieval",
+        "metadata": {
+            "pickup_number": 2,
+            "targets": [
+                {"id": "soccer_ball_1"},
+                {"id": "soccer_ball_2"},
+                {"id": "soccer_ball_3"}
+            ]
+        }
+    }
+}

--- a/machine_common_sense/reward.py
+++ b/machine_common_sense/reward.py
@@ -76,19 +76,27 @@ class Reward(object):
         metadata = goal.metadata or {}
         # Different goal categories may use different property names
         target_names = ['target', 'targets']
+        # Get the total number of targets.
+        pickup_number = metadata.get('pickup_number') or 0
         for target_name in target_names:
             # Some properties may be dicts, and some may be lists of dicts
             targets = metadata.get(target_name) or []
             targets = targets if isinstance(targets, list) else [targets]
+            # If pickup_number was not defined, use the list's length.
+            if not pickup_number:
+                pickup_number = len(targets)
             for target in targets:
                 goal_id = target.get('id')
                 goal_object = Reward.__get_object_from_list(objects, goal_id)
                 if goal_object:
                     goal_objects.append(goal_object)
 
-        # Only attain the reward if all targets are picked up
-        if goal_objects and all(
-                [obj.get('isPickedUp', False) for obj in goal_objects]):
+        picked_up = len([
+            object_metadata for object_metadata in goal_objects
+            if object_metadata.get('isPickedUp', True)
+        ])
+        # Attain the reward if the required number of targets were picked-up.
+        if goal_objects and pickup_number and picked_up >= pickup_number:
             reward = goal_reward
 
         return round(reward, 4)

--- a/machine_common_sense/reward.py
+++ b/machine_common_sense/reward.py
@@ -93,7 +93,7 @@ class Reward(object):
 
         picked_up = len([
             object_metadata for object_metadata in goal_objects
-            if object_metadata.get('isPickedUp', True)
+            if object_metadata.get('wasPickedUp')
         ])
         # Attain the reward if the required number of targets were picked-up.
         if goal_objects and pickup_number and picked_up >= pickup_number:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -130,6 +130,7 @@ class TestController(unittest.TestCase):
                     "distance": 1.5,
                     "distanceXZ": 1.1,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 12.34,
                     "objectBounds": {
                         "objectBoundsCorners": [
@@ -169,6 +170,7 @@ class TestController(unittest.TestCase):
                     "distance": 2.5,
                     "distanceXZ": 2.0,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 34.56,
                     "objectBounds": {
                         "objectBoundsCorners": [
@@ -209,6 +211,7 @@ class TestController(unittest.TestCase):
                     "distance": 2.5,
                     "distanceXZ": 2.2,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 56.78,
                     "objectBounds": {
                         "objectBoundsCorners": [
@@ -248,6 +251,7 @@ class TestController(unittest.TestCase):
                     "distance": 3.5,
                     "distanceXZ": 3.3,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 78.90,
                     "objectBounds": {
                         "objectBoundsCorners": [

--- a/tests/test_controller_output_handler.py
+++ b/tests/test_controller_output_handler.py
@@ -93,6 +93,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                     "distance": 1.5,
                     "distanceXZ": 1.1,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 12.34,
                     "objectBounds": {
                         "objectBoundsCorners": [
@@ -136,6 +137,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                     "distance": 2.5,
                     "distanceXZ": 2.0,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 34.56,
                     "objectBounds": {
                         "objectBoundsCorners": [
@@ -180,6 +182,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                     "distance": 2.5,
                     "distanceXZ": 2.2,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 56.78,
                     "objectBounds": {
                         "objectBoundsCorners": [
@@ -223,6 +226,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                     "distance": 3.5,
                     "distanceXZ": 3.3,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 78.90,
                     "objectBounds": {
                         "objectBoundsCorners": [
@@ -280,6 +284,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                     "distance": 0,
                     "distanceXZ": 0,
                     "isPickedUp": True,
+                    "wasPickedUp": True,
                     "mass": 1,
                     "objectId": "testId1",
                     "position": {
@@ -311,6 +316,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                     "distance": 1.5,
                     "distanceXZ": 1.1,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 12.34,
                     "objectBounds": {
                         "objectBoundsCorners": [
@@ -354,6 +360,7 @@ class TestControllerOutputHandler(unittest.TestCase):
                     "distance": 2.5,
                     "distanceXZ": 2,
                     "isPickedUp": False,
+                    "wasPickedUp": False,
                     "mass": 34.56,
                     "objectBounds": {
                         "objectBoundsCorners": [

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -286,6 +286,120 @@ class TestReward(unittest.TestCase):
         self.assertEqual(reward, 0)
         self.assertIsInstance(reward, int)
 
+    def test_retrieval_reward_multi_target_pickup_one_of_two(self):
+        goal = mcs.GoalMetadata()
+        goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}]
+        goal.metadata['pickup_number'] = 1
+
+        # Test: Picking up no targets should return a reward of 0
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': False},
+            {'objectId': '1', 'isPickedUp': False}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 0)
+
+        # Test: Picking up only the 1st target should return a reward of 1
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': True},
+            {'objectId': '1', 'isPickedUp': False}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 1)
+
+        # Test: Picking up only the 2nd target should return a reward of 1
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': False},
+            {'objectId': '1', 'isPickedUp': True}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 1)
+
+        # Test: Picking up all targets should return a reward of 1
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': True},
+            {'objectId': '1', 'isPickedUp': True}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 1)
+
+    def test_retrieval_reward_multi_target_pickup_two_of_three(self):
+        goal = mcs.GoalMetadata()
+        goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
+        goal.metadata['pickup_number'] = 2
+
+        # Test: Picking up no targets should return a reward of 0
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': False},
+            {'objectId': '1', 'isPickedUp': False},
+            {'objectId': '2', 'isPickedUp': False}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 0)
+
+        # Test: Picking up only the 1st target should return a reward of 0
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': True},
+            {'objectId': '1', 'isPickedUp': False},
+            {'objectId': '2', 'isPickedUp': False}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 0)
+
+        # Test: Picking up only the 2nd target should return a reward of 0
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': False},
+            {'objectId': '1', 'isPickedUp': True},
+            {'objectId': '2', 'isPickedUp': False}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 0)
+
+        # Test: Picking up only the 3rd target should return a reward of 0
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': False},
+            {'objectId': '1', 'isPickedUp': False},
+            {'objectId': '2', 'isPickedUp': True}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 0)
+
+        # Test: Picking up the 1st and 2nd targets should return a reward of 1
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': True},
+            {'objectId': '1', 'isPickedUp': True},
+            {'objectId': '2', 'isPickedUp': False}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 1)
+
+        # Test: Picking up the 1st and 3rd targets should return a reward of 1
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': True},
+            {'objectId': '1', 'isPickedUp': False},
+            {'objectId': '2', 'isPickedUp': True}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 1)
+
+        # Test: Picking up the 2nd and 3rd targets should return a reward of 1
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': False},
+            {'objectId': '1', 'isPickedUp': True},
+            {'objectId': '2', 'isPickedUp': True}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 1)
+
+        # Test: Picking up all targets should return a reward of 1
+        obj_list = [
+            {'objectId': '0', 'isPickedUp': True},
+            {'objectId': '1', 'isPickedUp': True},
+            {'objectId': '2', 'isPickedUp': True}
+        ]
+        reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
+        self.assertEqual(reward, 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -223,7 +223,7 @@ class TestReward(unittest.TestCase):
         goal.metadata['target'] = {'id': '0'}
         obj_list = []
         for i in range(10):
-            obj = {"objectId": str(i), 'isPickedUp': not i}
+            obj = {"objectId": str(i), 'wasPickedUp': not i}
             obj_list.append(obj)
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
                                                    performer_reach=1.0)
@@ -235,7 +235,7 @@ class TestReward(unittest.TestCase):
         goal.metadata['target'] = {'id': '0'}
         obj_list = []
         for i in range(10):
-            obj = {"objectId": str(i), 'isPickedUp': False}
+            obj = {"objectId": str(i), 'wasPickedUp': False}
             obj_list.append(obj)
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
                                                    performer_reach=1.0)
@@ -247,7 +247,7 @@ class TestReward(unittest.TestCase):
         goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
         obj_list = []
         for i in range(10):
-            obj_list.append({'objectId': str(i), 'isPickedUp': True})
+            obj_list.append({'objectId': str(i), 'wasPickedUp': True})
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
                                                    performer_reach=1.0)
         self.assertEqual(reward, 1)
@@ -258,7 +258,7 @@ class TestReward(unittest.TestCase):
         goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
         obj_list = []
         for i in range(10):
-            obj_list.append({'objectId': str(i), 'isPickedUp': False})
+            obj_list.append({'objectId': str(i), 'wasPickedUp': False})
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
                                                    performer_reach=1.0)
         self.assertEqual(reward, 0)
@@ -269,7 +269,7 @@ class TestReward(unittest.TestCase):
         goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
         obj_list = []
         for i in range(10):
-            obj_list.append({'objectId': str(i), 'isPickedUp': (i == 0)})
+            obj_list.append({'objectId': str(i), 'wasPickedUp': (i == 0)})
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
                                                    performer_reach=1.0)
         self.assertEqual(reward, 0)
@@ -280,7 +280,7 @@ class TestReward(unittest.TestCase):
         goal.metadata['targets'] = [{'id': '0'}, {'id': '1'}, {'id': '2'}]
         obj_list = []
         for i in range(10):
-            obj_list.append({'objectId': str(i), 'isPickedUp': (i != 0)})
+            obj_list.append({'objectId': str(i), 'wasPickedUp': (i != 0)})
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, agent={},
                                                    performer_reach=1.0)
         self.assertEqual(reward, 0)
@@ -293,32 +293,32 @@ class TestReward(unittest.TestCase):
 
         # Test: Picking up no targets should return a reward of 0
         obj_list = [
-            {'objectId': '0', 'isPickedUp': False},
-            {'objectId': '1', 'isPickedUp': False}
+            {'objectId': '0', 'wasPickedUp': False},
+            {'objectId': '1', 'wasPickedUp': False}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 0)
 
         # Test: Picking up only the 1st target should return a reward of 1
         obj_list = [
-            {'objectId': '0', 'isPickedUp': True},
-            {'objectId': '1', 'isPickedUp': False}
+            {'objectId': '0', 'wasPickedUp': True},
+            {'objectId': '1', 'wasPickedUp': False}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 1)
 
         # Test: Picking up only the 2nd target should return a reward of 1
         obj_list = [
-            {'objectId': '0', 'isPickedUp': False},
-            {'objectId': '1', 'isPickedUp': True}
+            {'objectId': '0', 'wasPickedUp': False},
+            {'objectId': '1', 'wasPickedUp': True}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 1)
 
         # Test: Picking up all targets should return a reward of 1
         obj_list = [
-            {'objectId': '0', 'isPickedUp': True},
-            {'objectId': '1', 'isPickedUp': True}
+            {'objectId': '0', 'wasPickedUp': True},
+            {'objectId': '1', 'wasPickedUp': True}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 1)
@@ -330,72 +330,72 @@ class TestReward(unittest.TestCase):
 
         # Test: Picking up no targets should return a reward of 0
         obj_list = [
-            {'objectId': '0', 'isPickedUp': False},
-            {'objectId': '1', 'isPickedUp': False},
-            {'objectId': '2', 'isPickedUp': False}
+            {'objectId': '0', 'wasPickedUp': False},
+            {'objectId': '1', 'wasPickedUp': False},
+            {'objectId': '2', 'wasPickedUp': False}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 0)
 
         # Test: Picking up only the 1st target should return a reward of 0
         obj_list = [
-            {'objectId': '0', 'isPickedUp': True},
-            {'objectId': '1', 'isPickedUp': False},
-            {'objectId': '2', 'isPickedUp': False}
+            {'objectId': '0', 'wasPickedUp': True},
+            {'objectId': '1', 'wasPickedUp': False},
+            {'objectId': '2', 'wasPickedUp': False}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 0)
 
         # Test: Picking up only the 2nd target should return a reward of 0
         obj_list = [
-            {'objectId': '0', 'isPickedUp': False},
-            {'objectId': '1', 'isPickedUp': True},
-            {'objectId': '2', 'isPickedUp': False}
+            {'objectId': '0', 'wasPickedUp': False},
+            {'objectId': '1', 'wasPickedUp': True},
+            {'objectId': '2', 'wasPickedUp': False}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 0)
 
         # Test: Picking up only the 3rd target should return a reward of 0
         obj_list = [
-            {'objectId': '0', 'isPickedUp': False},
-            {'objectId': '1', 'isPickedUp': False},
-            {'objectId': '2', 'isPickedUp': True}
+            {'objectId': '0', 'wasPickedUp': False},
+            {'objectId': '1', 'wasPickedUp': False},
+            {'objectId': '2', 'wasPickedUp': True}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 0)
 
         # Test: Picking up the 1st and 2nd targets should return a reward of 1
         obj_list = [
-            {'objectId': '0', 'isPickedUp': True},
-            {'objectId': '1', 'isPickedUp': True},
-            {'objectId': '2', 'isPickedUp': False}
+            {'objectId': '0', 'wasPickedUp': True},
+            {'objectId': '1', 'wasPickedUp': True},
+            {'objectId': '2', 'wasPickedUp': False}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 1)
 
         # Test: Picking up the 1st and 3rd targets should return a reward of 1
         obj_list = [
-            {'objectId': '0', 'isPickedUp': True},
-            {'objectId': '1', 'isPickedUp': False},
-            {'objectId': '2', 'isPickedUp': True}
+            {'objectId': '0', 'wasPickedUp': True},
+            {'objectId': '1', 'wasPickedUp': False},
+            {'objectId': '2', 'wasPickedUp': True}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 1)
 
         # Test: Picking up the 2nd and 3rd targets should return a reward of 1
         obj_list = [
-            {'objectId': '0', 'isPickedUp': False},
-            {'objectId': '1', 'isPickedUp': True},
-            {'objectId': '2', 'isPickedUp': True}
+            {'objectId': '0', 'wasPickedUp': False},
+            {'objectId': '1', 'wasPickedUp': True},
+            {'objectId': '2', 'wasPickedUp': True}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 1)
 
         # Test: Picking up all targets should return a reward of 1
         obj_list = [
-            {'objectId': '0', 'isPickedUp': True},
-            {'objectId': '1', 'isPickedUp': True},
-            {'objectId': '2', 'isPickedUp': True}
+            {'objectId': '0', 'wasPickedUp': True},
+            {'objectId': '1', 'wasPickedUp': True},
+            {'objectId': '2', 'wasPickedUp': True}
         ]
         reward = mcs.Reward._calc_retrieval_reward(goal, obj_list, {}, 1.0)
         self.assertEqual(reward, 1)


### PR DESCRIPTION
Throwing this up here for discussion. I believe we've done this in the past where we've "patched" TA1 EC2 instances by overwriting specific files (in this case, `reward.py`) that have been downloaded in their local python virtual environment.

Changes:
- Added an optional "pickup_number" property to the goal metadata. If a scene's goal has a "pickup_number", that's the number of targets which must be picked up in order to attain the reward. Therefore in ambiguous Number Comparison and Arithmetic scenes, we can label ALL soccer balls as "targets", but have the "pickup_number" be half of the total.
- Scenes without a "pickup_number" should still work as before: all of the "targets" must be picked up in order to attain the reward.

TODOs:
- Add an integration test as part of this PR.
- Update the Number Comparison and Arithmetic hypercube code (MCS-1708)