### PR TITLE
MCS-1931 - [Webenabled] Remove fetch.js

### DIFF
--- a/webenabled/templates/mcs_page.html
+++ b/webenabled/templates/mcs_page.html
@@ -313,7 +313,6 @@
     </div>
 </div>
 <script type="text/javascript">AddFillerLink("content", "navigation", "extra")</script>
-<script src="https://unpkg.com/whatwg-fetch@2.0.4/fetch.js"></script>
 <script>
     // ---------------------------------------------------------
     // Handle clicking on one of the scene file names


### PR DESCRIPTION
Ended up being a very small PR.

I'll add a comment on this ticket, but originally this was to localize this fetch.js dependency for when we package things up (which is why I branched off of the pyinstaller branch). The fetch.js script is a polyfill for older browsers that don't have the fetch API, but upon further investigation, this fetch.js script (which is also a really old version) would likely not even work correctly without an additional promise polyfill + we've never had to worry about older browsers like IE 7 before anyway, so I figured I'd just go ahead and remove it. 