### PR TITLE
MCS-1816 [Webenabled] Improve styling

### DIFF
--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -39,7 +39,7 @@
 
         div#scene-nav-info {
             flex: 1;
-            min-width: 350px;
+            min-width: 400px;
         }
 
         .section {
@@ -66,7 +66,6 @@
         }
 
         #scenes-dropdown {
-            max-width: 300px;
             margin: 5px 5px 10px 10px;
         }
 
@@ -143,6 +142,26 @@
             }
         }
 
+        select {
+            width: 90%;
+            font-family: inherit;
+            font-size: inherit;
+            line-height: inherit;
+            padding: 3px;
+        }
+
+        input {
+            font-family: inherit;
+            font-size: inherit;
+            margin-left: 4px;
+            margin-right: 4px;
+        }
+
+        input.checkbox {
+            width: 16px;
+            height: 16px;
+        }
+
         .input_fields {
             display: flex;
             justify-content: space-between;
@@ -176,11 +195,17 @@
         <div id="scene-nav-info" class="section">
             <p><strong>Scenes</strong></p>
             <p>Pick from one of the following scenes:</p>
-            <select id="scenes-dropdown">
+            <select id="scenes-dropdown" size="40">
                 {% for scene in scene_list %}
                     <option>{{ scene }}</option>
                 {% endfor %}
             </select>
+        </div>
+        <div id="scene-demo" class="section">
+            <div id="scene_filename_div">
+                <span><strong>Scene Name: </strong></span>
+                <span id="scene_filename">None</span>
+            </div>
             <div id="goal_cat_div">
                 <span><strong>Goal Category: </strong></span>
                 <span id="goal_cat">N/A</span>
@@ -188,12 +213,6 @@
             <div id="goal_desc_div">
                 <span><strong>Goal Description: </strong></span>
                 <span id="goal_desc">N/A</span>
-            </div>
-        </div>
-        <div id="scene-demo" class="section">
-            <div id="scene_filename_div">
-                <span><strong>Scene Name: </strong></span>
-                <span id="scene_filename">None</span>
             </div>
             <div id="step_number_div">
                 <span><strong>Step: </strong></span>
@@ -256,7 +275,7 @@
                     <input type="number" min="-1" max="1" step="0.1" value="0.5" id="force"/>
                 </div>
                 <div>Clockwise: 
-                    <input type="checkbox" id="clockwise" checked>
+                    <input type="checkbox" id="clockwise" class="checkbox" checked>
                 </div>
                 <div>Lateral: 
                     <input type="number" min="-1" max="1" step="1" value="0" id="lateral"/>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -37,7 +37,7 @@
             font-weight: 300;
         }
 
-        div#scene_nav_info {
+        div#scene-nav-info {
             flex: 1
         }
 
@@ -54,12 +54,12 @@
         }
 
 
-        #scenes_dropdown {
+        #scenes-dropdown {
             max-width: 300px;
             margin: 5px 5px 10px 10px;
         }
 
-        #scenes_dropdown:hover {
+        #scenes-dropdown:hover {
             cursor: pointer;
         }
 
@@ -76,7 +76,7 @@
             margin-top: 90px;
         }
 
-        #shortcuts .closebtn {
+        #shortcuts .close-btn {
             position: absolute;
             top: 0;
             right: 25px;
@@ -97,7 +97,7 @@
             color: #a3a8ad;
         }
 
-        .openbtn {
+        .open-btn {
             font-size: 20px;
             /* background-color: #007bff */
             background-color: #59C3C3;
@@ -106,12 +106,12 @@
             border: none;
         }
 
-        .openbtn:hover {
+        .open-btn:hover {
             color: #F8F8F8;
             background-color: #047471;
         }
 
-        #scene_demo {
+        #scene-demo {
             transition: margin-left 0.5s;
             padding: 16px;
         }
@@ -209,10 +209,10 @@
         <h1>Machine Common Sense</h1>
     </div>
     <div id="content-wrapper">
-        <div id="scene_nav_info" class="section">
+        <div id="scene-nav-info" class="section">
             <p><strong>Scenes</strong></p>
             <p>Pick from one of the following scenes:</p>
-            <select id="scenes_dropdown">
+            <select id="scenes-dropdown">
                 {% for scene in scene_list %}
                     <option>{{ scene }}</option>
                 {% endfor %}
@@ -260,7 +260,7 @@
                 <span id="action_list">N/A</span>
             </div>
         </div>
-        <div id="scene_demo" class="section">
+        <div id="scene-demo" class="section">
             <div id="scene_filename_div">
                 <span><strong>Scene Name: </strong></span>
                 <span id="scene_filename">None</span>
@@ -268,7 +268,7 @@
             <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image"/>
 
             <div>
-                <button class="openbtn" id="openbtn" onclick="showShortcutInfo()">Help/Keyboard Shortcuts</button>
+                <button class="open-btn" id="open-btn" onclick="showShortcutInfo()">Help/Keyboard Shortcuts</button>
             </div>
             <div>
                 <strong>Action Parameter Input Fields:</strong>
@@ -312,7 +312,7 @@
 
         </div>
         <div id="shortcuts" class="section">
-            <a href="javascript:void(0)" class="closebtn" onclick="hideShortcutInfo()">×</a>
+            <a href="javascript:void(0)" class="close-btn" onclick="hideShortcutInfo()">×</a>
             <p><strong>Keyboard Shortcuts</strong></p>
             <p>Below are the keyboard shortcuts. Make sure your mouse is somewhere in the
                 browser window and key strokes will be sent to the environment.</p>
@@ -333,7 +333,7 @@
 <script>
     // ---------------------------------------------------------
     // Handle clicking on one of the scene file names
-    var sceneSelect = document.getElementById("scenes_dropdown");
+    var sceneSelect = document.getElementById("scenes-dropdown");
     let actionKeysWithParams = ['1', '3', '4', '5', '6', '7', '8', '9', 'm', 'M', 't', 'T']
     let arrowKeys = ["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight"]
     var processingKeypress = false
@@ -349,7 +349,7 @@
     sceneSelect.addEventListener('change', select_scene, false);
 
     function eventHandleScenes() {
-        sceneSelect = document.getElementById("scenes_dropdown");
+        sceneSelect = document.getElementById("scenes-dropdown");
         sceneSelect.addEventListener('change', select_scene, false);
     }
 
@@ -515,7 +515,7 @@
             scenesString = scenesString.concat('<option value=\"' + scene + '\">' + scene + '</option>')
         });
 
-        var scenesList = document.getElementById('scenes_dropdown');
+        var scenesList = document.getElementById('scenes-dropdown');
         scenesList.innerHTML = scenesString;
         eventHandleScenes()
 
@@ -703,12 +703,12 @@
 
     function showShortcutInfo() {
       document.getElementById("shortcuts").style.width = "30%";
-      document.getElementById("scene_demo").style.marginRight = "30%";
+      document.getElementById("scene-demo").style.marginRight = "30%";
     }
 
    function hideShortcutInfo() {
       document.getElementById("shortcuts").style.width = "0";
-      document.getElementById("scene_demo").style.marginRight = "0";
+      document.getElementById("scene-demo").style.marginRight = "0";
    }
 
 

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -7,28 +7,52 @@
         html, body {
             margin: 0;
             padding: 0;
+            background-color: #F8F8F8;
+            height: 100%;
+        }
+        #container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
         }
 
+        #content-wrapper {
+            display: flex;
+            flex-direction: row;
+        }
+
+        div#header h1 {
+            height: 80px;
+            line-height: 80px;
+            margin: 0;
+            padding-left: 10px;
+            color: #F8F8F8;
+            background: #5F6871;
+        }
+        
         body {
             color: #292929;
-            font: 90% Verdana, Arial, sans-serif;
+            font-family: Arial, Verdana, sans-serif;
+            font-size: 16px;
             font-weight: 300;
         }
 
-        p {
-            padding: 0 10px;
-            line-height: 1.8;
+        div#scene_nav_info {
+            flex: 1
         }
 
