### PR TITLE
MCS-1963 Updates to Support Windows

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -240,7 +240,7 @@ controller_timeout
 
 (int, optional)
 
-Sets the time (in seconds) to allow on controller initialization before timing out. Default 180
+Sets the time (in seconds) to allow on controller initialization before timing out. Default 600
 
 terminal_output
 ^^^^^^^^^^^^^^^

--- a/integration_tests/run_handmade_tests.py
+++ b/integration_tests/run_handmade_tests.py
@@ -392,7 +392,7 @@ def start_handmade_tests(
             else:
                 failed_test_list.append((test_name, metadata_tier, status))
 
-    controller.stop_simulation()
+        controller.stop_simulation()
 
     successful_test_list.sort(key=lambda x: x[0])
     failed_test_list.sort(key=lambda x: x[0])

--- a/machine_common_sense/__init__.py
+++ b/machine_common_sense/__init__.py
@@ -1,3 +1,5 @@
+from . import import_override  # isort: skip
+
 import concurrent.futures
 import json
 import logging

--- a/machine_common_sense/config_manager.py
+++ b/machine_common_sense/config_manager.py
@@ -356,7 +356,7 @@ class ConfigManager:
     TIMEOUT_DEFAULT = 3600
 
     # Default time for initalizing a controller.
-    CONTROLLER_TIMEOUT_DEFAULT = 180
+    CONTROLLER_TIMEOUT_DEFAULT = 600
 
     def __init__(self, config_file_or_dict=None):
         '''

--- a/machine_common_sense/controller.py
+++ b/machine_common_sense/controller.py
@@ -7,12 +7,15 @@ import io
 import json
 import logging
 import os
+import platform
 import threading
 import time
 from typing import Dict, List, Optional, Union
 
 import ai2thor.controller
+import ai2thor.fifo_server
 import ai2thor.server
+import ai2thor.wsgi_server
 import numpy as np
 import typeguard  # can we replace with pydantic function validator?
 
@@ -47,6 +50,16 @@ def __reset_override(self, scene):
 
 
 ai2thor.controller.Controller.reset = __reset_override
+
+
+def __stop_unity_override(self):
+    if self.server and self.server.unity_proc:
+        self.killing_unity = True
+        # Cannot use os.kill on Windows due to permissions, so use Popen.kill.
+        self.server.unity_proc.kill()
+
+
+ai2thor.controller.Controller.stop_unity = __stop_unity_override
 
 
 def __image_depth_override(self, image_depth_data, **kwargs):
@@ -93,6 +106,10 @@ class Controller():
     @typeguard.typechecked
     def __init__(self, unity_app_file_path: str, config: ConfigManager):
 
+        server_class = ai2thor.fifo_server.FifoServer
+        if platform.system() == 'Windows':
+            # Cannot use os.mkfifo on Windows, so use ai2thor's WSGI server.
+            server_class = ai2thor.wsgi_server.WsgiServer
         # Suppress print statements from the AI2-THOR Controller's constructor.
         with contextlib.redirect_stdout(io.StringIO()) as _:
             self._controller = ai2thor.controller.Controller(
@@ -103,6 +120,7 @@ class Controller():
                 width=config.get_screen_width(),
                 height=config.get_screen_height(),
                 scene='MCS',  # Unity scene name
+                server_class=server_class,
                 logs=True,
                 # This constructor always initializes a scene, so add a scene
                 # config to ensure it doesn't error

--- a/machine_common_sense/import_override.py
+++ b/machine_common_sense/import_override.py
@@ -36,7 +36,7 @@ def mock_import(name, *args, **kwargs):
     try:
         real_module = real_import(name, *args, **kwargs)
         return real_module
-    except ImportError as e:
+    except (ImportError, NameError) as e:
         # Return mocks for all modules required by the ai2thor python library
         # but not available on Windows.
         if name == 'fcntl':

--- a/machine_common_sense/import_override.py
+++ b/machine_common_sense/import_override.py
@@ -1,0 +1,51 @@
+import builtins
+from types import ModuleType
+
+import portalocker
+
+
+class MockFcntl(ModuleType):
+    """
+    The fcntl module is not available on Windows; if it's not found, then
+    return this mock module which wraps calls to the portalocker library.
+    The ai2thor python library depends on its "lockf" function and some static
+    variables.
+    """
+
+    LOCK_SH = 1
+    LOCK_EX = 2
+    LOCK_NB = 4
+    LOCK_UN = 8
+
+    def lockf(self, lock_file, lock_mode):
+        if lock_mode == self.LOCK_SH:
+            portalocker.lock(lock_file, portalocker.LockFlags.SHARED)
+        if lock_mode > self.LOCK_SH and lock_mode < self.LOCK_UN:
+            portalocker.lock(lock_file, portalocker.LockFlags.EXCLUSIVE)
+        if lock_mode == self.LOCK_UN:
+            portalocker.unlock(lock_file)
+
+
+class MockModule(ModuleType):
+    def __getattr__(self, key):
+        return None
+    __all__ = []
+
+
+def mock_import(name, *args, **kwargs):
+    try:
+        real_module = real_import(name, *args, **kwargs)
+        return real_module
+    except ImportError as e:
+        # Return mocks for all modules required by the ai2thor python library
+        # but not available on Windows.
+        if name == 'fcntl':
+            return MockFcntl(name)
+        if name in ['termios', 'tty']:
+            return MockModule(name)
+        raise e
+
+
+# Override the built-in import function with mock_import, but save the original
+# import function as real_import.
+real_import, builtins.__import__ = builtins.__import__, mock_import

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ numpyencoder==0.3.0
 opencv-python==4.4.0.46; python_version<="3.9"
 opencv-python==4.5.4.60; python_version>="3.10"
 pep8-naming==0.13.3
+portalocker
 pre-commit==2.21.0; python_version<"3.8"
 pre-commit==3.2.2; python_version>="3.8"
 pydantic==1.10.7

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -191,9 +191,9 @@ class TestConfigManager(unittest.TestCase):
             'oracle')
 
     def test_controller_timeout(self):
-        self.assertEquals(self.config_mngr.get_controller_timeout(), 180)
+        self.assertEqual(self.config_mngr.get_controller_timeout(), 600)
         self.config_mngr.set_controller_timeout(str(90))
-        self.assertEquals(self.config_mngr.get_controller_timeout(), 90)
+        self.assertEqual(self.config_mngr.get_controller_timeout(), 90)
 
     def test_get_size(self):
         self.assertEqual(self.config_mngr.get_size(), 600)

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -249,7 +249,10 @@ class TestVideoRecorder(unittest.TestCase):
 
     def tearDown(self):
         if self.test_video_file.exists():
-            self.test_video_file.unlink()
+            try:
+                self.test_video_file.unlink()
+            except Exception:
+                pass
 
     def test_video_path(self):
         self.assertEqual(self.recorder.path, self.test_video_file)


### PR DESCRIPTION
Corresponding Unity PR: https://github.com/NextCenturyCorporation/ai2thor/pull/345

These changes would make Phi's PR obsolete: https://github.com/NextCenturyCorporation/ai2thor/pull/343

There are some spicy changes here, and I'm happy to discuss the pros and cons further.

I've tested this on both Windows and Linux.

For Windows:
- (On Linux) Build the Unity app for Windows, using the correct Unity feature branch (switching the Target Platform may cause the Unity Editor to think for a while)
- Move the Unity app onto your Windows machine
- (On Windows) Clone the MCS git repo, checkout this feature branch, and setup your virtual environment (install python dependencies, etc.)
- (On Windows) Optionally, run `cache_addressables`
- (On Windows) Try `run_in_human_input_mode` with the `--mcs_unity_build_file` argument
- (On Windows) Try running the integration tests (I built the Windows addressable files locally and uploaded them to S3 myself)
  - NOTE: I got a couple of minor errors while running the integration tests, but I'm not concerned. I'm not sure if I uploaded the most recent versions of the addressable assets, which will be solved by having Jenkins automatically build and deploy the Windows bundles (MCS-1958). Additionally, my recent changes to the way we initialize and run consecutive scenes (https://github.com/NextCenturyCorporation/MCS/pull/700) will also affect the integration test results. Therefore I think we should wait and circle back around to this once all of the mentioned tickets are completed.

For Linux (similar steps will probably also work for Mac):
- Build the Unity app for Linux, using the correct Unity feature branch
- Checkout this feature branch
- In `machine_common_sense/controller.py`, when initializing the `ai2thor.controller.Controller`, temporarily set the `server_class` to `ai2thor.wsgi_server.WsgiServer`
- Try running the app like above