### PR TITLE
MCS-1990 Trying to get the webenabled downloads to work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setuptools.setup(
         'numpyencoder==0.3.0',
         'opencv-python==4.4.0.46; python_version<="3.9"',
         'opencv-python==4.5.4.60; python_version>="3.10"',
+        'portalocker',
         'pydantic==1.10.7',
         'requests==2.31.0',
         'scikit-image==0.19.3',

--- a/webenabled/README.md
+++ b/webenabled/README.md
@@ -1,6 +1,14 @@
-# Running MCS on the web
+# Machine Common Sense Web Browser Demo
 
-## Install
+This MCS web app lets you run scenes in your web browser, using your keyboard to move around and perform actions like an AI would.
+
+## Usage
+
+TODO
+
+## Development
+
+### Install
 
 First, "git clone" this repository. Then run the following commands from this folder to setup your python environment:
 
@@ -17,12 +25,12 @@ If you are a developer for this software, we recommend you install the machine_c
 python -m pip install -e ../
 ```
 
-## Scene Files
+### Scene Files
 
 Put scene json files into scenes/.   The directory will be scanned and the list of 
 scene files will appear on the web page 
 
-## Run Web Server
+### Run Web Server
 
 First, run `cache_addressables` to cache all addressable assets and prevent possible timeout issues. You should do this each time you reboot your machine.
 
@@ -30,15 +38,15 @@ Then, run `python mcsweb.py` to start the flask server with host `0.0.0.0` (so t
 
 Alternatively, run `python mcsweb.py` to see all of the available options. The `--debug` flag is very helpful for development.
 
-## Use 
-
-On same or other machine, go to:
+Then, on your machine (or another machine on your network), in your web browser, go to:
 
 ```
 http://<machine.ip.address>:8080/mcs
 ```
 
-## Overview
+If accessing on your local machine, you can use `localhost` instead of an IP address.
+
+### Overview
 
 1. Routing is done in `mcsweb`. Loading `localhost:8080/mcs` calls `show_mcs_page`. This uses `request.cookies` to identify new user sessions. A single `MCSInterface` is instantiated for each user session. The page is rendered using `templates/mcs_page.html`.
 2. The `MCSInterface` class creates the `cmd_<time>/` and `output_<time>/` directories in `static/mcsinterface/` for the input and output data for the current user session. It starts a subprocess in a separate thread which runs `run_scene_with_dir.py`. It watches the `output_<time>/` directory for step output and images the subprocess saves in that directory, which are the images returned by action steps.
@@ -46,9 +54,11 @@ http://<machine.ip.address>:8080/mcs
 4. When the user selects a scene in the UI, the `handle_scene_selection` function in `mcsweb` calls `load_scene` in `MCSInterface` which saves a "command" text file containing the scene filename.
 5. When the user presses a key in the UI, the `handle_keypress` function in `mcsweb` calls `perform_action` in `MCSInterface` which saves a "command" text file containing the action string.
 
-## Pyinstaller
+### Pyinstaller
 
-### Linux and Mac
+Please note: Your python virtual environment must be installed in this folder (`venv/` is inside `webenabled/`) and activated.
+
+#### Linux and Mac
 
 Setup:
 
@@ -74,12 +84,12 @@ Cleanup (do before you need to rebuild):
 rm -rf build/ dist/
 ```
 
-### Windows
+#### Windows
 
 Same as the Linux/Mac instructions, except as noted below.
 
 Build:
 
 ```
-pyinstaller --add-data "templates;templates" --add-data "static;static" --add-data "scenes;scenes" --console mcsweb.py --log-level=DEBUG -y *>&1 | Tee-Object -Append -FilePath pyinstaller.out
+pyinstaller --add-data "templates;templates" --add-data "static;static" --add-data "scenes;scenes" --console mcsweb.py --log-level=DEBUG *>&1 | Tee-Object -Append -FilePath pyinstaller.out
 ```

--- a/webenabled/README.md
+++ b/webenabled/README.md
@@ -38,13 +38,9 @@ Then, run `python mcsweb.py` to start the flask server with host `0.0.0.0` (so t
 
 Alternatively, run `python mcsweb.py` to see all of the available options. The `--debug` flag is very helpful for development.
 
-Then, on your machine (or another machine on your network), in your web browser, go to:
+Then, on your machine, in your web browser, go to: `http://localhost:8080/mcs` (or, alternatively, `http://127.0.0.1:8080/mcs`).
 
-```
-http://<machine.ip.address>:8080/mcs
-```
-
-If accessing on your local machine, you can use `localhost` instead of an IP address.
+If on another machine in the same network, then instead go to: `http://<machine.ip.address>:8080/mcs`
 
 ### Overview
 
@@ -60,25 +56,35 @@ Please note: Your python virtual environment must be installed in this folder (`
 
 #### Linux and Mac
 
-Setup:
+##### Setup
 
 ```
 pip install -U pyinstaller
 ```
 
-Build:
+##### Build
 
 ```
 pyinstaller --add-data 'templates:templates' --add-data 'static:static' --add-data 'scenes:scenes' --console mcsweb.py --log-level=DEBUG &> pyinstaller.out
 ```
 
-Run:
+##### Run
 
 ```
 ./dist/mcsweb/mcsweb
 ```
 
-Cleanup (do before you need to rebuild):
+##### Package
+
+Unfortunately, you need to copy a bunch of files into the `dist/mcsweb/` folder before you begin packaging, in order for the application to run properly:
+
+```
+cp *.py dist/mcsweb/ ; cp config_level1.ini dist/mcsweb/ ; cp -r scenes/ dist/mcsweb/ ; cp -r static/ dist/mcsweb/ ; cp -r venv/ dist/mcsweb/
+```
+
+##### Cleanup
+
+Do before you rebuild:
 
 ```
 rm -rf build/ dist/

--- a/webenabled/mcs_task_desc.py
+++ b/webenabled/mcs_task_desc.py
@@ -1,7 +1,6 @@
-from enum import Enum, unique
+from enum import Enum
 
 
-@unique
 class TaskDescription(Enum):
     """
     The names for each enum correspond to the naming conventions currently

--- a/webenabled/mcsweb.py
+++ b/webenabled/mcsweb.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 import argparse
 import logging
 import os
@@ -289,6 +291,10 @@ if __name__ == "__main__":
     app.logger.info(
         f'Starting MCS web interface: host={args.host} port={args.port} '
         f'dev={args.dev} debug={args.debug}'
+    )
+    app.logger.info(
+        f'Please go to {"127.0.0.1" if args.host == "0.0.0.0" else args.host}:'
+        f'{args.port}/mcs in your web browser'
     )
 
     if args.dev:


### PR DESCRIPTION
Ideally, we should be able to double-click on the "mcsweb" package file (binary/executable) to start the application.

NOTES BEFORE YOU BEGIN:
- I had problems using pyinstaller with a python virtual environment installed in the MCS root folder. I'd recommend installing a new python virtual environment in the webenabled folder (see the webenabled README for details).
- You'll need to `pip install portalocker` before you use pyinstaller (I've just added it to the MCS `setup.py` file, but since it wasn't there for the latest release, you'll need to do it manually for now).
- From what I've read, you can't use pyinstaller to build an application on Linux, and then run that application on Windows; you need to use pyinstaller to build the application on Windows, and have separate packages for each OS.
- When running everything via the pyinstaller file, to open the webpage, I had to use `127.0.0.1:8080/mcs` instead of `localhost:8080/mcs`

STATUS REPORT:

Previously we tested by executing `./dist/mcsweb/mcsweb` on the command line (from the `webenabled/` folder), and this still works on Linux.

As an intermediary step, I tried executing `./mcsweb` (from the `webenabled/dist/mcsweb/` folder). There were a few problems that I've since resolved, so that also works on Linux. As you'll see in the "Package" instructions on the README, the resolution involved copying a bunch of files into the `dist/mcsweb/` folder (not ideal, but, hey, it works).

PROBLEM 1: Unfortunately, double-clicking on the binary in Linux doesn't work; you can still load the webpage, but Unity doesn't start, so clicking on a scene doesn't do anything. Since running things this way means you can't see log messages in a terminal, I don't know what sort of error is being thrown. You could try temporarily hard-coding the logger in `mcsweb.py` to write to a log file, which might get you some information.

PROBLEM 2: I can't get the Windows package to run at all, for any of these three methods; the flask server starts, but when I open the webpage, I get a ModuleNotFoundError for the watchdog python module, which should be installed correctly on my machine... I don't remember who originally tested this on Windows (maybe it was Phi?), but I'm not sure why it's not working at all anymore.