### PR TITLE
MCS-1910 [Webenabled] error handling

### DIFF
--- a/webenabled/mcs_interface.py
+++ b/webenabled/mcs_interface.py
@@ -18,6 +18,7 @@ IMG_HEIGHT = 400
 MCS_INTERFACE_TMP_DIR = "static/mcsinterface/"
 BLANK_IMAGE_NAME = 'blank_600x400.png'
 IMAGE_WAIT_TIMEOUT = 20.0
+UNITY_STARTUP_WAIT_TIMEOUT = 10.0
 
 
 def convert_key_to_action(key: str, logger):
@@ -82,7 +83,7 @@ class MCSInterface:
         self.pid = start_subprocess(self.command_out_dir, self.step_output_dir)
 
         # Read in the image
-        self.img_name = self.get_image_name_and_step_output()
+        self.img_name = self.get_image_name_and_step_output(init=True)
         return self.img_name
 
     def is_controller_alive(self):
@@ -164,7 +165,7 @@ class MCSInterface:
         f.write(full_action_str)
         f.close()
         # wait for action to process
-        time.sleep(0.1)
+        time.sleep(0.5)
 
         action_to_return = full_action_str
 
@@ -175,7 +176,7 @@ class MCSInterface:
 
         return action_to_return, img, step_output
 
-    def get_image_name_and_step_output(self):
+    def get_image_name_and_step_output(self, init=False):
         """Watch the output directory, get image that appears.  If it does
         not appear in timeout seconds, give up and return blank."""
         timestart = time.time()
@@ -183,9 +184,37 @@ class MCSInterface:
         while True:
             timenow = time.time()
             elapsed = (timenow - timestart)
+            if (init and elapsed > UNITY_STARTUP_WAIT_TIMEOUT):
+                self.logger.info(
+                    "Display blank image on default when starting up.")
+                self.img_name = self.blank_path
+                return self.img_name, self.step_output
+
             if elapsed > IMAGE_WAIT_TIMEOUT:
                 self.logger.info("Timeout waiting for image")
                 self.img_name = self.blank_path
+
+                list_of_error_files = glob.glob(
+                    self.step_output_dir + "/error_*.json")
+
+                if len(list_of_error_files) > 0:
+                    latest_error_file = max(
+                        list_of_error_files, key=os.path.getctime
+                    )
+                    if latest_error_file.endswith(
+                            f"step_{self.step_number}.json"):
+                        opened_error_file = open(latest_error_file, "r")
+                        new_error_output = json.load(opened_error_file)
+                        opened_error_file.close()
+                        self.img_name = self.blank_path
+                        if (self.step_output is None):
+                            self.step_output = {}
+
+                        self.step_output['error_output'] = {
+                            'step_number': new_error_output["step_number"],
+                            'error': new_error_output["error"]
+                        }
+
                 return self.img_name, self.step_output
 
             list_of_output_files = glob.glob(
@@ -193,7 +222,8 @@ class MCSInterface:
             list_of_img_files = glob.glob(self.step_output_dir + "/rgb_*.png")
 
             # Image file logic
-            if len(list_of_img_files) > 0 and len(list_of_output_files) > 0:
+            if len(list_of_img_files) > 0 and len(
+                    list_of_output_files) > 0:  # noqa: E501
                 latest_json_file = max(
                     list_of_output_files, key=os.path.getctime)
 

--- a/webenabled/mcs_interface.py
+++ b/webenabled/mcs_interface.py
@@ -107,10 +107,12 @@ class MCSInterface:
         key = params["keypress"]
         del params["keypress"]
         action = convert_key_to_action(key, self.logger)
-        self.step_number = self.step_number + 1
-        action_list_str = self.get_action_list(step_number=self.step_number)
         full_action, img, step_output = self._post_step_and_get_output(
             action, params)
+        if (step_output):
+            self.step_number = step_output.get('step_number', self.step_number)
+            action_list_str = self.get_action_list(
+                step_number=self.step_number)
         return full_action, img, step_output, action_list_str
 
     def _post_step_and_get_output(self, action: str, params=None):
@@ -225,11 +227,11 @@ class MCSInterface:
                 opened_json_file.close()
 
                 has_new_step_output = (("step_number" in new_step_output and
-                                       (self.step_output is None or
-                                        self.step_number == 0)) or
+                                        (self.step_output is None or
+                                         self.step_number == 0)) or
                                        ("step_number" in self.step_output and
-                                        new_step_output["step_number"] >
-                                        self.step_output["step_number"]))
+                                       new_step_output["step_number"] >
+                                       self.step_output["step_number"]))
 
                 if latest_image_file != self.img_name and has_new_step_output:
                     self.step_output = new_step_output

--- a/webenabled/run_scene_with_dir.py
+++ b/webenabled/run_scene_with_dir.py
@@ -12,6 +12,7 @@
 # resulting images from MCS are written out and put into the 'outdir'.
 #
 import argparse
+import glob
 import json
 import logging
 import os
@@ -36,6 +37,7 @@ class RunSceneWithDir:
         self.controller = None
         self.command_in_dir = command_in_dir
         self.output_dir = output_dir
