### PR TITLE
MCS-1976 - Fix integration test for windows

### DIFF
--- a/integration_tests/data/107.lava.oracle.outputs.json
+++ b/integration_tests/data/107.lava.oracle.outputs.json
@@ -166,7 +166,7 @@
         ],
         "objects_count": 0,
         "position_x": 0.0,
-        "position_z": 0.5,
+        "position_z": 0.51,
         "return_status": "SUCCESSFUL",
         "reward": -100.005,
         "rotation_y": 0.0,

--- a/integration_tests/data/119.lava_end_scene.oracle.outputs.json
+++ b/integration_tests/data/119.lava_end_scene.oracle.outputs.json
@@ -76,7 +76,7 @@
         "lava": [[-0.5, 0.5, 0.5, 1.5], [0.5, -0.5, 1.5, 0.5]],
         "objects_count": 0,
         "position_x": 0.0,
-        "position_z": 0.5,
+        "position_z": 0.51,
         "return_status": "SUCCESSFUL",
         "reward": -100.005,
         "rotation_y": 0.0,


### PR DESCRIPTION
Updated output for failing test.. Reran integration for both Windows and Linux builds/addressables.   Looks like the int tests are all good (change .5 to .51 which is now passes the math.isclose check).