-        ul {
-            list-style-type: none;
-            margin: 10px;
+        .section > div {
             padding: 10px;
-            height: 200px;
-            width: 90%;
-            overflow: hidden;
-            overflow-y: scroll;
         }
+
+        .section > p {
+            padding: 0 10px 0;
+        }
+
+        .section > img {
+            padding: 0 10px 0;
+        }
+
 
         #scenes_dropdown {
             max-width: 300px;
@@ -39,94 +63,22 @@
             cursor: pointer;
         }
 
-        ul li a {
-            display: block;
-            width: 100%;
-            text-decoration: none;
-            padding: 5px;
-            color: #072c3e;
-            background-color: #98b8b9;
-        }
-
-        ul li a:hover {
-            background-color: #ccc;
-        }
-
-        h3 {
-            padding: 5px 20px;
-            margin: 0;
-        }
-
-        div#header h1 {
-            height: 80px;
-            line-height: 80px;
-            margin: 0;
-            padding-left: 10px;
-            background: #e0e0e0;
-            color: #292929;
-        }
-
-        div#navigation {
-            background: #7fa0a9;
-            padding-bottom: 20px;
-        }
-
-        div#navigation li {
-            list-style: none;
-        }
-
-        div#navigation div {
-            padding: 10px;
-        }
-
-        div#extra {
-            background: #7fa0a9;
-        }
-
-        div#footer {
-            background: #42444e;
-            color: #fff;
-        }
-
-        div#footer p {
-            padding: 20px 10px;
-        }
-
-        div#wrapper {
-            float: left;
-            width: 100%;
-        }
-
-        div#content {
-            margin: 0 25%;
-            padding-right: 25px;
-        }
-
-        div#content div {
-            padding: 10px 0 10px 0;
-        }
-
-        div#navigation {
-            float: left;
-            width: 20%;
-            margin-left: -100%;
-        }
-
-        div#extra {
-            float: left;
-            width: 25%;
-            margin-left: -25%;
-        }
-
         div#footer {
             clear: left;
             width: 100%;
+            color: #5F6871;
+            background-color: #F8F8F8;;
+            position: fixed;
+            left: 0;
+            bottom: 0;
+            text-align: center;
+        }
+        div#footer p {
+            padding: 10px 10px;
         }
 
-        .center {
-            display: block;
-            margin-left: auto;
-            margin-right: auto;
+        .section {
+            margin: 0.75em;
         }
 
         .overlay {
@@ -206,23 +158,75 @@
     <div id="header">
         <h1>Machine Common Sense</h1>
     </div>
-    <div id="wrapper">
-        <div id="content">
+    <div id="content-wrapper">
+        <div id="scene_nav_info" class="section">
+            <p><strong>Scenes</strong></p>
+            <p>Pick from one of the following scenes:</p>
+            <select id="scenes_dropdown">
+                {% for scene in scene_list %}
+                    <option>{{ scene }}</option>
+                {% endfor %}
+            </select>
+    
+            <p><strong>Scene Info:</strong></p>
+            <div id="goal_cat_div">
+                <span>Goal Category: </span>
+                <span id="goal_cat">N/A</span>
+            </div>
+            <div id="goal_desc_div">
+                <span>Goal Description: </span>
+                <span id="goal_desc">N/A</span>
+            </div>
+            <div id="step_number_div">
+                <span>Step: </span>
+                <span id="step_number">N/A</span>
+            </div>
+            <div id="goal_last_step_div">
+                <span>Max Steps: </span>
+                <span id="goal_last_step">N/A</span>
+            </div>
+            <div id="last_action_div">
+                <span>Last Action Attempted: </span>
+                <span id="last_action">N/A</span>
+            </div>
+            <div id="return_status_div">
+                <span>Return Status: </span>
+                <span id="return_status">N/A</span>
+            </div>
+            <div id="error_div">
+                <span>Error: </span>
+                <span id="error">N/A</span>
+            </div>
+            <div id="reward_div">
+                <span>Reward: </span>
+                <span id="reward">N/A</span>
+            </div>
+            <div id="steps_on_lava_div">
+                <span>Steps On Lava: </span>
+                <span id="steps_on_lava">N/A</span>
+            </div>
+            <div id="action_list_div">
+                <span>Actions Available: </span>
+                <span id="action_list">N/A</span>
+            </div>
+        </div>
+        <div id="scene_demo" class="section">
             <div id="scene_filename_div">
-                <span>Scene: </span>
+                <span><strong>Scene Name: </strong></span>
                 <span id="scene_filename">None</span>
             </div>
             <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image"/>
 
             <div>
-                Action Parameter Input Fields:
+                <strong>Action Parameter Input Fields:</strong>
             </div>
 
             <div>
-            Parameter(s) will be used if applicable for chosen keyboard shortcut, 
-            see <a href="https://nextcenturycorporation.github.io/MCS/api.html#machine_common_sense.Action">Action API</a>
-            for more information on parameters. If any of the inputs are not valid, an error message will be displayed,
-            and your chosen action will not be processed until error(s) are resolved.</div>
+                Parameter(s) will be used if applicable for chosen keyboard shortcut, 
+                see <a href="https://nextcenturycorporation.github.io/MCS/api.html#machine_common_sense.Action">Action API</a>
+                for more information on parameters. If any of the inputs are not valid, an error message will be displayed,
+                and your chosen action will not be processed until error(s) are resolved.
+            </div>
             <div>
                 For image coordinates, the default is the center of the scene image. 
                 Click a point on the Unity image to populate with a different coordinate.
@@ -254,69 +258,21 @@
             <br/>
 
         </div>
-    </div>
-    <div id="navigation">
-        <p><strong>Scenes</strong></p>
-        <p>Pick from one of the following scenes:</p>
-        <select id="scenes_dropdown">
-            {% for scene in scene_list %}
-                <option>{{ scene }}</option>
-            {% endfor %}
-        </select>
-
-        <div id="goal_cat_div">
-            <span>Goal Category: </span>
-            <span id="goal_cat">N/A</span>
-        </div>
-        <div id="goal_desc_div">
-            <span>Goal Description: </span>
-            <span id="goal_desc">N/A</span>
-        </div>
-        <div id="step_number_div">
-            <span>Step: </span>
-            <span id="step_number">N/A</span>
-        </div>
-        <div id="goal_last_step_div">
-            <span>Max Steps: </span>
-            <span id="goal_last_step">N/A</span>
-        </div>
-        <div id="last_action_div">
-            <span>Last Action Attempted: </span>
-            <span id="last_action">N/A</span>
-        </div>
-        <div id="return_status_div">
-            <span>Return Status: </span>
-            <span id="return_status">N/A</span>
-        </div>
-        <div id="error_div">
-            <span>Error: </span>
-            <span id="error">N/A</span>
-        </div>
-        <div id="reward_div">
-            <span>Reward: </span>
-            <span id="reward">N/A</span>
-        </div>
-        <div id="steps_on_lava_div">
-            <span>Steps On Lava: </span>
-            <span id="steps_on_lava">N/A</span>
-        </div>
-        <div id="action_list_div">
-            <span>Actions Available: </span>
-            <span id="action_list">N/A</span>
+        <div id="shortcuts" class="section">
+            <p><strong>Keyboard Shortcuts</strong></p>
+            <p>Below are the keyboard shortcuts. Make sure your mouse is somewhere in the
+                browser window and key strokes will be sent to the environment.</p>
+    
+            <img id="keyboard" width="400" src="static/keyboard.jpg" alt="keyboard" class="center"/>
+    
+            <p>The left part of the keyboard is for <strong>motion</strong>
+                so that 'a' and 'd' make the agent move left or right without rotating.
+                To <strong>rotate</strong> left and right, use 'j' and 'l' (lower case 'L') </p>
         </div>
     </div>
-    <div id="extra">
-        <p><strong>Keyboard Shortcuts</strong></p>
-        <p>Below are the keyboard shortcuts. Make sure your mouse is somewhere in the
-            browser window and key strokes will be sent to the environment.</p>
 
-        <img id="keyboard" width="400" src="static/keyboard.jpg" alt="keyboard" class="center"/>
-
-        <p>The left part of the keyboard is for <strong>motion</strong>
-            so that 'a' and 'd' make the agent move left or right without rotating.
-            To <strong>rotate</strong> left and right, use 'j' and 'l' (lower case 'L') </p>
-    </div>
-    <div id="footer"><p>Footer</p>
+    <div id="footer">
+        <p>This research was developed with funding from the Defense Advanced Research Projects Agency (DARPA). The views, opinions and/or findings expressed are those of the author and should not be interpreted as representing the official views or policies of the Department of Defense or the U.S. Government.<br/> <a href="https://www.darpa.mil/program/machine-common-sense" target="_blank">DARPA's Machine Common Sense (MCS) Program Page</a></p>
     </div>
 </div>
 <script src="https://unpkg.com/whatwg-fetch@2.0.4/fetch.js"></script>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -7,8 +7,8 @@
         html, body {
             margin: 0;
             padding: 0;
-            background-color: #F8F8F8;
-            height: 100%;
+            /*background-color: #F8F8F8;*/
+            background-color: #5F6871;
         }
         #container {
             display: flex;
@@ -35,10 +35,22 @@
             font-family: Arial, Helvetica, Verdana, sans-serif;
             font-size: 14pt;
             font-weight: 300;
+            min-height: 100vh;
         }
 
         div#scene-nav-info {
-            flex: 1
+            flex: 1;
+        }
+
+        .section {
+            margin: 0.75em;
+            background-color: #FFFFFF;
+            padding-left: 5px;
+            padding-right: 5px;
+            border-top-left-radius: 10px;
+            border-top-right-radius: 10px;
+            border-bottom-left-radius: 10px;
+            border-bottom-right-radius: 10px;
         }
 
         .section > div {
@@ -53,7 +65,6 @@
             padding: 0 10px 0;
         }
 
