### PR TITLE
MCS-1808 - Fix shortcut keys for Pass and EndScene in human input mode 

### DIFF
--- a/machine_common_sense/action.py
+++ b/machine_common_sense/action.py
@@ -749,7 +749,6 @@ class Action(Enum):
         Unexpected error; please report immediately to development team.
     """
 
-    # Pass should always be the last action in the enum.
     END_SCENE = (
         "EndScene",
         "q",

--- a/machine_common_sense/action.py
+++ b/machine_common_sense/action.py
@@ -752,7 +752,7 @@ class Action(Enum):
     # Pass should always be the last action in the enum.
     END_SCENE = (
         "EndScene",
-        " ",
+        "q",
         "There is no action available and end_scene needs to be called."
     )
     """

--- a/machine_common_sense/scripts/run_human_input.py
+++ b/machine_common_sense/scripts/run_human_input.py
@@ -66,6 +66,17 @@ class HumanInputShell(cmd.Cmd):
     def precmd(self, line):
         return line
 
+    def parseline(self, line):
+        # don't strip line if spacebar was pressed
+        if (line == ' '):
+            i, n = 0, len(line)
+            while i < n and line[i] in self.identchars:
+                i = i + 1
+            cmd, arg = line[:i], line[i:].strip()
+            return cmd, arg, line
+        else:
+            return super().parseline(line)
+
     def postcmd(self, stop_flag, line) -> bool:
         print('================================================='
               '==============================')


### PR DESCRIPTION
This was originally a webenabled ticket to enable the "spacebar = Pass" action, but I realized the problem was actually in human input mode:
1.) The spacebar was being used as a shortcut for two different actions (Pass and EndScene)
2.) Input in human input mode is stripped, so the spacebar didn't actually do anything.

This should be fixed now + can be tested in human input mode (spacebar will now pass, "q" to EndScene).