### PR TITLE
MCS-1925 - [Webenabled] Ignoring non-action keys

### DIFF
--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -360,8 +360,7 @@
     // Handle clicking on one of the scene file names
     var sceneSelect = document.getElementById("scenes-dropdown");
     let actionKeysWithParams = ['1', '3', '4', '5', '6', '7', '8', '9', 'm', 'M', 't', 'T']
-    let allOtherActionKeys = ['2', 'w', 'W', 'a', 'A', 's', 'D', 'h', 'H', 'i', 'I', 'j', 
-    'J', 'k', 'K', 'L', 'l', ' ', 'q', 'Q']
+    let allOtherActionKeys = ['2', 'W', 'A', 'S', 'D', 'H', 'I', 'J', 'K', 'L', ' ', 'Q']
     var processingKeypress = false
     // default screen coordinates are in the center of image
     var params = {
@@ -651,7 +650,12 @@
     window.addEventListener('keydown', this.process_key, false);
 
     function process_key(e) {
-        if((!actionKeysWithParams.includes(e.key)) && (!allOtherActionKeys.includes(e.key))) {
+        // avoid scrolling with spacebar/Pass action
+        if(e.keyCode == 32) {
+            e.preventDefault();
+        }
+
+        if((!actionKeysWithParams.includes(e.key)) && (!allOtherActionKeys.includes(e.key.toUpperCase()))) {
             return;
         }
 

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -660,8 +660,7 @@
             return;
         }
 
-        var sceneFilename = document.getElementById('scene-filename');
-        if (sceneFilename.innerHTML == "None") {
+        if (document.getElementById('scene-filename').innerHTML == "None") {
             alert("Please select a scene before attempting an action.");
             return;
         }

--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -360,7 +360,8 @@
     // Handle clicking on one of the scene file names
     var sceneSelect = document.getElementById("scenes-dropdown");
     let actionKeysWithParams = ['1', '3', '4', '5', '6', '7', '8', '9', 'm', 'M', 't', 'T']
-    let arrowKeys = ["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight"]
+    let allOtherActionKeys = ['2', 'w', 'W', 'a', 'A', 's', 'D', 'h', 'H', 'i', 'I', 'j', 
+    'J', 'k', 'K', 'L', 'l', ' ', 'q', 'Q']
     var processingKeypress = false
     // default screen coordinates are in the center of image
     var params = {
@@ -650,11 +651,18 @@
     window.addEventListener('keydown', this.process_key, false);
 
     function process_key(e) {
-        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || (arrowKeys.includes(e.key))) {
+        if((!actionKeysWithParams.includes(e.key)) && (!allOtherActionKeys.includes(e.key))) {
             return;
         }
+
         if (processingKeypress) {
             console.log('Currently processing keypress, ignoring new input.')
+            return;
+        }
+
+        var sceneFilename = document.getElementById('scene-filename');
+        if (sceneFilename.innerHTML == "None") {
+            alert("Please select a scene before attempting an action.");
             return;
         }
 


### PR DESCRIPTION
Original ticket was to not submit a pass action for function keys -- decided to simply ignore all non-action keys. Also addressed a small bug where you could submit an action before actually choosing a scene. 

Note that this is branched off of MCS-1816-styling. 