-
         #scenes-dropdown {
             max-width: 300px;
             margin: 5px 5px 10px 10px;
@@ -67,7 +78,7 @@
             height: 100%;
             width: 0;
             position: fixed;
-            z-index: 1;
+            z-index: -10;
             top: 0;
             right: 0;
             background-color: #F8F8F8;
@@ -114,21 +125,18 @@
         #scene-demo {
             transition: margin-left 0.5s;
             padding: 16px;
+            margin-right: 10px;
         }
 
-        div#footer {
-            margin-top:auto;
+        #footer {
+            margin-top: auto;
             z-index: 2;
         }
 
-        div#footer p {
+        #footer p {
             padding: 10px 10px;
             text-align: center;
             font-size: 12pt;
-        }
-
-        .section {
-            margin: 0.75em;
         }
 
         .overlay {
@@ -702,14 +710,16 @@
     }
 
     function showShortcutInfo() {
-      document.getElementById("shortcuts").style.width = "30%";
-      document.getElementById("scene-demo").style.marginRight = "30%";
+        document.getElementById("shortcuts").style.width = "30%";
+        document.getElementById("shortcuts").style["z-index"] = "1";
+        document.getElementById("scene-demo").style.marginRight = "30%";
     }
 
-   function hideShortcutInfo() {
-      document.getElementById("shortcuts").style.width = "0";
-      document.getElementById("scene-demo").style.marginRight = "0";
-   }
+    function hideShortcutInfo() {
+        document.getElementById("shortcuts").style.width = "0";
+        document.getElementById("shortcuts").style["z-index"] = "-10";
+        document.getElementById("scene-demo").style.marginRight = "10px";
+    }
 
 
 </script>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -465,7 +465,7 @@
             let returnStatus = document.getElementById('return-status');
             returnStatus.innerHTML = data.step_output.return_status;
         } else {
-            console.warn("return-status-div not in step_output");
+            console.warn("return_status not in step_output");
         }
 
         if("last_action" in data) {

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -32,8 +32,8 @@
         
         body {
             color: #292929;
-            font-family: Arial, Verdana, sans-serif;
-            font-size: 16px;
+            font-family: Arial, Helvetica, Verdana, sans-serif;
+            font-size: 14pt;
             font-weight: 300;
         }
 
@@ -63,13 +63,68 @@
             cursor: pointer;
         }
 
+        #shortcuts {
+            height: 100%;
+            width: 0;
+            position: fixed;
+            z-index: 1;
+            top: 0;
+            right: 0;
+            background-color: #F8F8F8;
+            overflow-x: hidden;
+            transition: 0.5s;
+            margin-top: 90px;
+        }
+
+        #shortcuts .closebtn {
+            position: absolute;
+            top: 0;
+            right: 25px;
+            font-size: 36px;
+            margin-left: 50px;
+        }
+
+        #shortcuts a {
+            padding: 8px 8px 8px 32px;
+            text-decoration: none;
+            font-size: 25px;
+            color: #5F6871;
+            display: block;
+            transition: 0.3s;
+        }
+
+        #shortcuts a:hover {
+            color: #a3a8ad;
+        }
+
+        .openbtn {
+            font-size: 20px;
+            /* background-color: #007bff */
+            background-color: #59C3C3;
+            cursor: pointer;
+            padding: 10px 15px;
+            border: none;
+        }
+
+        .openbtn:hover {
+            color: #F8F8F8;
+            background-color: #047471;
+        }
+
+        #scene_demo {
+            transition: margin-left 0.5s;
+            padding: 16px;
+        }
+
         div#footer {
-            margin-top:auto
+            margin-top:auto;
+            z-index: 2;
         }
 
         div#footer p {
             padding: 10px 10px;
             text-align: center;
+            font-size: 12pt;
         }
 
         .section {
@@ -107,7 +162,7 @@
             display: inline-block;
             animation: spin 2s infinite linear;
             border: 16px solid #f3f3f3;
-            border-top: 16px solid #59C3C3;
+            border-top: 16px solid #07BEB8;
             border-radius: 50%;
         }
 
@@ -213,6 +268,9 @@
             <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image"/>
 
             <div>
+                <button class="openbtn" id="openbtn" onclick="showShortcutInfo()">Help/Keyboard Shortcuts</button>
+            </div>
+            <div>
                 <strong>Action Parameter Input Fields:</strong>
             </div>
 
@@ -254,6 +312,7 @@
 
         </div>
         <div id="shortcuts" class="section">
+            <a href="javascript:void(0)" class="closebtn" onclick="hideShortcutInfo()">×</a>
             <p><strong>Keyboard Shortcuts</strong></p>
             <p>Below are the keyboard shortcuts. Make sure your mouse is somewhere in the
                 browser window and key strokes will be sent to the environment.</p>
@@ -641,6 +700,16 @@
         imgref.src = data.image;
         return data;
     }
+
+    function showShortcutInfo() {
+      document.getElementById("shortcuts").style.width = "30%";
+      document.getElementById("scene_demo").style.marginRight = "30%";
+    }
+
+   function hideShortcutInfo() {
+      document.getElementById("shortcuts").style.width = "0";
+      document.getElementById("scene_demo").style.marginRight = "0";
+   }
 
 
 </script>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -40,6 +40,7 @@
         div#scene-nav-info {
             flex: 1;
             min-width: 400px;
+            margin-bottom: 10px
         }
 
         .section {
@@ -182,12 +183,12 @@
             color: red;
         }
 
-        #img-and-outputs {
+        .row {
             display: flex;
             flex-direction: row;
         }
 
-        .output-col {
+        .column {
             display: flex;
             flex-direction: column;
         }
@@ -197,7 +198,7 @@
             margin-right: 5px;
         }
 