+        self.step_number = 0
 
     def run_loop(self):
         logger.info(
@@ -100,6 +102,7 @@ class RunSceneWithDir:
             # Handle file names (new scene file) by loading
             if command.endswith(".json"):
                 self.scene_file = command
+                self.step_number = 0
                 self.load_scene()
             else:
                 # Otherwise, assume that it is a valid action
@@ -128,8 +131,32 @@ class RunSceneWithDir:
             if output is not None:
                 self.save_output_info(output)
                 self.save_output_image(output)
-        except Exception:
+                self.step_number = output.step_number
+        except Exception as error:
             logger.exception(f"Error executing command {command}")
+            self.log_error(error)
+
+    def log_error(self, error):
+        # Save error output to a separate file
+        scene_id = self.scene_file[
+            (self.scene_file.rfind('/') + 1):(self.scene_file.rfind('.'))
+        ]
+        error_output_file = f'{self.output_dir}/error_{scene_id}_step_{self.step_number}.json'  # noqa: E501
+
+        try:
+            f = open(error_output_file, "w")
+            output_to_save_dict = {
+                'step_number': self.step_number,
+                'error': str(error)
+            }
+
+            output_to_save_json = json.dumps(output_to_save_dict, indent=4)
+
+            f.write(output_to_save_json)
+            f.close()
+        except Exception:
+            logger.exception(
+                f"Error saving error output to file {error_output_file}")
 
     def save_output_info(self, output: StepMetadata):
         logger.info(f"Saving output info at step {output.step_number}")

--- a/webenabled/run_scene_with_dir.py
+++ b/webenabled/run_scene_with_dir.py
@@ -132,9 +132,19 @@ class RunSceneWithDir:
                 self.save_output_info(output)
                 self.save_output_image(output)
                 self.step_number = output.step_number
+                self.delete_old_error_files()
         except Exception as error:
             logger.exception(f"Error executing command {command}")
             self.log_error(error)
+
+    def delete_old_error_files(self):
+        # Delete outdated error files
+        list_of_error_files = glob.glob(
+            self.output_dir + "/error_*.json")
+
+        if len(list_of_error_files) > 0:
+            for file in list_of_error_files:
+                os.unlink(file)
 
     def log_error(self, error):
         # Save error output to a separate file

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -170,6 +170,11 @@
             font-size: 80%;
             min-height: 18px;
         }
+
+        #error_div {
+            display: none;
+            color: red;
+        }
     </style>
 </head>
 
@@ -258,7 +263,7 @@
                 <span id="goal_last_step">N/A</span>
             </div></p>
             <p><div id="last_action_div">
-                <span>Last Action Taken: </span>
+                <span>Last Action Attempted: </span>
                 <span id="last_action">N/A</span>
             </div></p>
             <p><div id="return_status_div">
@@ -266,7 +271,7 @@
                 <span id="return_status">N/A</span>
             </div></p>
             <p><div id="error_div">
-                <span>Error (if applicable): </span>
+                <span>Error: </span>
                 <span id="error">N/A</span>
             </div></p>
             <p><div id="reward_div">
@@ -426,14 +431,7 @@
         let passiveCategories = ["intuitive physics", "passive", "agents"]
         let isPassive = passiveCategories.includes(document.getElementById('goal_cat').innerHTML)
 
-        if("error_output" in data.step_output) {
-            console.warn("last attempted step resulted in an error");
-            let errorOutput = document.getElementById('error');
-            errorOutput.innerHTML = data.step_output.error_output.error;
-        } else {
-            let errorOutput = document.getElementById('error');
-            errorOutput.innerHTML = "N/A"
-        }
+        let errorOutput = document.getElementById('error');
 
         if("return_status" in data.step_output) {
             let returnStatus = document.getElementById('return_status');
@@ -447,6 +445,22 @@
             lastAction.innerHTML = data.last_action;
         } else {
             console.warn("last_action not in step_output");
+        }
+
+        if("error_output" in data.step_output) {
+            console.warn("last attempted step resulted in an error");
+            document.getElementById("error_div").style.display = "block"
+            errorOutput.innerHTML = data.step_output.error_output.error;
+
+            if(data.step_output.error_output.error.includes("[Errno 32] Broken pipe")) {
+                errorOutput.innerHTML += " - the Unity app is likely not running. Restart the Flask app and try again. "
+            }
+
+            document.getElementById("return_status_div").style.display = "none"
+        } else {
+            errorOutput.innerHTML = "N/A"
+            document.getElementById("error_div").style.display = "none"
+            document.getElementById("return_status_div").style.display = "block"
         }
 
         if(isPassive) {

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -265,6 +265,10 @@
                 <span>Return Status: </span>
                 <span id="return_status">N/A</span>
             </div></p>
+            <p><div id="error_div">
+                <span>Error (if applicable): </span>
+                <span id="error">N/A</span>
+            </div></p>
             <p><div id="reward_div">
                 <span>Reward: </span>
                 <span id="reward">N/A</span>
@@ -421,6 +425,15 @@
 
         let passiveCategories = ["intuitive physics", "passive", "agents"]
         let isPassive = passiveCategories.includes(document.getElementById('goal_cat').innerHTML)
+
+        if("error_output" in data.step_output) {
+            console.warn("last attempted step resulted in an error");
+            let errorOutput = document.getElementById('error');
+            errorOutput.innerHTML = data.step_output.error_output.error;
+        } else {
+            let errorOutput = document.getElementById('error');
+            errorOutput.innerHTML = "N/A"
+        }
 
         if("return_status" in data.step_output) {
             let returnStatus = document.getElementById('return_status');


### PR DESCRIPTION
This was to slightly improve the experience of when the user has an unexpected error from the Unity app. The main things I tested were:
- invalid actions (i.e. only available action is "Pass" but I tried "MoveAhead")
- trying an action when the unity app is no longer running

There should be an error displayed in these cases instead of return status (and an error file saved in the output folder).
