### PR TITLE
MCS-1803 Various Integration Test Updates

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -12,7 +12,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Build and Commit
-      uses: sphinx-notes/pages@master
+      uses: sphinx-notes/pages@v3
       with:
         documentation_path: docs/source
     - name: Push changes

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -50,12 +50,94 @@ Create the following files (Replace `<X>` with your test name):
 
 - `./data/<X>.scene.json`: An MCS scene configuration JSON file. Give it a useful `name` that describes the specific test case for future developers.
 - `./data/<X>.actions.txt`: The list of specific actions to take in the scene, each action and its corresponding parameters on its own line, with the following format: `action<,parameter=value>\n`
-- `./data/<X>.<level1|level2|oracle>.outputs.json`: Each file is a JSON list of expected step and object output metadata per action step, starting at step 0 (initialization), for runs with the file's corresponding metadata tier. Please do not skip any step. See the Python code for the available JSON test properties. One separate file per metadata tier, and each metadata tier should have its own corresponding file.
+- `./data/<X>.<level1|level2|oracle>.outputs.json`: Each file is a JSON list of expected step and object output metadata per action step, starting at step 0 (initialization), for runs with the file's corresponding metadata tier. Please do not skip any step. See the [Outputs File Schema](#Outputs-File-Schema) below for the available JSON test properties. One separate file per metadata tier, and each metadata tier should have its own corresponding file.
+- (Optionally) `./data/<X>.<level1|level2|oracle>.config.ini`: MCS config files to use for running this specific scene at each metadata level, overriding the default config files in `integration_tests/`.
 
 While adding a new test scene, you can run with the `--dev` flag to run the whole scene and print the errors at each action step (by default, a test will stop immediately if it finds an error).
 
-### Future Handmade Test Scene Ideas
+### Outputs File Schema
 