-        .output-col > div {
+        .output-info > div {
             padding-top: 10px;
             padding-bottom: 10px;
         }
@@ -225,14 +226,27 @@
         <h1>Machine Common Sense</h1>
     </div>
     <div id="content-wrapper">
-        <div id="scene-nav-info" class="section">
-            <p><strong>Scenes</strong>
-            <p>Pick from one of the following scenes:</p>
-            <select id="scenes-dropdown" size="15">
-                {% for scene in scene_list %}
-                    <option>{{ scene }}</option>
-                {% endfor %}
-            </select>
+        <div class="column">
+            <div id="scene-nav-info" class="section">
+                <p><strong>Scenes</strong>
+                <p>Pick from one of the following scenes:</p>
+                <select id="scenes-dropdown" size="15">
+                    {% for scene in scene_list %}
+                        <option>{{ scene }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div id="shortcuts" class="section">
+                <p><strong>Keyboard Shortcuts</strong></p>
+                <p>Below are the keyboard shortcuts. Make sure your mouse is somewhere in the
+                    browser window and key strokes will be sent to the environment.</p>
+        
+                <img id="keyboard" width="400" src="static/keyboard.jpg" alt="keyboard" class="center"/>
+        
+                <p>The left part of the keyboard is for <strong>motion</strong>
+                    so that 'a' and 'd' make the agent move left or right without rotating.
+                    To <strong>rotate</strong> left and right, use 'j' and 'l' (lower case 'L') </p>
+            </div>
         </div>
         <div id="scene-demo" class="section">
             <div id="scene-name-div">
@@ -252,11 +266,11 @@
                 <span><strong>Actions Available: </strong></span>
                 <span id="action-list">N/A</span>
             </div>
-            <div id="img-and-outputs">
-                <div class="output-col">
+            <div class="row">
+                <div class="column">
                     <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="current step image"/>
                 </div>
-                <div class="output-col output-info">
+                <div class="column output-info">
                     <div><strong>Outputs</strong></div>
                     <div id="step-number-div">
                         <span>Step: </span>
@@ -329,18 +343,8 @@
 
             <br/>
 
-        </div>
-        <div id="shortcuts" class="section">
-            <p><strong>Keyboard Shortcuts</strong></p>
-            <p>Below are the keyboard shortcuts. Make sure your mouse is somewhere in the
-                browser window and key strokes will be sent to the environment.</p>
-    
-            <img id="keyboard" width="400" src="static/keyboard.jpg" alt="keyboard" class="center"/>
-    
-            <p>The left part of the keyboard is for <strong>motion</strong>
-                so that 'a' and 'd' make the agent move left or right without rotating.
-                To <strong>rotate</strong> left and right, use 'j' and 'l' (lower case 'L') </p>
-        </div>
+        </div>  
+
     </div>
 
     <div id="footer">

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -102,6 +102,10 @@
             padding-right: 25px;
         }
 
+        div#content div {
+            padding: 10px 0 10px 0;
+        }
+
         div#navigation {
             float: left;
             width: 20%;
@@ -204,60 +208,50 @@
     </div>
     <div id="wrapper">
         <div id="content">
-            <p><div id="scene_filename_div">
+            <div id="scene_filename_div">
                 <span>Scene: </span>
                 <span id="scene_filename">None</span>
-            </div></p>
+            </div>
             <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image"/>
 
-            <p>
-                <div>
-                    Action Parameter Input Fields:
-                </div>
-            </p>
-            <p>
-                <div>
+            <div>
+                Action Parameter Input Fields:
+            </div>
+
+            <div>
             Parameter(s) will be used if applicable for chosen keyboard shortcut, 
             see <a href="https://nextcenturycorporation.github.io/MCS/api.html#machine_common_sense.Action">Action API</a>
             for more information on parameters. If any of the inputs are not valid, an error message will be displayed,
             and your chosen action will not be processed until error(s) are resolved.</div>
-            </p>
-            <p>
-                <div>
-                    For image coordinates, the default is the center of the scene image. 
-                    Click a point on the Unity image to populate with a different coordinate.
-                </div>
-            </p>
-            <p><div id="image_coords_div">
+            <div>
+                For image coordinates, the default is the center of the scene image. 
+                Click a point on the Unity image to populate with a different coordinate.
+            </div>
+            <div id="image_coords_div">
                 <span>Image Coordinates: (
                     x: <span id="image_coord_x">300</span>,
                     y: <span id="image_coord_y">200</span>
                 )</span></div>
-            </p>
-            <p>
-                <div class="input_fields">
-                    <div>Amount: 
-                        <input type="number" min="0" max="1" step="0.1" value="1" id="amount"/>
-                    </div>
-                    <div>Force: 
-                        <input type="number" min="-1" max="1" step="0.1" value="0.5" id="force"/>
-                    </div>
-                    <div>Clockwise: 
-                        <input type="checkbox" id="clockwise" checked>
-                    </div>
-                    <div>Lateral: 
-                        <input type="number" min="-1" max="1" step="1" value="0" id="lateral"/>
-                    </div>
-                    <div>Straight: 
-                        <input type="number" min="-1" max="1" step="1" value="1" id="straight"/>
-                    </div>
+            <div class="input_fields">
+                <div>Amount: 
+                    <input type="number" min="0" max="1" step="0.1" value="1" id="amount"/>
                 </div>
-            </p>
+                <div>Force: 
+                    <input type="number" min="-1" max="1" step="0.1" value="0.5" id="force"/>
+                </div>
+                <div>Clockwise: 
+                    <input type="checkbox" id="clockwise" checked>
+                </div>
+                <div>Lateral: 
+                    <input type="number" min="-1" max="1" step="1" value="0" id="lateral"/>
+                </div>
+                <div>Straight: 
+                    <input type="number" min="-1" max="1" step="1" value="1" id="straight"/>
+                </div>
+            </div>
             <span id="validation_errors"></span>
-            <p></p>
 
             <br/>
-            <p></p>
 
         </div>
     </div>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -181,53 +181,51 @@
                     <option>{{ scene }}</option>
                 {% endfor %}
             </select>
-    
-            <p><strong>Scene Info:</strong></p>
             <div id="goal_cat_div">
-                <span>Goal Category: </span>
+                <span><strong>Goal Category: </strong></span>
                 <span id="goal_cat">N/A</span>
             </div>
             <div id="goal_desc_div">
-                <span>Goal Description: </span>
+                <span><strong>Goal Description: </strong></span>
                 <span id="goal_desc">N/A</span>
-            </div>
-            <div id="step_number_div">
-                <span>Step: </span>
-                <span id="step_number">N/A</span>
-            </div>
-            <div id="goal_last_step_div">
-                <span>Max Steps: </span>
-                <span id="goal_last_step">N/A</span>
-            </div>
-            <div id="last_action_div">
-                <span>Last Action Attempted: </span>
-                <span id="last_action">N/A</span>
-            </div>
-            <div id="return_status_div">
-                <span>Return Status: </span>
-                <span id="return_status">N/A</span>
-            </div>
-            <div id="error_div">
-                <span>Error: </span>
-                <span id="error">N/A</span>
-            </div>
-            <div id="reward_div">
-                <span>Reward: </span>
-                <span id="reward">N/A</span>
-            </div>
-            <div id="steps_on_lava_div">
-                <span>Steps On Lava: </span>
-                <span id="steps_on_lava">N/A</span>
-            </div>
-            <div id="action_list_div">
-                <span>Actions Available: </span>
-                <span id="action_list">N/A</span>
             </div>
         </div>
         <div id="scene-demo" class="section">
             <div id="scene_filename_div">
                 <span><strong>Scene Name: </strong></span>
                 <span id="scene_filename">None</span>
