### PR TITLE
MCS-1869 Fixes for Doc Publish

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -6,17 +6,24 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      pages: write 
+      id-token: write
+      contents: write
+      pull-requests: write
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Build and Commit
-      uses: sphinx-notes/pages@master
+      uses: sphinx-notes/pages@v3
       with:
         documentation_path: docs/source
+        publish: false        
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PLE_PAT_ACTIONS }}
         branch: gh-pages
+        force: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,35 @@
+ai2thor==2.5.0
+autopep8==1.7.1; python_version<"3.8"
+autopep8==2.0.2; python_version>="3.8"
+colour==0.1.5
+commonmark==0.9.1
+flake8==5.0.4; python_version<"3.8"
+flake8==6.0.0; python_version>="3.8"
+flake8-implicit-str-concat==0.4.0
+flake8-use-fstring==1.4
+importlib-metadata==4.2.0; python_version<"3.8"
+importlib-metadata==6.3.0; python_version>="3.8"
+isort==5.11.5; python_version<"3.8"
+isort==5.12.0; python_version>="3.8"
+Jinja2==3.1.2
+matplotlib==3.5.3; python_version<"3.8"
+matplotlib==3.7.1; python_version>="3.8"
+msgpack==1.0.5
+numpyencoder==0.3.0
+opencv-python==4.4.0.46; python_version<="3.9"
+opencv-python==4.5.4.60; python_version>="3.10"
+pep8-naming==0.13.3
+pre-commit==2.21.0; python_version<"3.8"
+pre-commit==3.2.2; python_version>="3.8"
+pydantic==1.10.7
+recommonmark==0.7.1
+requests==2.31.0
+scikit-image==0.19.3
+Shapely==1.7.1; python_version<"3.10"
+Shapely==1.8.5; python_version>="3.10"
+Sphinx==4.3.2; python_version<"3.8"
+Sphinx==6.1.3; python_version>="3.8"
+sphinxcontrib-websupport==1.2.4
+sphinx-markdown-builder==0.5.5
+typeguard==3.0.2
+git+https://github.com/sphinx-contrib/video.git

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,1 +1,0 @@
-../../requirements.txt


### PR DESCRIPTION
Fixes to for Doc Publish (hot fixed on master to get release deployed)

Looks like deploy has gone through successfully.  There will be errors with the PYPI push since that was successful the first time, subsequent workflow runs (since doc-publish and pypi push are part of the same workflow) show the PYPI fails because it already exists.