-- PickupObject on a container with an object positioned inside of it (MCS-473)
-- Circumnavigating objects (MCS-541)
-- PickupObject on a "pickupable" object that is too large or heavy (when needed by an evaluation task)
+#### Example
+
+```json
+[{
+    "step_number": 0,
+    "head_tilt": 0.0,
+    "objects_count": 1,
+    "position_x": 0.0,
+    "position_y": 0.0,
+    "position_z": 0.0,
+    "return_status": "SUCCESSFUL",
+    "rotation_y": 0.0,
+    "structural_objects_count": 5,
+    "objects": [{
+        "id": "testObject",
+        "held": true,
+        "position_x": 0.0,
+        "position_y": 0.0,
+        "position_z": 1.0,
+        "rotation_x": 0.0,
+        "rotation_y": 0.0,
+        "rotation_z": 1.0,
+        "shape": "ball",
+        "texture_color_list": ["blue"],
+        "visible": true
+    }]
+}]
+```
+
+#### Notes
+
+- Please have validation for each step.
+- If you do not include checks for properties, it does not mean those properties are null, it just means you are not checking them in the particular test. This is also true for objects: if you put an empty array for `objects`, it does not mean there are no objects, it just means you are not checking any object properties (so use `objects_count: 0` instead).
+
+#### Step Validation
+
+- `action_list`: Expected action restrictions at this step, as an array of nested [action, parameters] array 
+- `camera_height`: Expected camera height
+- `haptic_feedback`: Expected haptick feedback
+- `head_tilt`: Expected head tilt
+- `holes`: Expected holes, as an array of nested [X, Z] arrays
+- `lava`: Expected lava, as an array of nested [X, Z] arrays
+- `objects`: Validation of specific objects; see [Object Validation](#Object-Validation) below. Note that each element in this array is required to have an `id` corresponding to the `id` of an object in the scene file.
+- `objects_count`: Expected number of objects
+- `physics_frames_per_second`: Expected physics frames per second
+- `position_x`: Expected performer agent X position
+- `position_y`: Expected performer agent Y position
+- `position_z`: Expected performer agent Z position
+- `return_status`: Expected action return status
+- `resolved_object`: Expected resolved object
+- `resolved_receptacle`: Expected resolved receptacle object
+- `reward`: Expected reward
+- `rotation_y`: Expected performer agent Y rotation
+- `room_dimensions`: Expected room dimensions
+- `step_number`: Expected step number
+- `structural_objects`: Validation of specific structural objects; see [Object Validation](#Object-Validation) below. Note that each element in this array is required to have an `id` corresponding to the `id` of an object in the scene file.
+- `structural_objects_count`: Expected number of structural objects
+- `triggered_by_sequence_incorrect`: Expected "triggered_by_sequence_incorrect"
+
+#### Object Validation
+
+- `id` (Required): The "id" of the corresponding object in the scene file
+- `associated_with_agent`: Whether this object starts held by a simulation-controlled agent
+- `direction_x`: Expected X direction from the performer agent to this object
+- `direction_y`: Expected Y direction from the performer agent to this object
+- `direction_z`: Expected Z direction from the performer agent to this object
+- `distance`: Expected distance between the performer agent and this object
+- `held`: Whether this object is being held
+- `is_open`: Whether this object is currently open
+- `locked`: Whether this object is currently locked
+- `mass`: Expected object mass
+- `material_list`: Expected object salient material list
+- `position_x`: Expected object X position
+- `position_y`: Expected object Y position
+- `position_z`: Expected object Z position
+- `rotation_x`: Expected object X rotation
+- `rotation_y`: Expected object Y rotation
+- `rotation_z`: Expected object Z rotation
+- `shape`: Expected object shape string (not to be confused with its "type" string)
+- `simulation_agent_held_object`: Expected object this simulation-controlled agent starts holding
+- `simulation_agent_is_holding_held_object`: Whether this simulation-controlled agent is still holding its object
+- `state_list`: Expected object "states" at this step
+- `texture_color_list`: Expected object texture colors
+- `visible`: Whether this object is currently visible

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -7,6 +7,12 @@ The goal of the integration tests is to:
 ## Run Handmade Tests
 
 ```
+python run_handmade_tests.py
+```
+
+### Run Specific Unity Build
+
+```
 python run_handmade_tests.py --mcs_unity_build_file_path <mcs_unity_build_file_path>
 ```
 
@@ -26,12 +32,16 @@ Replace `001` with any test scene.
 
 ## Run Prefab Tests
 
-TODO MCS-432
-
-## Run All Tests
+Note that this test requires an internet connection to run.
 
 ```
-python run_tests.py --mcs_unity_build_file_path <mcs_unity_build_file_path>
+python run_prefab_tests.py
+```
+
+### Run on Development Branch
+
+```
+python run_prefab_tests.py --mcs_unity_version development
 ```
 
 ## Run the Autofixer

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -100,6 +100,8 @@ While adding a new test scene, you can run with the `--dev` flag to run the whol
 
 - Please have validation for each step.
 - If you do not include checks for properties, it does not mean those properties are null, it just means you are not checking them in the particular test. This is also true for objects: if you put an empty array for `objects`, it does not mean there are no objects, it just means you are not checking any object properties (so use `objects_count: 0` instead).
+- Any numerical property can be an array instead of a single number. The array must contain two numbers. The integration tests will use the numbers in the array as minimum and maximum values for validating the property at that step.
+- All numerical properties will be rounded to the hundredths place.
 
 #### Step Validation
 
@@ -151,3 +153,5 @@ While adding a new test scene, you can run with the `--dev` flag to run the whol
 - `state_list`: Expected object "states" at this step
 - `texture_color_list`: Expected object texture colors
 - `visible`: Whether this object is currently visible
+
+Copyright 2023 CACI (formerly Next Century Corporation)

--- a/integration_tests/additional_integration_tests.py
+++ b/integration_tests/additional_integration_tests.py
@@ -4,13 +4,29 @@ import math
 import os.path
 
 import numpy as np
+from integration_test_utils import DEFAULT_TEST_CONFIGS
 
 import machine_common_sense as mcs
 
 INTEGRATION_TESTS_FOLDER = os.path.dirname(os.path.abspath(__file__))
+
 DEPTH_AND_SEGMENTATION_SCENE = (
     f'{INTEGRATION_TESTS_FOLDER}/depth_and_segmentation.scene.json'
 )
+DEPTH_AND_SEGMENTATION_TEST_CONFIGS = {
+    'level1': {
+        'history_enabled': False,
+        'metadata': 'level1'
+    },
+    'level2': {
+        'history_enabled': False,
+        'metadata': 'level2'
+    },
+    'oracle': {
+        'history_enabled': False,
+        'metadata': 'oracle'
+    },
+}
 
 DEPTH_DATA = (
     f'{INTEGRATION_TESTS_FOLDER}/depth_map.outputs.json'
@@ -472,9 +488,9 @@ def run_restricted_action_list_test(controller, metadata_tier):
 
 
 FUNCTION_LIST = [
-    run_depth_and_segmentation_test,
-    run_habituation_trial_counts_test,
-    run_position_by_step_test,
-    run_public_sample_scenes_test,
-    run_restricted_action_list_test
+    (run_depth_and_segmentation_test, DEPTH_AND_SEGMENTATION_TEST_CONFIGS),
+    (run_habituation_trial_counts_test, DEFAULT_TEST_CONFIGS),
+    (run_position_by_step_test, DEFAULT_TEST_CONFIGS),
+    (run_public_sample_scenes_test, DEFAULT_TEST_CONFIGS),
+    (run_restricted_action_list_test, DEFAULT_TEST_CONFIGS),
 ]

--- a/integration_tests/config_level1.ini
+++ b/integration_tests/config_level1.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1000

--- a/integration_tests/config_level2.ini
+++ b/integration_tests/config_level2.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1000

--- a/integration_tests/config_oracle.ini
+++ b/integration_tests/config_oracle.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/081.move_into_light_object_intuitive_reset.oracle.outputs.json
+++ b/integration_tests/data/081.move_into_light_object_intuitive_reset.oracle.outputs.json
@@ -323,7 +323,7 @@
             {
                 "direction_x": 0.0,
                 "direction_y": -0.734,
-                "direction_z": 0.679,
+                "direction_z": 0.69,
                 "distance": 0.697,
                 "held": false,
                 "id": "testBall",
@@ -353,9 +353,9 @@
         "objects": [
             {
                 "direction_x": 0.0,
-                "direction_y": -0.731,
-                "direction_z": 0.683,
-                "distance": 0.7,
+                "direction_y": -0.72,
+                "direction_z": 0.69,
+                "distance": 0.71,
                 "held": false,
                 "id": "testBall",
                 "mass": 1.9,
@@ -363,7 +363,7 @@
                     "RUBBER"
                 ],
                 "position_x": 0.0,
-                "position_z": 1.478,
+                "position_z": 1.49,
                 "shape": "ball",
                 "texture_color_list": [
                     "blue"

--- a/integration_tests/data/119.lava_end_scene.level1.config.ini
+++ b/integration_tests/data/119.lava_end_scene.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/119.lava_end_scene.level2.config.ini
+++ b/integration_tests/data/119.lava_end_scene.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1

--- a/integration_tests/data/119.lava_end_scene.oracle.config.ini
+++ b/integration_tests/data/119.lava_end_scene.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1

--- a/integration_tests/data/182.multiple_targets_config_only_goal_objs.level1.config.ini
+++ b/integration_tests/data/182.multiple_targets_config_only_goal_objs.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/182.multiple_targets_config_only_goal_objs.level2.config.ini
+++ b/integration_tests/data/182.multiple_targets_config_only_goal_objs.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/182.multiple_targets_config_only_goal_objs.oracle.config.ini
+++ b/integration_tests/data/182.multiple_targets_config_only_goal_objs.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/183.multiple_targets_config_only_goal_objs_false.level1.config.ini
+++ b/integration_tests/data/183.multiple_targets_config_only_goal_objs_false.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/183.multiple_targets_config_only_goal_objs_false.level2.config.ini
+++ b/integration_tests/data/183.multiple_targets_config_only_goal_objs_false.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/183.multiple_targets_config_only_goal_objs_false.oracle.config.ini
+++ b/integration_tests/data/183.multiple_targets_config_only_goal_objs_false.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/184.disable_position_false.level1.config.ini
+++ b/integration_tests/data/184.disable_position_false.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/184.disable_position_false.level2.config.ini
+++ b/integration_tests/data/184.disable_position_false.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/184.disable_position_false.oracle.config.ini
+++ b/integration_tests/data/184.disable_position_false.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/185.disable_position_true.level1.config.ini
+++ b/integration_tests/data/185.disable_position_true.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/185.disable_position_true.level2.config.ini
+++ b/integration_tests/data/185.disable_position_true.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/185.disable_position_true.oracle.config.ini
+++ b/integration_tests/data/185.disable_position_true.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/186.only_return_goal_objects_true.level1.config.ini
+++ b/integration_tests/data/186.only_return_goal_objects_true.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/186.only_return_goal_objects_true.level2.config.ini
+++ b/integration_tests/data/186.only_return_goal_objects_true.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/186.only_return_goal_objects_true.oracle.config.ini
+++ b/integration_tests/data/186.only_return_goal_objects_true.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1000

--- a/integration_tests/data/189.single-retrieval_only_return_goal_object.level1.config.ini
+++ b/integration_tests/data/189.single-retrieval_only_return_goal_object.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/189.single-retrieval_only_return_goal_object.level2.config.ini
+++ b/integration_tests/data/189.single-retrieval_only_return_goal_object.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1

--- a/integration_tests/data/189.single-retrieval_only_return_goal_object.oracle.config.ini
+++ b/integration_tests/data/189.single-retrieval_only_return_goal_object.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1

--- a/integration_tests/data/190.intuitive_only_return_goal_object.level1.config.ini
+++ b/integration_tests/data/190.intuitive_only_return_goal_object.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/190.intuitive_only_return_goal_object.level2.config.ini
+++ b/integration_tests/data/190.intuitive_only_return_goal_object.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1

--- a/integration_tests/data/190.intuitive_only_return_goal_object.oracle.config.ini
+++ b/integration_tests/data/190.intuitive_only_return_goal_object.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1

--- a/integration_tests/data/191.imitation_only_return_goal_object.level1.config.ini
+++ b/integration_tests/data/191.imitation_only_return_goal_object.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/191.imitation_only_return_goal_object.level2.config.ini
+++ b/integration_tests/data/191.imitation_only_return_goal_object.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1

--- a/integration_tests/data/191.imitation_only_return_goal_object.oracle.config.ini
+++ b/integration_tests/data/191.imitation_only_return_goal_object.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1

--- a/integration_tests/data/192.passive_physics_only_return_goal_object.level1.config.ini
+++ b/integration_tests/data/192.passive_physics_only_return_goal_object.level1.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level1
 steps_allowed_in_lava: 1

--- a/integration_tests/data/192.passive_physics_only_return_goal_object.level2.config.ini
+++ b/integration_tests/data/192.passive_physics_only_return_goal_object.level2.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: level2
 steps_allowed_in_lava: 1

--- a/integration_tests/data/192.passive_physics_only_return_goal_object.oracle.config.ini
+++ b/integration_tests/data/192.passive_physics_only_return_goal_object.oracle.config.ini
@@ -1,4 +1,6 @@
 [MCS]
+disable_depth_maps: true
+disable_object_masks: true
 history_enabled: false
 metadata: oracle
 steps_allowed_in_lava: 1

--- a/integration_tests/integration_test_utils.py
+++ b/integration_tests/integration_test_utils.py
@@ -1,12 +1,14 @@
 import argparse
 import pathlib
 
+METADATA_TIER_LIST = ['level1', 'level2', 'oracle']
+
 config_dir = pathlib.Path(__file__).parent
-METADATA_TIER_LIST = [
-    ('level1', str(config_dir / 'config_level1.ini')),
-    ('level2', str(config_dir / 'config_level2.ini')),
-    ('oracle', str(config_dir / 'config_oracle.ini'))
-]
+DEFAULT_TEST_CONFIGS = {
+    'level1': str(config_dir / 'config_level1.ini'),
+    'level2': str(config_dir / 'config_level2.ini'),
+    'oracle': str(config_dir / 'config_oracle.ini')
+}
 
 
 def print_divider():
@@ -15,15 +17,15 @@ def print_divider():
 
 def add_test_args(parser: argparse.ArgumentParser,
                   handmade_only=False) -> argparse.ArgumentParser:
-    if not handmade_only:
-        parser.add_argument(
-            'mcs_unity_github_branch_name',
-            help='Name of branch/tag on MCS AI2-THOR Unity GitHub repository'
-        )
+    # if not handmade_only:
+    #    parser.add_argument(
+    #        'mcs_unity_github_branch_name',
+    #        help='Name of branch/tag on MCS AI2-THOR Unity GitHub repository'
+    #    )
     parser.add_argument(
         '--metadata',
         default=None,
-        choices=[metadata_tier[0] for metadata_tier in METADATA_TIER_LIST],
+        choices=[metadata_tier for metadata_tier in METADATA_TIER_LIST],
         help='Metadata tier to run (by default, test each metadata tier)'
     )
     parser.add_argument(

--- a/integration_tests/integration_test_utils.py
+++ b/integration_tests/integration_test_utils.py
@@ -17,11 +17,6 @@ def print_divider():
 
 def add_test_args(parser: argparse.ArgumentParser,
                   handmade_only=False) -> argparse.ArgumentParser:
-    # if not handmade_only:
-    #    parser.add_argument(
-    #        'mcs_unity_github_branch_name',
-    #        help='Name of branch/tag on MCS AI2-THOR Unity GitHub repository'
-    #    )
     parser.add_argument(
         '--metadata',
         default=None,

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -6,8 +6,8 @@ import os.path
 import time
 
 from additional_integration_tests import FUNCTION_LIST
-from integration_test_utils import (METADATA_TIER_LIST, add_test_args,
-                                    print_divider)
+from integration_test_utils import (DEFAULT_TEST_CONFIGS, METADATA_TIER_LIST,
+                                    add_test_args, print_divider)
 
 import machine_common_sense as mcs
 from machine_common_sense.logging_config import LoggingConfig
@@ -311,21 +311,19 @@ def start_handmade_tests(
     failed_test_list = []
     mcs.init_logging(LoggingConfig.get_errors_only_console_config())
     # Run each test scene at each metadata tier.
-    controller = None
-    for metadata_tier, config_filename in METADATA_TIER_LIST:
+    for metadata_tier in METADATA_TIER_LIST:
         if only_metadata_tier and metadata_tier != only_metadata_tier:
             continue
         print_divider()
         print(f'HANDMADE TEST METADATA TIER: {metadata_tier.upper()}')
-        print(f'mcs_unity_build: {mcs_unity_build}')
+
         # Create one controller to run all of the tests at this metadata tier.
-        if (not controller):
-            controller = mcs.create_controller(
-                unity_app_file_path=mcs_unity_build,
-                unity_cache_version=unity_version,
-                config_file_or_dict=config_filename)
-        else:
-            mcs.change_config(controller, config_file_or_dict=config_filename)
+        config_filename = DEFAULT_TEST_CONFIGS[metadata_tier]
+        controller = mcs.create_controller(
+            unity_app_file_path=mcs_unity_build,
+            unity_cache_version=unity_version,
+            config_file_or_dict=config_filename
+        )
 
         reset_config = False
         # Run each test scene and record if it failed validation.
@@ -379,10 +377,13 @@ def start_handmade_tests(
                     controller, config_file_or_dict=config_filename)
 
         # Run each additional test at this metadata tier.
-        for runner_function in (
-                [func for func in FUNCTION_LIST
-                 if only_test_name is None or
-                 only_test_name in str(func)]):
+        for runner_function, config_data in [
+            (runner_function, config_data)
+            for runner_function, config_data in FUNCTION_LIST
+            if only_test_name is None or only_test_name in str(runner_function)
+        ]:
+            config = config_data[metadata_tier]
+            mcs.change_config(controller, config_file_or_dict=config)
             print(f'RUNNING TESTS: {runner_function.__name__}')
             successful, status = runner_function(controller, metadata_tier)
             test_name = runner_function.__name__

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -317,6 +317,7 @@ def start_handmade_tests(
             continue
         print_divider()
         print(f'HANDMADE TEST METADATA TIER: {metadata_tier.upper()}')
+        print(f'mcs_unity_build: {mcs_unity_build}')
         # Create one controller to run all of the tests at this metadata tier.
         if (not controller):
             controller = mcs.create_controller(

--- a/integration_tests/run_prefab_tests.py
+++ b/integration_tests/run_prefab_tests.py
@@ -1,21 +1,214 @@
 import argparse
+import copy
+import json
+import time
+import urllib.request
 
-from integration_test_utils import add_test_args
+from integration_test_utils import (DEFAULT_TEST_CONFIGS, add_test_args,
+                                    print_divider)
 
+import machine_common_sense as mcs
+from machine_common_sense.logging_config import LoggingConfig
+
+# Template for test scenes.
+SCENE_TEMPLATE = {
+    'name': None,
+    'version': 2,
+    'ceilingMaterial': 'AI2-THOR/Materials/Walls/Drywall',
+    'floorMaterial': 'AI2-THOR/Materials/Fabrics/CarpetWhite 3',
+    'wallMaterial': 'AI2-THOR/Materials/Walls/Drywall',
+    'performerStart': {
+        'position': {
+            'x': 0,
+            'z': -4
+        },
+        'rotation': {
+            'x': 0,
+            'y': 0
+        }
+    },
+    'objects': [{
+        'id': None,
+        'type': None,
+        'kinematic': True,
+        'physics': True,
+        'materials': ['Custom/Materials/Blue'],
+        'shows': [{
+            'stepBegin': 0,
+            'position': {
+                'x': 0,
+                'y': 0,
+                'z': 1
+            },
+            'rotation': {
+                'x': 0,
+                'y': 45,
+                'z': 0
+            },
+            'scale': {
+                'x': 1,
+                'y': 1,
+                'z': 1
+            }
+        }]
+    }]
+}
+
+# List of object registries.
 OBJECT_REGISTRY_LIST = [
     'ai2thor_object_registry.json',
     'mcs_object_registry.json',
     'primitive_object_registry.json'
 ]
 
+# URL for object registries (replacing branch_name and registry_name).
+OBJECT_REGISTRY_URL = "https://raw.githubusercontent.com/NextCenturyCorporation/ai2thor/branch_name/unity/Assets/Addressables/MCS/registry_name"  # noqa: E501
 
-def identify_mcs_resources_github_link(branch):
-    return f'https://github.com/NextCenturyCorporation/ai2thor/tree/{branch}/unity/Assets/Resources/MCS/'  # noqa: E501
+# Materials for objects with material restrictions. It doesn't matter what the
+# exact material is, as long as each object has a valid material configured.
+MATERIALS = {
+    'no_material': [],
+    'flat_colors': ['Custom/Materials/Blue'],
+    'armchair_thorkea': ['AI2-THOR/Objects/Physics/SimObjsPhysics/THORKEA Objects/THORKEA_Assets_Furniture/Armchair/Materials/THORKEA_Armchair_Ekemas_Fabric_Mat'],  # noqa: E501
+    'block_blank': ['UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/blue_1x1'],  # noqa: E501
+    'block_design': ['UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_A_Blue_1K/ToyBlockBlueA'],  # noqa: E501
+    'cardboard': ['AI2-THOR/Materials/Misc/Cardboard_Brown'],
+    'ceramic': ['AI2-THOR/Materials/Ceramics/GREYGRANITE'],
+    'fabric': ['AI2-THOR/Materials/Fabrics/Carpet4'],
+    'leather': ['AI2-THOR/Materials/Fabrics/Leather'],
+    'leather_armchair': ['UnityAssetStore/Leather_Chair/Assets/Materials/Leather_Chair_NEW_1'],  # noqa: E501
+    'metal': ['AI2-THOR/Materials/Metals/BrushedAluminum_Blue'],
+    'plastic': ['AI2-THOR/Materials/Plastics/OrangePlastic'],
+    'rubber': ['AI2-THOR/Materials/Plastics/LightBlueRubber'],
+    'sofa_1': ['AI2-THOR/Materials/Fabrics/Sofa1_Blue'],
+    'sofa_chair_1': ['AI2-THOR/Materials/Fabrics/SofaChair1_Salmon'],
+    'sofa_2': ['AI2-THOR/Materials/Fabrics/Sofa2_Grey'],
+    'sofa_3': ['AI2-THOR/Materials/Fabrics/Sofa3_Blue'],
+    'sofa_8': ['Assets/Addressables/MCS/UnityAssetStore/Furniture/Source/Materials/3Seat_BaseColor'],  # noqa: E501
+    'sofa_chair_8': ['Assets/Addressables/MCS/UnityAssetStore/Furniture/Source/Materials/fotel2_BaseColor'],  # noqa: E501
+    'sofa_9': ['Assets/Addressables/MCS/UnityAssetStore/Furniture/Source/Materials/2Seat_BaseColor'],  # noqa: E501
+    'sofa_thorkea': ['AI2-THOR/Objects/Physics/SimObjsPhysics/THORKEA Objects/THORKEA_Assets_Furniture/Sofa/Materials/THORKEA_Sofa_Alrid_Fabric_Mat'],  # noqa: E501
+    'tools': ['UnityAssetStore/YughuesFreeMetalMaterials/Materials/M_YFMM_15'],
+    'wall': ['AI2-THOR/Materials/Walls/EggshellDrywall'],
+    'wood': ['AI2-THOR/Materials/Wood/WornWood']
+}
 
 
-def start_prefab_tests(mcs_unity_build, branch):
-    # TODO MCS-432
-    pass
+def retrieve_registry_data(registry_name: str, branch_name: str) -> dict:
+    # Retrieve the object registry data from the latest on GitHub.
+    url = OBJECT_REGISTRY_URL
+    url = url.replace("registry_name", registry_name)
+    url = url.replace("branch_name", branch_name)
+    with urllib.request.urlopen(url) as page:
+        html = page.read().decode('utf-8')
+        html = html.replace("\n", "").replace(" ", "")
+        data = json.loads(html)
+        return data['objects']
+    return []
+
+
+def start_prefab_tests(mcs_unity_version: str, branch_name: str) -> None:
+    # Set logging.
+    mcs.init_logging(LoggingConfig.get_errors_only_console_config())
+
+    # Use the oracle MCS config file.
+    config_file = DEFAULT_TEST_CONFIGS['oracle']
+
+    # Create the controller and start Unity.
+    controller = mcs.create_controller(
+        unity_app_file_path=None,
+        unity_cache_version=mcs_unity_version,
+        config_file_or_dict=config_file
+    )
+
+    failed_scenes = []
+    successful_scenes = []
+
+    # Loop over each object registry file...
+    for registry_name in OBJECT_REGISTRY_LIST:
+        # Retrieve all of the objects in this registry.
+        objects = retrieve_registry_data(registry_name, branch_name)
+        print_divider()
+        print(f'Reading {len(objects)} objects from {registry_name}')
+
+        # Loop over each object...
+        for entry in objects:
+            object_type = entry['id']
+            # Skip over deprecated objects.
+            if (
+                object_type == 'cake' or
+                object_type.startswith('emoji_') or
+                object_type.startswith('painting_') or
+                object_type.startswith('plant_') or
+                object_type.endswith('_faceless')
+            ):
+                continue
+
+            # Generate the test scene to validate this object.
+            scene_data = copy.deepcopy(SCENE_TEMPLATE)
+            scene_data['name'] = f'prefab_test_{object_type}'
+            scene_data['objects'][0]['id'] = f'test_{object_type}'
+            scene_data['objects'][0]['type'] = object_type
+
+            # Update the object's material if the object has any restrictions.
+            material_restrictions = entry.get('materialRestrictions', [])
+            if material_restrictions:
+                materials = MATERIALS[material_restrictions[0]]
+                scene_data['objects'][0]['materials'] = materials
+
+            # Start the test scene, and wait for it to load.
+            step_metadata = controller.start_scene(scene_data)
+            time.sleep(1)
+
+            # Ensure the object exists, is visible, and has texture/shape.
+            successful = False
+            if len(step_metadata.object_list) == 0:
+                failed_scenes.append((
+                    object_type,
+                    ['No objects']
+                ))
+            else:
+                object_metadata = step_metadata.object_list[0]
+                failed_conditions = []
+                if not object_metadata.visible:
+                    failed_conditions.append('Not visible')
+                if not object_metadata.texture_color_list:
+                    failed_conditions.append('No texture color list')
+                if not object_metadata.shape:
+                    failed_conditions.append('No shape')
+                if not object_metadata.position:
+                    failed_conditions.append('No position')
+                if not object_metadata.mass:
+                    failed_conditions.append('No mass')
+                if failed_conditions:
+                    failed_scenes.append((
+                        object_type,
+                        failed_conditions
+                    ))
+                else:
+                    successful_scenes.append(object_type)
+                    successful = True
+
+            # Record success or failure.
+            if successful:
+                print(f'{object_type} successful')
+            else:
+                conditions = failed_scenes[-1][1]
+                print(f'{object_type} FAILED: {"; ".join(conditions)}')
+
+            # End the current scene.
+            controller.end_scene()
+
+    # List each failed scene (if any).
+    print_divider()
+    print(
+        f'Final results: {len(successful_scenes)} successful, '
+        f'{len(failed_scenes)} failed'
+    )
+    if len(failed_scenes):
+        print('Failed scenes:')
+    for object_type, conditions in failed_scenes:
+        print(f'    {object_type}: {"; ".join(conditions)}')
 
 
 if __name__ == "__main__":
@@ -25,6 +218,7 @@ if __name__ == "__main__":
     parser = add_test_args(parser)
     args = parser.parse_args()
     start_prefab_tests(
-        args.mcs_unity_build_file_path,
-        args.mcs_unity_github_branch_name
+        args.mcs_unity_version,
+        'development' if args.mcs_unity_version in ['dev', 'development']
+        else 'master'
     )

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -3,16 +3,14 @@ import argparse
 from integration_test_utils import add_test_args
 from run_handmade_tests import start_handmade_tests
 
-# from run_prefab_tests import start_prefab_tests
+"""
+This script is effectively the same as running run_handmade_tests directly,
+but kept here to avoid breaking our CI/CD workflow.
+"""
 
 
 if __name__ == "__main__":
-    # TODO MCS-432
-    # args = retrieve_test_args('All')
-    # start_prefab_tests(
-    #     args.mcs_unity_build_file_path,
-    #     args.mcs_unity_github_branch_name
-    # )
+    # Intentionally don't run the "prefab tests", because it seems excessive.
     parser = argparse.ArgumentParser(
         description="Run All Integration Tests"
     )

--- a/machine_common_sense/scripts/run_scene_with_command_file.py
+++ b/machine_common_sense/scripts/run_scene_with_command_file.py
@@ -41,7 +41,8 @@ def main():
 
     controller = mcs.create_controller(
         unity_app_file_path=args.mcs_unity_build_file,
-        config_file_or_dict='./run_scripts_config_with_history.ini'
+        # config_file_or_dict='./run_scripts_config_with_history.ini'
+        config_file_or_dict='./phi_config.ini'
     )
 
     config_file_path = args.mcs_config_json_file


### PR DESCRIPTION
1. Added documentation on the integration test "outputs" file schema to the README.
2. Config files for all integration tests now have depth maps and object masks disabled by default, to improve runtime performance; the one test that checks the depth and segmentation data now has its own config file.
3. A new controller (Unity window) is now created for each metadata tier, to stop some timeout issues probably due to memory usage.
4. Added "prefab tests" -- see the README for details. Please note that you'll currently see "no texture color list" failures for agents, TVs, some sofas/chairs, and most antiques, which will be fixed on this PR: https://github.com/NextCenturyCorporation/ai2thor/pull/334