+            </div>
+            <div id="step_number_div">
+                <span><strong>Step: </strong></span>
+                <span id="step_number">N/A</span>
+            </div>
+            <div id="goal_last_step_div">
+                <span><strong>Max Steps:</strong></span>
+                <span id="goal_last_step">N/A</span>
+            </div>
+            <div id="last_action_div">
+                <span><strong>Last Action Attempted: </strong></span>
+                <span id="last_action">N/A</span>
+            </div>
+            <div id="return_status_div">
+                <span><strong>Return Status: </strong></span>
+                <span id="return_status">N/A</span>
+            </div>
+            <div id="error_div">
+                <span><strong>Error: </strong></span>
+                <span id="error">N/A</span>
+            </div>
+            <div id="reward_div">
+                <span><strong>Reward: </strong></span>
+                <span id="reward">N/A</span>
+            </div>
+            <div id="steps_on_lava_div">
+                <span><strong>Steps On Lava: </strong></span>
+                <span id="steps_on_lava">N/A</span>
+            </div>
+            <div id="action_list_div">
+                <span><strong>Actions Available: </strong></span>
+                <span id="action_list">N/A</span>
             </div>
             <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image"/>
 

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -163,19 +163,19 @@
             height: 16px;
         }
 
-        .input_fields {
+        .input-fields {
             display: flex;
             justify-content: space-between;
         }
 
-        #validation_errors {
+        #validation-errors {
             display: block;
             color: red;
             font-size: 80%;
             min-height: 18px;
         }
 
-        #error_div {
+        #error-div {
             display: none;
             color: red;
         }
@@ -200,7 +200,7 @@
             padding-bottom: 10px;
         }
 
-        #scene_name_div {
+        #scene-name-div {
             margin-top: 1em;
             padding-top: 0px;
         }
@@ -233,22 +233,22 @@
             </select>
         </div>
         <div id="scene-demo" class="section">
-            <div id="scene_name_div">
+            <div id="scene-name-div">
                 <span><strong>Scene Name: </strong></span>
-                <span id="scene_filename">None</span>
+                <span id="scene-filename">None</span>
             </div>
-            <div id="goal_cat_div">
+            <div id="goal-cat-div">
                 <span><strong>Goal Category: </strong></span>
-                <span id="goal_cat">N/A</span>
+                <span id="goal-cat">N/A</span>
             </div>
-            <div id="goal_desc_div">
+            <div id="goal-desc-div">
                 <span><strong>Goal Description: </strong></span>
-                <span id="goal_desc">N/A</span>
+                <span id="goal-desc">N/A</span>
             </div>
 
-            <div id="action_list_div">
+            <div id="action-list-div">
                 <span><strong>Actions Available: </strong></span>
-                <span id="action_list">N/A</span>
+                <span id="action-list">N/A</span>
             </div>
             <div id="img-and-outputs">
                 <div class="output-col">
@@ -256,33 +256,33 @@
                 </div>
                 <div class="output-col output-info">
                     <div><strong>Outputs</strong></div>
-                    <div id="step_number_div">
+                    <div id="step-number-div">
                         <span>Step: </span>
-                        <span id="step_number">N/A</span>
+                        <span id="step-number">N/A</span>
                     </div>
-                    <div id="goal_last_step_div">
+                    <div id="goal-last-step-div">
                         <span>Max Steps:</span>
-                        <span id="goal_last_step">N/A</span>
+                        <span id="goal-last-step">N/A</span>
                     </div>
-                    <div id="last_action_div">
+                    <div id="last-action-div">
                         <span>Last Action Attempted: </span>
-                        <span id="last_action">N/A</span>
+                        <span id="last-action">N/A</span>
                     </div>
-                    <div id="return_status_div">
+                    <div id="return-status-div">
                         <span>Return Status: </span>
-                        <span id="return_status">N/A</span>
+                        <span id="return-status">N/A</span>
                     </div>
-                    <div id="error_div">
+                    <div id="error-div">
                         <span>Error: </span>
                         <span id="error">N/A</span>
                     </div>
-                    <div id="reward_div">
+                    <div id="reward-div">
                         <span>Reward: </span>
                         <span id="reward">N/A</span>
                     </div>
-                    <div id="steps_on_lava_div">
+                    <div id="steps-on-lava-div">
                         <span>Steps On Lava: </span>
-                        <span id="steps_on_lava">N/A</span>
+                        <span id="steps-on-lava">N/A</span>
                     </div>
                 </div>
             </div>
@@ -303,10 +303,10 @@
             </div>
             <div id="image_coords_div">
                 <span>Image Coordinates: (
-                    x: <span id="image_coord_x">300</span>,
-                    y: <span id="image_coord_y">200</span>
+                    x: <span id="image-coord-x">300</span>,
+                    y: <span id="image-coord-y">200</span>
                 )</span></div>
-            <div class="input_fields">
+            <div class="input-fields">
                 <div>Amount: 
                     <input type="number" min="0" max="1" step="0.1" value="1" id="amount"/>
                 </div>
@@ -323,7 +323,7 @@
                     <input type="number" min="-1" max="1" step="1" value="1" id="straight"/>
                 </div>
             </div>
-            <span id="validation_errors"></span>
+            <span id="validation-errors"></span>
 
             <br/>
 
@@ -405,7 +405,7 @@
 
     function updateActionList(data) {
         console.log("actionList is " + data.action_list);
-        var actionList = document.getElementById('action_list');
+        var actionList = document.getElementById('action-list');
         actionList.innerHTML = data.action_list;
         return data;
     }
@@ -415,7 +415,7 @@
         console.log(data.goal);
 
         if("category" in data.goal) {
-            let goalCategory = document.getElementById('goal_cat');
+            let goalCategory = document.getElementById('goal-cat');
             goalCategory.innerHTML = data.goal.category;
         } else {
             console.warn("category not in goalInfo");
@@ -425,11 +425,11 @@
             let hasNoDesc = ["intuitive physics", "passive"].includes(data.goal.category)
 
             if(hasNoDesc) {
-                document.getElementById("goal_desc_div").style.display = "none"
+                document.getElementById("goal-desc-div").style.display = "none"
             } else {
-                document.getElementById("goal_desc_div").style.display = "block"
+                document.getElementById("goal-desc-div").style.display = "block"
 
-                let goalDesc = document.getElementById('goal_desc');
+                let goalDesc = document.getElementById('goal-desc');
                 goalDesc.innerHTML = data.goal.description;
             }
         } else {
@@ -437,7 +437,7 @@
         }
 
         if("last_step" in data.goal) {
-            let lastStep = document.getElementById('goal_last_step');
+            let lastStep = document.getElementById('goal-last-step');
             lastStep.innerHTML = data.goal['last_step'];
         } else {
             console.warn("last_step not in goalInfo");
@@ -451,19 +451,19 @@
         console.log(data.step_output);
 
         let passiveCategories = ["intuitive physics", "passive", "agents"]
-        let isPassive = passiveCategories.includes(document.getElementById('goal_cat').innerHTML)
+        let isPassive = passiveCategories.includes(document.getElementById('goal-cat').innerHTML)
 
         let errorOutput = document.getElementById('error');
 
         if("return_status" in data.step_output) {
-            let returnStatus = document.getElementById('return_status');
+            let returnStatus = document.getElementById('return-status');
             returnStatus.innerHTML = data.step_output.return_status;
         } else {
-            console.warn("return_status not in step_output");
+            console.warn("return-status-div not in step_output");
         }
 
         if("last_action" in data) {
-            let lastAction = document.getElementById('last_action');
+            let lastAction = document.getElementById('last-action');
             lastAction.innerHTML = data.last_action;
         } else {
             console.warn("last_action not in step_output");
@@ -471,26 +471,26 @@
 
         if("error_output" in data.step_output) {
             console.warn("last attempted step resulted in an error");
-            document.getElementById("error_div").style.display = "block"
+            document.getElementById("error-div").style.display = "block"
             errorOutput.innerHTML = data.step_output.error_output.error;
 
             if(data.step_output.error_output.error.includes("[Errno 32] Broken pipe")) {
                 errorOutput.innerHTML += " - the Unity app is likely not running. Restart the Flask app and try again. "
             }
 
-            document.getElementById("return_status_div").style.display = "none"
+            document.getElementById("return-status-div").style.display = "none"
         } else {
             errorOutput.innerHTML = "N/A"
-            document.getElementById("error_div").style.display = "none"
-            document.getElementById("return_status_div").style.display = "block"
+            document.getElementById("error-div").style.display = "none"
+            document.getElementById("return-status-div").style.display = "block"
         }
 
         if(isPassive) {
-            document.getElementById("reward_div").style.display = "none"
-            document.getElementById("steps_on_lava_div").style.display = "none"
+            document.getElementById("reward-div").style.display = "none"
+            document.getElementById("steps-on-lava-div").style.display = "none"
         } else {
-            document.getElementById("reward_div").style.display = "block"
-            document.getElementById("steps_on_lava_div").style.display = "block"
+            document.getElementById("reward-div").style.display = "block"
+            document.getElementById("steps-on-lava-div").style.display = "block"
 
             if("reward" in data.step_output) {
                 let reward = document.getElementById('reward');
@@ -500,7 +500,7 @@
             }
 
             if("steps_on_lava" in data.step_output) {
-                let stepsOnLava = document.getElementById('steps_on_lava');
+                let stepsOnLava = document.getElementById('steps-on-lava');
                 stepsOnLava.innerHTML = data.step_output.steps_on_lava;
             } else {
                 console.warn("steps_on_lava not in step_output");
@@ -512,14 +512,14 @@
 
     function updateSceneFilename(data) {
         console.log("sceneFilename is " + data.scene);
-        var sceneFilename = document.getElementById('scene_filename');
+        var sceneFilename = document.getElementById('scene-filename');
         sceneFilename.innerHTML = data.scene;
         return data;
     }
 
     function updateStepNumber(data) {
         console.log("stepNumber is " + data.step);
-        var stepNumber = document.getElementById('step_number');
+        var stepNumber = document.getElementById('step-number');
         stepNumber.innerHTML = data.step;
         return data;
     }
@@ -563,9 +563,9 @@
             "objectImageCoordsY": yValue
         }
         console.log("Image coords are: (x: " + xValue + ", y: " + yValue+ ")");
-        var imageCoordX = document.getElementById('image_coord_x');
+        var imageCoordX = document.getElementById('image-coord-x');
         imageCoordX.innerHTML = xValue;
-        var imageCoordY = document.getElementById('image_coord_y');
+        var imageCoordY = document.getElementById('image-coord-y');
         imageCoordY.innerHTML = yValue;
         return params;
     }
@@ -576,8 +576,8 @@
             "objectImageCoordsX": 300,
             "objectImageCoordsY": 200
         }
-        document.getElementById('image_coord_x').innerHTML = 300
-        document.getElementById('image_coord_y').innerHTML = 200
+        document.getElementById('image-coord-x').innerHTML = 300
+        document.getElementById('image-coord-y').innerHTML = 200
 
         return data;
     }
