### PR TITLE
MCS-1393 Make Multiple Consecutive Runs More Deterministic

### DIFF
--- a/integration_tests/data/081.move_into_light_object_intuitive_reset.oracle.outputs.json
+++ b/integration_tests/data/081.move_into_light_object_intuitive_reset.oracle.outputs.json
@@ -323,7 +323,7 @@
             {
                 "direction_x": 0.0,
                 "direction_y": -0.734,
-                "direction_z": 0.69,
+                "direction_z": 0.68,
                 "distance": 0.697,
                 "held": false,
                 "id": "testBall",
@@ -353,7 +353,7 @@
         "objects": [
             {
                 "direction_x": 0.0,
-                "direction_y": -0.72,
+                "direction_y": -0.73,
                 "direction_z": 0.69,
                 "distance": 0.71,
                 "held": false,

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -392,7 +392,7 @@ def start_handmade_tests(
             else:
                 failed_test_list.append((test_name, metadata_tier, status))
 
-    controller.stop_simulation()
+        controller.stop_simulation()
 
     successful_test_list.sort(key=lambda x: x[0])
     failed_test_list.sort(key=lambda x: x[0])

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -238,10 +238,11 @@ class Controller():
 
         ai2thor_step = self.parameter_converter.wrap_step(
             output_folder=self.__output_folder,
-            action='Initialize',
             sceneConfig=sc,
             goal_object_ids=self.__goal_object_ids)
-        step_output = self._controller.step(ai2thor_step)
+        # Must call reset first, which automatically initializes the new scene.
+        self._controller.initialization_parameters = ai2thor_step
+        step_output = self._controller.reset(scene='MCS')
 
         self._output_handler.set_scene_config(scene_config)
         (pre_restrict_output, output) = self._output_handler.handle_output(


### PR DESCRIPTION
Corresponding Unity PR: https://github.com/NextCenturyCorporation/ai2thor/pull/344

Previously, running multiple scenes in a row using the same MCS Controller might yield minor differences in the physics simulation, specifically with the way objects bounce and roll over time.

The solution is to call Reset between each scene, which will now correctly reload the MCS Unity scene from addressables.

You can use the following script for testing (you'll need to modify the `unity_app_file_path` variable, and can play around with the `scene_data` as desired).

```python
import time

import machine_common_sense as mcs


"""
Test if consecutive runs with the same controller perform deterministicly.
"""


scene_data = {
    "name": "consistency_run",
    "version": "2",
    "ceilingMaterial": "AI2-THOR/Materials/Walls/WallDrywallWhite",
    "floorMaterial": "AI2-THOR/Materials/Fabrics/RUG4",
    "wallMaterial": "AI2-THOR/Materials/Walls/YellowDrywall",
    "objects": [{
        "id": "my_object",
        "type": "sphere",
        "mass": 1,
        "materials": ["AI2-THOR/Materials/Plastics/BlueRubber"],
        "physics": True,
        "shows": [{
            "stepBegin": 1,
            "position": {
                "x": -2.5,
                "y": 1,
                "z": 3
            },
            "rotation": {
                "x": 90,
                "y": 0,
                "z": 0
            },
            "scale": {
                "x": 0.5,
                "y": 0.25,
                "z": 0.5
            }
        }],
        "forces": [{
            "impulse": True,
            "stepBegin": 1,
            "stepEnd": 1,
            "vector": {
                "x": 4,
                "y": 2,
                "z": 0
            }
        }]
    }]
}

count = 100
recorded_position = [None] * count
# Modify to use the correct file path for your machine!
unity_app_file_path = '/home/tschellenberg/Development/darpa/ai2thor/unity/MCS-AI2-THOR-Unity-App-v0.7.2.x86_64'

print('=======================================================')
print('Starting consecutive runs with same controller...')

controller = mcs.create_controller(
    unity_app_file_path=unity_app_file_path,
    config_file_or_dict={
        'disable_depth_maps': True,
        'disable_object_masks': True,
        'history_enabled': False,
        'metadata': 'oracle',
        'video_enabled': False
    }
)

for i in range(10):

    print('-------------------------------------------------------')
    controller.start_scene(scene_data)
    successful = True

    for step in range(count):
        step_metadata = controller.step('Pass')
        cylinder = step_metadata.object_list[0]
        position = tuple([round(v, 4) for v in cylinder.position.values()])
        if not recorded_position[step]:
            recorded_position[step] = position
        elif recorded_position[step] != position:
            successful = False
            print(
                f'Mismatch run={i+1} step={step+1}: '
                f'{recorded_position[step]} VS {position}'
            )

    if successful:
        print(f'Consecutive run {i+1} successful')
    controller.end_scene()

controller.stop_simulation()
```