### PR TITLE
MCS-1908 Added isometric_front_right scene property for Eval 7 NYU tasks.

### DIFF
--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -641,6 +641,7 @@ class SceneConfiguration(BaseModel):
     holes: List[Vector2dInt] = []
     intuitive_physics: bool = False
     isometric: bool = False
+    isometric_front_right: bool = False
     lava: List[Vector2dInt] = []
     name: Optional[str]
     objects: List[SceneObject] = []


### PR DESCRIPTION
See Unity PR: https://github.com/NextCenturyCorporation/ai2thor/pull/341