@@ -585,7 +585,7 @@
     // If the applicable action is triggered, checks any related input
     // fields to ensure the values make sense.
     function passesValidation(actionKey) {
-        let errorMsg = document.getElementById("validation_errors")
+        let errorMsg = document.getElementById("validation-errors")
 
         let amountVal = document.getElementById("amount").value
         if(['1', '2'].includes(actionKey) && (amountVal > 1 || amountVal < 0)) {

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -178,6 +178,20 @@
             display: none;
             color: red;
         }
+
+        #outputs {
+            display: flex;
+            flex-direction: row;
+        }
+
+        .output-col {
+            width: 50%;
+        }
+
+        .output-col > div {
+            padding-top: 10px;
+            padding-bottom: 10px;
+        }
     </style>
 </head>
 
@@ -193,19 +207,19 @@
     </div>
     <div id="content-wrapper">
         <div id="scene-nav-info" class="section">
-            <p><strong>Scenes</strong></p>
+            <p><strong>Scenes</strong>
             <p>Pick from one of the following scenes:</p>
-            <select id="scenes-dropdown" size="40">
+            <select id="scenes-dropdown" size="15">
                 {% for scene in scene_list %}
                     <option>{{ scene }}</option>
                 {% endfor %}
             </select>
         </div>
         <div id="scene-demo" class="section">
-            <div id="scene_filename_div">
+            <p>
                 <span><strong>Scene Name: </strong></span>
                 <span id="scene_filename">None</span>
-            </div>
+            </p>
             <div id="goal_cat_div">
                 <span><strong>Goal Category: </strong></span>
                 <span id="goal_cat">N/A</span>
@@ -214,33 +228,39 @@
                 <span><strong>Goal Description: </strong></span>
                 <span id="goal_desc">N/A</span>
             </div>
-            <div id="step_number_div">
-                <span><strong>Step: </strong></span>
-                <span id="step_number">N/A</span>
-            </div>
-            <div id="goal_last_step_div">
-                <span><strong>Max Steps:</strong></span>
-                <span id="goal_last_step">N/A</span>
-            </div>
-            <div id="last_action_div">
-                <span><strong>Last Action Attempted: </strong></span>
-                <span id="last_action">N/A</span>
-            </div>
-            <div id="return_status_div">
-                <span><strong>Return Status: </strong></span>
-                <span id="return_status">N/A</span>
-            </div>
-            <div id="error_div">
-                <span><strong>Error: </strong></span>
-                <span id="error">N/A</span>
-            </div>
-            <div id="reward_div">
-                <span><strong>Reward: </strong></span>
-                <span id="reward">N/A</span>
-            </div>
-            <div id="steps_on_lava_div">
-                <span><strong>Steps On Lava: </strong></span>
-                <span id="steps_on_lava">N/A</span>
+            <div id="outputs">
+                <div class="output-col">
+                    <div id="step_number_div">
+                        <span><strong>Step: </strong></span>
+                        <span id="step_number">N/A</span>
+                    </div>
+                    <div id="goal_last_step_div">
+                        <span><strong>Max Steps:</strong></span>
+                        <span id="goal_last_step">N/A</span>
+                    </div>
+                    <div id="last_action_div">
+                        <span><strong>Last Action Attempted: </strong></span>
+                        <span id="last_action">N/A</span>
+                    </div>
+                </div>
+                <div class="output-col">
+                    <div id="return_status_div">
+                        <span><strong>Return Status: </strong></span>
+                        <span id="return_status">N/A</span>
+                    </div>
+                    <div id="error_div">
+                        <span><strong>Error: </strong></span>
+                        <span id="error">N/A</span>
+                    </div>
+                    <div id="reward_div">
+                        <span><strong>Reward: </strong></span>
+                        <span id="reward">N/A</span>
+                    </div>
+                    <div id="steps_on_lava_div">
+                        <span><strong>Steps On Lava: </strong></span>
+                        <span id="steps_on_lava">N/A</span>
+                    </div>
+                </div>
             </div>
             <div id="action_list_div">
                 <span><strong>Actions Available: </strong></span>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -30,7 +30,12 @@
             overflow-y: scroll;
         }
 
-        #scenes_unordered_list:hover {
+        #scenes_dropdown {
+            max-width: 300px;
+            margin: 5px 5px 10px 10px;
+        }
+
+        #scenes_dropdown:hover {
             cursor: pointer;
         }
 
@@ -295,12 +300,11 @@
     <div id="navigation">
         <p><strong>Scenes</strong></p>
         <p>Pick from one of the following scenes:</p>
-        <ul id="scenes_unordered_list">
+        <select id="scenes_dropdown">
             {% for scene in scene_list %}
-                <li>{{ scene }}</li>
+                <option>{{ scene }}</option>
             {% endfor %}
-        </ul>
-
+        </select>
     </div>
     <div id="extra">
         <p><strong>Keyboard Shortcuts</strong></p>
@@ -316,12 +320,11 @@
     <div id="footer"><p>Footer</p>
     </div>
 </div>
-<script type="text/javascript">AddFillerLink("content", "navigation", "extra")</script>
 <script src="https://unpkg.com/whatwg-fetch@2.0.4/fetch.js"></script>
 <script>
     // ---------------------------------------------------------
     // Handle clicking on one of the scene file names
-    var lis = document.getElementById("scenes_unordered_list").getElementsByTagName('li');
+    var sceneSelect = document.getElementById("scenes_dropdown");
     let actionKeysWithParams = ['1', '3', '4', '5', '6', '7', '8', '9', 'm', 'M', 't', 'T']
     let arrowKeys = ["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight"]
     var processingKeypress = false
@@ -334,16 +337,11 @@
     loadingSpinner(false)
     loadController()
 
-    for (var i = 0; i < lis.length; i++) {
-        lis[i].addEventListener('click', select_scene, false);
-    }
+    sceneSelect.addEventListener('change', select_scene, false);
 
     function eventHandleScenes() {
-        lis = document.getElementById("scenes_unordered_list").getElementsByTagName('li');
-        for (var i = 0; i < lis.length; i++) {
-            lis[i].addEventListener('click', select_scene, false);
-        }
-
+        sceneSelect = document.getElementById("scenes_dropdown");
+        sceneSelect.addEventListener('change', select_scene, false);
     }
 
     function loadController() {
@@ -359,14 +357,9 @@
     }
 
     function select_scene() {
-        if(this.innerHTML == document.getElementById('scene_filename').innerHTML &&
-            document.getElementById('step_number').innerHTML == "0") {
-            console.log("Clicked scene is already selected and initialized. Returning...")
-            return;
-        }
         loadingSpinner(true)
         resp = fetch("{{url_for('handle_scene_selection')}}",
-            {method: 'POST', body: JSON.stringify(this.innerHTML)})
+            {method: 'POST', body: JSON.stringify(sceneSelect.value)})
             .then(parseJsonResponse)
             .then(updateSceneFilename)
             .then(updateStepNumber)
@@ -510,10 +503,10 @@
         var scenesString = ''
 
         data.scene_list.forEach(scene => {
-            scenesString = scenesString.concat('<li>' + scene + '</li>')
+            scenesString = scenesString.concat('<option value=\"' + scene + '\">' + scene + '</option>')
         });
 
-        var scenesList = document.getElementById('scenes_unordered_list');
+        var scenesList = document.getElementById('scenes_dropdown');
         scenesList.innerHTML = scenesString;
         eventHandleScenes()
 

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -68,10 +68,15 @@
 
         div#navigation {
             background: #7fa0a9;
+            padding-bottom: 20px;
         }
 
         div#navigation li {
             list-style: none;
+        }
+
+        div#navigation div {
+            padding: 10px;
         }
 
         div#extra {
@@ -195,7 +200,7 @@
         </div>
     </div>
     <div id="header">
-        <h1>MCS Demo</h1>
+        <h1>Machine Common Sense</h1>
     </div>
     <div id="wrapper">
         <div id="content">
@@ -203,19 +208,8 @@
                 <span>Scene: </span>
                 <span id="scene_filename">None</span>
             </div></p>
-            <p><div id="action_list_div">
-                <span>Actions Available: </span>
-                <span id="action_list">N/A</span>
-            </div></p>
-            <p><div id="goal_cat_div">
-                <span>Goal Category: </span>
-                <span id="goal_cat">N/A</span>
-            </div></p>
-            <p><div id="goal_desc_div">
-                <span>Goal Description: </span>
-                <span id="goal_desc">N/A</span>
-            </div></p>
-            <hr/>
+            <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image"/>
+
             <p>
                 <div>
                     Action Parameter Input Fields:
@@ -261,36 +255,6 @@
             </p>
             <span id="validation_errors"></span>
             <p></p>
-            <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image" class="center"/>
-
-            <p><div id="step_number_div">
-                <span>Step: </span>
-                <span id="step_number">N/A</span>
-            </div></p>
-            <p><div id="goal_last_step_div">
-                <span>Max Steps: </span>
-                <span id="goal_last_step">N/A</span>
-            </div></p>
-            <p><div id="last_action_div">
-                <span>Last Action Attempted: </span>
-                <span id="last_action">N/A</span>
-            </div></p>
-            <p><div id="return_status_div">
-                <span>Return Status: </span>
-                <span id="return_status">N/A</span>
-            </div></p>
-            <p><div id="error_div">
-                <span>Error: </span>
-                <span id="error">N/A</span>
-            </div></p>
-            <p><div id="reward_div">
-                <span>Reward: </span>
-                <span id="reward">N/A</span>
-            </div></p>
-            <p><div id="steps_on_lava_div">
-                <span>Steps On Lava: </span>
-                <span id="steps_on_lava">N/A</span>
-            </div></p>
 
             <br/>
             <p></p>
@@ -305,6 +269,47 @@
                 <option>{{ scene }}</option>
             {% endfor %}
         </select>
+
+        <div id="goal_cat_div">
+            <span>Goal Category: </span>
+            <span id="goal_cat">N/A</span>
+        </div>
+        <div id="goal_desc_div">
+            <span>Goal Description: </span>
+            <span id="goal_desc">N/A</span>
+        </div>
+        <div id="step_number_div">
+            <span>Step: </span>
+            <span id="step_number">N/A</span>
+        </div>
+        <div id="goal_last_step_div">
+            <span>Max Steps: </span>
+            <span id="goal_last_step">N/A</span>
+        </div>
+        <div id="last_action_div">
+            <span>Last Action Attempted: </span>
+            <span id="last_action">N/A</span>
+        </div>
+        <div id="return_status_div">
+            <span>Return Status: </span>
+            <span id="return_status">N/A</span>
+        </div>
+        <div id="error_div">
+            <span>Error: </span>
+            <span id="error">N/A</span>
+        </div>
+        <div id="reward_div">
+            <span>Reward: </span>
+            <span id="reward">N/A</span>
+        </div>
+        <div id="steps_on_lava_div">
+            <span>Steps On Lava: </span>
+            <span id="steps_on_lava">N/A</span>
+        </div>
+        <div id="action_list_div">
+            <span>Actions Available: </span>
+            <span id="action_list">N/A</span>
+        </div>
     </div>
     <div id="extra">
         <p><strong>Keyboard Shortcuts</strong></p>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -7,8 +7,7 @@
         html, body {
             margin: 0;
             padding: 0;
-            /*background-color: #F8F8F8;*/
-            background-color: #5F6871;
+            background-color: #e3e7ea;
         }
         #container {
             display: flex;
@@ -40,6 +39,7 @@
 
         div#scene-nav-info {
             flex: 1;
+            min-width: 350px;
         }
 
         .section {
@@ -75,57 +75,13 @@
         }
 
         #shortcuts {
-            height: 100%;
-            width: 0;
-            position: fixed;
-            z-index: -10;
-            top: 0;
-            right: 0;
-            background-color: #F8F8F8;
-            overflow-x: hidden;
-            transition: 0.5s;
-            margin-top: 90px;
+            margin-right: 15px;
         }
 
-        #shortcuts .close-btn {
-            position: absolute;
-            top: 0;
-            right: 25px;
-            font-size: 36px;
-            margin-left: 50px;
-        }
-
-        #shortcuts a {
-            padding: 8px 8px 8px 32px;
-            text-decoration: none;
-            font-size: 25px;
-            color: #5F6871;
+        .center {
             display: block;
-            transition: 0.3s;
-        }
-
-        #shortcuts a:hover {
-            color: #a3a8ad;
-        }
-
-        .open-btn {
-            font-size: 20px;
-            /* background-color: #007bff */
-            background-color: #59C3C3;
-            cursor: pointer;
-            padding: 10px 15px;
-            border: none;
-        }
-
-        .open-btn:hover {
-            color: #F8F8F8;
-            background-color: #047471;
-        }
-
-        #scene-demo {
-            transition: margin-left 0.5s;
-            padding: 16px;
-            margin-right: 10px;
+            margin-left: auto;
+            margin-right: auto;
         }
 
         #footer {
@@ -276,9 +232,6 @@
             <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image"/>
 
             <div>
-                <button class="open-btn" id="open-btn" onclick="showShortcutInfo()">Help/Keyboard Shortcuts</button>
-            </div>
-            <div>
                 <strong>Action Parameter Input Fields:</strong>
             </div>
 
@@ -320,7 +273,6 @@
 
         </div>
         <div id="shortcuts" class="section">
-            <a href="javascript:void(0)" class="close-btn" onclick="hideShortcutInfo()">×</a>
             <p><strong>Keyboard Shortcuts</strong></p>
             <p>Below are the keyboard shortcuts. Make sure your mouse is somewhere in the
                 browser window and key strokes will be sent to the environment.</p>
@@ -708,19 +660,6 @@
         imgref.src = data.image;
         return data;
     }
-
-    function showShortcutInfo() {
-        document.getElementById("shortcuts").style.width = "30%";
-        document.getElementById("shortcuts").style["z-index"] = "1";
-        document.getElementById("scene-demo").style.marginRight = "30%";
-    }
-
-    function hideShortcutInfo() {
-        document.getElementById("shortcuts").style.width = "0";
-        document.getElementById("shortcuts").style["z-index"] = "-10";
-        document.getElementById("scene-demo").style.marginRight = "10px";
-    }
-
 
 </script>
 </body>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -64,17 +64,12 @@
         }
 
         div#footer {
-            clear: left;
-            width: 100%;
-            color: #5F6871;
-            background-color: #F8F8F8;;
-            position: fixed;
-            left: 0;
-            bottom: 0;
-            text-align: center;
+            margin-top:auto
         }
+
         div#footer p {
             padding: 10px 10px;
+            text-align: center;
         }
 
         .section {
@@ -112,7 +107,7 @@
             display: inline-block;
             animation: spin 2s infinite linear;
             border: 16px solid #f3f3f3;
-            border-top: 16px solid #7fa0a9;
+            border-top: 16px solid #59C3C3;
             border-radius: 50%;
         }
 

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -75,6 +75,7 @@
 
         #shortcuts {
             margin-right: 15px;
+            max-width: 450px;
         }
 
         .center {
@@ -185,12 +186,23 @@
         }
 
         .output-col {
-            width: 50%;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .output-info {
+            margin-left: 15px;
+            margin-right: 5px;
         }
 
         .output-col > div {
             padding-top: 10px;
             padding-bottom: 10px;
+        }
+
+        #scene_name_div {
+            margin-top: 1em;
+            padding-top: 0px;
         }
     </style>
 </head>
@@ -216,10 +228,10 @@
             </select>
         </div>
         <div id="scene-demo" class="section">
-            <p>
+            <div id="scene_name_div">
                 <span><strong>Scene Name: </strong></span>
                 <span id="scene_filename">None</span>
-            </p>
+            </div>
             <div id="goal_cat_div">
                 <span><strong>Goal Category: </strong></span>
                 <span id="goal_cat">N/A</span>
@@ -228,45 +240,47 @@
                 <span><strong>Goal Description: </strong></span>
                 <span id="goal_desc">N/A</span>
             </div>
-            <div id="outputs">
-                <div class="output-col">
-                    <div id="step_number_div">
-                        <span><strong>Step: </strong></span>
-                        <span id="step_number">N/A</span>
-                    </div>
-                    <div id="goal_last_step_div">
-                        <span><strong>Max Steps:</strong></span>
-                        <span id="goal_last_step">N/A</span>
-                    </div>
-                    <div id="last_action_div">
-                        <span><strong>Last Action Attempted: </strong></span>
-                        <span id="last_action">N/A</span>
-                    </div>
-                </div>
-                <div class="output-col">
-                    <div id="return_status_div">
-                        <span><strong>Return Status: </strong></span>
-                        <span id="return_status">N/A</span>
-                    </div>
-                    <div id="error_div">
-                        <span><strong>Error: </strong></span>
-                        <span id="error">N/A</span>
-                    </div>
-                    <div id="reward_div">
-                        <span><strong>Reward: </strong></span>
-                        <span id="reward">N/A</span>
-                    </div>
-                    <div id="steps_on_lava_div">
-                        <span><strong>Steps On Lava: </strong></span>
-                        <span id="steps_on_lava">N/A</span>
-                    </div>
-                </div>
-            </div>
+
             <div id="action_list_div">
                 <span><strong>Actions Available: </strong></span>
                 <span id="action_list">N/A</span>
             </div>
-            <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="my image"/>
+            <div id="outputs">
+                <div class="output-col">
+                    <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="current step image"/>
+                </div>
+                <div class="output-col output-info">
+                    <p><strong>Outputs</strong></p>
+                    <div id="step_number_div">
+                        <span>Step: </span>
+                        <span id="step_number">N/A</span>
+                    </div>
+                    <div id="goal_last_step_div">
+                        <span>Max Steps:</span>
+                        <span id="goal_last_step">N/A</span>
+                    </div>
+                    <div id="last_action_div">
+                        <span>Last Action Attempted: </span>
+                        <span id="last_action">N/A</span>
+                    </div>
+                    <div id="return_status_div">
+                        <span>Return Status: </span>
+                        <span id="return_status">N/A</span>
+                    </div>
+                    <div id="error_div">
+                        <span>Error: </span>
+                        <span id="error">N/A</span>
+                    </div>
+                    <div id="reward_div">
+                        <span>Reward: </span>
+                        <span id="reward">N/A</span>
+                    </div>
+                    <div id="steps_on_lava_div">
+                        <span>Steps On Lava: </span>
+                        <span id="steps_on_lava">N/A</span>
+                    </div>
+                </div>
+            </div>
 
             <div>
                 <strong>Action Parameter Input Fields:</strong>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -180,7 +180,7 @@
             color: red;
         }
 
-        #outputs {
+        #img-and-outputs {
             display: flex;
             flex-direction: row;
         }
@@ -203,6 +203,11 @@
         #scene_name_div {
             margin-top: 1em;
             padding-top: 0px;
+        }
+
+        /* override needed for Firefox */
+        strong {
+            font-weight: 700;
         }
     </style>
 </head>
@@ -245,12 +250,12 @@
                 <span><strong>Actions Available: </strong></span>
                 <span id="action_list">N/A</span>
             </div>
-            <div id="outputs">
+            <div id="img-and-outputs">
                 <div class="output-col">
                     <img id="unityimg" width="600" height="400" src="{{ unityimg }}" alt="current step image"/>
                 </div>
                 <div class="output-col output-info">
-                    <p><strong>Outputs</strong></p>
+                    <div><strong>Outputs</strong></div>
                     <div id="step_number_div">
                         <span>Step: </span>
                         <span id="step_number">N/A</span>

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -173,6 +173,8 @@
             color: red;
             font-size: 80%;
             min-height: 18px;
+            margin-left: 10px;
+            margin-right: 10px;
         }
 
         #error-div {


### PR DESCRIPTION
Some notes:
- Ended up making things look similar to the analysis UI website, since we already kind of do that for the home page as well with the similar colors + didn't want to get too whacky with color scheme. 
- Used the footer we use everywhere -- I can always change it to something else. 
- I had originally intended to utilize more space on the left for some of the outputs, but it didn't actually make sense in practice, so I went with Thomas' suggestion on how to order things in the middle. 
- Wanted to find different ways to display the shortcut panel (tried making it a collapsible div but it didn't quite work out right with the new layout). Originally left it more or less the same as it is, but then last minute changed things so that its on the bottom left (thought it'd be nice to save some screen real estate on a smaller monitor, but maybe that doesn't matter so much). Here's how the two different versions look in case anyone has a preference:

<img width="1510" alt="Screenshot 2023-08-14 at 10 57 28 AM" src="https://github.com/NextCenturyCorporation/MCS/assets/7502824/a92d9801-dda3-419f-8d41-6695443514d6">
vs 
<img width="1236" alt="Screenshot 2023-08-14 at 10 50 05 AM" src="https://github.com/NextCenturyCorporation/MCS/assets/7502824/7d9ba1ab-fbfd-4014-a669-b02590271e6c">

- Some of my changes were nitpicks about naming conventions ("some_div" vs "some-div" for instance), so apologies for the diffs!